### PR TITLE
WIP: Comment on commit messages

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -1,6 +1,7 @@
 class Commit
   pattr_initialize :repo_name, :sha, :github
   attr_reader :repo_name, :sha
+  attr_accessor :message
 
   def file_content(filename)
     contents = @github.file_contents(repo_name, filename, sha)
@@ -11,5 +12,21 @@ class Commit
     end
   rescue Octokit::NotFound
     ""
+  end
+
+  def comments
+    @github.commit_comments(repo_name, sha)
+  end
+
+  def add_comment(comment)
+    @github.add_commit_comment(commit: self, comment: comment)
+  end
+
+  def subject
+    message ? message.split("\n\n").first : ""
+  end
+
+  def body
+    message ? message.split("\n\n", 2).last : ""
   end
 end

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -23,10 +23,10 @@ class Commit
   end
 
   def subject
-    message ? message.split("\n\n").first : ""
+    message.to_s.split("\n\n").first || ""
   end
 
   def body
-    message ? message.split("\n\n", 2).last : ""
+    message.to_s.split("\n\n", 2).last || ""
   end
 end

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -5,6 +5,12 @@ class PullRequest
     @comments ||= api.pull_request_comments(full_repo_name, number)
   end
 
+  def commits
+    @commits ||= api.
+      pull_request_commits(full_repo_name, number).
+      map { |commit| build_commit(commit) }
+  end
+
   def pull_request_files
     @pull_request_files ||= api.
       pull_request_files(full_repo_name, number).
@@ -38,6 +44,12 @@ class PullRequest
   end
 
   private
+
+  def build_commit(api_commit)
+    Commit.new(full_repo_name, api_commit.sha, api).tap do |commit|
+      commit.message = api_commit.commit.message
+    end
+  end
 
   def build_commit_file(file)
     CommitFile.new(file, head_commit)

--- a/app/policies/commit_commenting_policy.rb
+++ b/app/policies/commit_commenting_policy.rb
@@ -1,0 +1,17 @@
+class CommitCommentingPolicy
+  pattr_initialize :commit
+
+  def allowed_for?(message)
+    !existing_messages.include?(message)
+  end
+
+  private
+
+  def existing_messages
+    existing_comments.map(&:body).flat_map { |body| body.split("<br>") }
+  end
+
+  def existing_comments
+    @existing_comments ||= commit.comments
+  end
+end

--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -10,6 +10,7 @@ class BuildRunner
         commit_sha: payload.head_sha,
       )
       commenter.comment_on_violations(violations)
+      commenter.comment_on_commits
       create_success_status
       track_reviewed_repo_for_each_user
     end

--- a/app/services/commenter.rb
+++ b/app/services/commenter.rb
@@ -10,6 +10,32 @@ class Commenter
     end
   end
 
+  def comment_on_commits
+    pull_request.commits.each do |commit|
+      violations = []
+
+      if commit.subject.lines.length > 1
+        violations << "Message subject consists of multiple lines."
+      end
+
+      if commit.subject.lines.any? { |line| line.length > 50 }
+        violations << "Message subject line(s) exceeds 50 characters."
+      end
+
+      if commit.body.lines.any? { |line| line.length > 72 }
+        violations << "Message body contains line(s) longer than 72 characters."
+      end
+
+      commit_commenting_policy = CommitCommentingPolicy.new(commit)
+      violations.select! do |message|
+        commit_commenting_policy.allowed_for?(message)
+      end
+      if violations.any?
+        commit.add_comment(violations.join("\n"))
+      end
+    end
+  end
+
   private
 
   def commenting_policy

--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -44,6 +44,14 @@ class GithubApi
     )
   end
 
+  def add_commit_comment(options)
+    client.create_commit_comment(
+      options[:commit].repo_name,
+      options[:commit].sha,
+      options[:comment]
+    )
+  end
+
   def create_hook(full_repo_name, callback_endpoint)
     hook = client.create_hook(
       full_repo_name,
@@ -75,11 +83,19 @@ class GithubApi
     end
   end
 
+  def commit_comments(full_repo_name, sha)
+    client.commit_comments(full_repo_name, sha)
+  end
+
   def pull_request_comments(full_repo_name, pull_request_number)
     repo_path = Octokit::Repository.path full_repo_name
 
     # client.pull_request_comments does not do auto-pagination.
     client.paginate "#{repo_path}/pulls/#{pull_request_number}/comments"
+  end
+
+  def pull_request_commits(full_repo_name, pull_request_number)
+    client.pull_request_commits(full_repo_name, pull_request_number)
   end
 
   def pull_request_files(full_repo_name, number)

--- a/spec/features/builds_spec.rb
+++ b/spec/features/builds_spec.rb
@@ -39,6 +39,8 @@ feature 'Builds' do
     stub_github_requests_with_violations
     stub_commit_request(repo_name, pr_sha)
     stub_pull_request_comments_request(repo_name, pr_number)
+    stub_pull_request_commits_request(repo_name, pr_number)
+    stub_commit_comments_requests
     comment_request = stub_simple_comment_request
     stub_status_requests(repo_name, pr_sha)
 
@@ -82,6 +84,15 @@ feature 'Builds' do
     stub_request(
       :post,
       "https://api.github.com/repos/#{repo_name}/pulls/#{pr_number}/comments"
+    )
+  end
+
+  def stub_commit_comments_requests
+    stub_request(
+      :any,
+      %r{https://api\.github\.com/repos/#{repo_name}/commits/.*/comments}
+    ).to_return(
+      body: []
     )
   end
 end

--- a/spec/models/commit_spec.rb
+++ b/spec/models/commit_spec.rb
@@ -97,6 +97,15 @@ describe Commit do
       end
     end
 
+    context "with an empty commit message" do
+      it "returns an empty string" do
+        commit = Commit.new(double, double, double).
+          tap { |c| c.message = "" }
+
+        expect(commit.subject).to eq("")
+      end
+    end
+
     context "without a commit message" do
       it "returns an empty string" do
         commit = Commit.new(double, double, double)
@@ -113,6 +122,15 @@ describe Commit do
           tap { |c| c.message = "fix\n\na\n\nbug" }
 
         expect(commit.body).to eq("a\n\nbug")
+      end
+    end
+
+    context "with an empty commit message" do
+      it "returns an empty string" do
+        commit = Commit.new(double, double, double).
+          tap { |c| c.message = "" }
+
+        expect(commit.subject).to eq("")
       end
     end
 

--- a/spec/models/commit_spec.rb
+++ b/spec/models/commit_spec.rb
@@ -57,4 +57,71 @@ describe Commit do
       end
     end
   end
+
+  describe "#comments" do
+    it "fetches comments from GitHub" do
+      github = double(:github_client, commit_comments: nil)
+      commit = Commit.new("test/test", "abc", github)
+
+      commit.comments
+
+      expect(github).to have_received(:commit_comments).with(
+        commit.repo_name,
+        commit.sha
+      )
+    end
+  end
+
+  describe "#add_comment" do
+    it "posts a comment to GitHub for the Hound user" do
+      github = double(:github_client, add_commit_comment: nil)
+      commit = Commit.new("test/test", "abc", github)
+      comment = "Commit violation"
+
+      commit.add_comment(comment)
+
+      expect(github).to have_received(:add_commit_comment).with(
+        commit: commit,
+        comment: comment
+      )
+    end
+  end
+
+  describe "#subject" do
+    context "with a commit message" do
+      it "returns all lines up to double newlines" do
+        commit = Commit.new(double, double, double).
+          tap { |c| c.message = "fix\na\n\nbug" }
+
+        expect(commit.subject).to eq("fix\na")
+      end
+    end
+
+    context "without a commit message" do
+      it "returns an empty string" do
+        commit = Commit.new(double, double, double)
+
+        expect(commit.subject).to eq("")
+      end
+    end
+  end
+
+  describe "#body" do
+    context "with a commit message" do
+      it "returns all lines after the first double newlines" do
+        commit = Commit.new(double, double, double).
+          tap { |c| c.message = "fix\n\na\n\nbug" }
+
+        expect(commit.body).to eq("a\n\nbug")
+      end
+    end
+
+    context "without a commit message" do
+      it "returns an empty string" do
+        commit = Commit.new(double, double, double)
+
+        expect(commit.body).to eq("")
+      end
+    end
+  end
 end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -43,6 +43,24 @@ describe PullRequest do
     end
   end
 
+  describe "#commits" do
+    it "returns commits in pull request" do
+      commit = double(
+        :commit,
+        sha: "1234abcd",
+        commit: double(:commit, message: "Comment on commits")
+      )
+      github = double(:github, pull_request_commits: [commit])
+      pull_request = pull_request_stub(github)
+
+      commits = pull_request.commits
+
+      expect(commits.size).to eq(1)
+      expect(commits.first.sha).to eq("1234abcd")
+      expect(commits.first.message).to eq("Comment on commits")
+    end
+  end
+
   describe "#comments" do
     it "returns comments on pull request" do
       filename = "spec/models/style_guide_spec.rb"

--- a/spec/policies/commit_commenting_policy_spec.rb
+++ b/spec/policies/commit_commenting_policy_spec.rb
@@ -1,0 +1,53 @@
+require "attr_extras"
+require "fast_spec_helper"
+require "app/policies/commit_commenting_policy"
+
+describe CommitCommentingPolicy do
+  describe "#allowed_for?" do
+    context "when commit with violation has not been previously commented on" do
+      it "returns true" do
+        commit = stub_commit
+        commit_commenting_policy = CommitCommentingPolicy.new(commit)
+
+        expect(commit_commenting_policy).to be_allowed_for("Subject too long.")
+      end
+    end
+
+    context "when commit with violation has been previously commented on" do
+      context "when comment includes violation message" do
+        it "returns false" do
+          violation = "Subject too long."
+          comment = stub_comment(
+            body: "Subject too long.<br>Body too long."
+          )
+          commit = stub_commit(comments: [comment])
+          commit_commenting_policy = CommitCommentingPolicy.new(commit)
+
+          expect(commit_commenting_policy).not_to be_allowed_for(violation)
+        end
+      end
+
+      context "when comment does not include violation message" do
+        it "returns true" do
+          violation = "Subject too long."
+          comment = stub_comment(
+            body: "Body too long."
+          )
+          commit = stub_commit(comments: [comment])
+          commit_commenting_policy = CommitCommentingPolicy.new(commit)
+
+          expect(commit_commenting_policy).to be_allowed_for(violation)
+        end
+      end
+    end
+  end
+
+  def stub_comment(options = {})
+    double(:comment, options)
+  end
+
+  def stub_commit(options = {})
+    defaults = { comments: [] }
+    double(:commit, defaults.merge(options))
+  end
+end

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -44,6 +44,18 @@ describe BuildRunner, '#run' do
         with(style_checker.violations)
     end
 
+    it "comments on commits" do
+      build_runner = make_build_runner
+      stubbed_commenter
+      stubbed_style_checker_with_violations
+      commenter = Commenter.new(stubbed_pull_request)
+      allow(Commenter).to receive(:new).and_return(commenter)
+
+      build_runner.run
+
+      expect(commenter).to have_received(:comment_on_commits)
+    end
+
     it 'initializes StyleChecker with modified files and config' do
       build_runner = make_build_runner
       pull_request = stubbed_pull_request

--- a/spec/support/fixtures/commit_comments.json
+++ b/spec/support/fixtures/commit_comments.json
@@ -1,0 +1,33 @@
+[
+  {
+    "url": "https://api.github.com/repos/thoughtbot/hound/comments/8032255",
+    "html_url": "https://github.com/thoughtbot/hound/commit/913ef9c11d96cc090a02020336fbe95a0c1ff52c#commitcomment-8032255",
+    "id": 8032255,
+    "user": {
+      "login": "alxndr",
+      "id": 174307,
+      "avatar_url": "https://avatars.githubusercontent.com/u/174307?v=2",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/alxndr",
+      "html_url": "https://github.com/alxndr",
+      "followers_url": "https://api.github.com/users/alxndr/followers",
+      "following_url": "https://api.github.com/users/alxndr/following{/other_user}",
+      "gists_url": "https://api.github.com/users/alxndr/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/alxndr/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/alxndr/subscriptions",
+      "organizations_url": "https://api.github.com/users/alxndr/orgs",
+      "repos_url": "https://api.github.com/users/alxndr/repos",
+      "events_url": "https://api.github.com/users/alxndr/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/alxndr/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "position": null,
+    "line": null,
+    "path": null,
+    "commit_id": "913ef9c11d96cc090a02020336fbe95a0c1ff52c",
+    "created_at": "2014-10-03T18:45:05Z",
+    "updated_at": "2014-10-03T18:45:05Z",
+    "body": "[:+1:!](https://twitter.com/houndci/status/518079134577074176)"
+  }
+]

--- a/spec/support/fixtures/pull_request_commits.json
+++ b/spec/support/fixtures/pull_request_commits.json
@@ -1,0 +1,72 @@
+[
+  {
+    "sha": "9a0822414cc33ec3ecdb6e241a72895028a39570",
+    "commit": {
+      "author": {
+        "name": "Britt Ballard",
+        "email": "britt@thoughtbot.com",
+        "date": "2014-03-07T20:49:26Z"
+      },
+      "committer": {
+        "name": "Britt Ballard",
+        "email": "britt@thoughtbot.com",
+        "date": "2014-03-07T22:01:45Z"
+      },
+      "message": "Ignore confirmation 'zen' pings sent out setup\n\n* When a person first adds the webhook github responds with a \"zen\" ping\n* We don't need to do anything in this case, so these POSTs should be ignored\n* Fix for: https://app.getsentry.com/app20126465herokucom/production/group/14971351/",
+      "tree": {
+        "sha": "6edc5391359ba1421208fdb101267e20c16afa8e",
+        "url": "https://api.github.com/repos/thoughtbot/hound/git/trees/6edc5391359ba1421208fdb101267e20c16afa8e"
+      },
+      "url": "https://api.github.com/repos/thoughtbot/hound/git/commits/9a0822414cc33ec3ecdb6e241a72895028a39570",
+      "comment_count": 0
+    },
+    "url": "https://api.github.com/repos/thoughtbot/hound/commits/9a0822414cc33ec3ecdb6e241a72895028a39570",
+    "html_url": "https://github.com/thoughtbot/hound/commit/9a0822414cc33ec3ecdb6e241a72895028a39570",
+    "comments_url": "https://api.github.com/repos/thoughtbot/hound/commits/9a0822414cc33ec3ecdb6e241a72895028a39570/comments",
+    "author": {
+      "login": "brittballard",
+      "id": 129564,
+      "avatar_url": "https://avatars.githubusercontent.com/u/129564?v=2",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/brittballard",
+      "html_url": "https://github.com/brittballard",
+      "followers_url": "https://api.github.com/users/brittballard/followers",
+      "following_url": "https://api.github.com/users/brittballard/following{/other_user}",
+      "gists_url": "https://api.github.com/users/brittballard/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/brittballard/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/brittballard/subscriptions",
+      "organizations_url": "https://api.github.com/users/brittballard/orgs",
+      "repos_url": "https://api.github.com/users/brittballard/repos",
+      "events_url": "https://api.github.com/users/brittballard/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/brittballard/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "brittballard",
+      "id": 129564,
+      "avatar_url": "https://avatars.githubusercontent.com/u/129564?v=2",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/brittballard",
+      "html_url": "https://github.com/brittballard",
+      "followers_url": "https://api.github.com/users/brittballard/followers",
+      "following_url": "https://api.github.com/users/brittballard/following{/other_user}",
+      "gists_url": "https://api.github.com/users/brittballard/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/brittballard/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/brittballard/subscriptions",
+      "organizations_url": "https://api.github.com/users/brittballard/orgs",
+      "repos_url": "https://api.github.com/users/brittballard/repos",
+      "events_url": "https://api.github.com/users/brittballard/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/brittballard/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "c39adcdfdbd0966e5a649337937a2b9d4864ddd0",
+        "url": "https://api.github.com/repos/thoughtbot/hound/commits/c39adcdfdbd0966e5a649337937a2b9d4864ddd0",
+        "html_url": "https://github.com/thoughtbot/hound/commit/c39adcdfdbd0966e5a649337937a2b9d4864ddd0"
+      }
+    ]
+  }
+]

--- a/spec/support/helpers/github_api_helper.rb
+++ b/spec/support/helpers/github_api_helper.rb
@@ -322,6 +322,34 @@ module GithubApiHelper
     )
   end
 
+  def stub_commit_comments_request(full_repo_name, commit_sha)
+    stub_request(
+      :get,
+      "https://api.github.com/repos/#{full_repo_name}" \
+        "/commits/#{commit_sha}/comments"
+    ).with(
+      headers: { "Authorization" => "token #{hound_token}" }
+    ).to_return(
+      status: 200,
+      body: File.read("spec/support/fixtures/commit_comments.json"),
+      headers: { "Content-Type" => "application/json; charset=utf-8" }
+    )
+  end
+
+  def stub_pull_request_commits_request(full_repo_name, pull_request_number)
+    stub_request(
+      :get,
+      "https://api.github.com/repos/#{full_repo_name}" \
+        "/pulls/#{pull_request_number}/commits?per_page=100"
+    ).with(
+      headers: { "Authorization" => "token #{hound_token}" }
+    ).to_return(
+      status: 200,
+      body: File.read("spec/support/fixtures/pull_request_commits.json"),
+      headers: { "Content-Type" => "application/json; charset=utf-8" }
+    )
+  end
+
   def stub_pull_request_files_request(full_repo_name, pull_request_number)
     stub_request(
       :get,
@@ -462,6 +490,21 @@ module GithubApiHelper
         commit_id: commit_sha,
         path: file,
         position: line_number
+      }.to_json
+    ).to_return(status: 200)
+  end
+
+  def stub_commit_comment_request(full_repo_name, comment, commit_sha)
+    stub_request(
+      :post,
+      "https://api.github.com/repos/#{full_repo_name}" \
+        "/commits/#{commit_sha}/comments"
+    ).with(
+      body: {
+        body: comment,
+        path: nil,
+        line: nil,
+        position: nil
       }.to_json
     ).to_return(status: 200)
   end


### PR DESCRIPTION
This code implements (parts of) the functionality discussed in #394. The discussion ended rather quickly, but I decided to go ahead and implement it.

I've been sitting on this code for a couple of months now, and I though I might as well share it. While the pre-squash-and-rebase version of it has been running smoothly on a separate instance, there are some things I'd like to fix with the current implementation. One such thing is to make this functionality opt-in (as mentioned in #394).

I'd love some more feedback on this. Mainly, is there sufficient interest in seeing this feature completed?