### PR TITLE
Handle repos with inadequate information

### DIFF
--- a/db/migrate/20141219224840_inactivate_repos_without_privacy_or_org_info.rb
+++ b/db/migrate/20141219224840_inactivate_repos_without_privacy_or_org_info.rb
@@ -1,0 +1,18 @@
+class InactivateReposWithoutPrivacyOrOrgInfo < ActiveRecord::Migration
+  def up
+    sql = <<-SQL
+      UPDATE "repos"
+        SET "active" = 'f'
+        WHERE
+          "active" IS true
+          AND
+          ("private" OR "in_organization" IS NULL)
+    SQL
+
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  def down
+    ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,25 +11,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141210070831) do
+ActiveRecord::Schema.define(version: 20141219224840) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "builds", force: true do |t|
+  create_table "builds", force: :cascade do |t|
     t.text     "violations_archive"
     t.integer  "repo_id"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
-    t.string   "uuid",                null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
+    t.string   "uuid",                limit: 255, null: false
     t.integer  "pull_request_number"
-    t.string   "commit_sha"
+    t.string   "commit_sha",          limit: 255
   end
 
   add_index "builds", ["repo_id"], name: "index_builds_on_repo_id", using: :btree
   add_index "builds", ["uuid"], name: "index_builds_on_uuid", unique: true, using: :btree
 
-  create_table "memberships", force: true do |t|
+  create_table "memberships", force: :cascade do |t|
     t.integer  "user_id",    null: false
     t.integer  "repo_id",    null: false
     t.datetime "created_at"
@@ -38,11 +38,11 @@ ActiveRecord::Schema.define(version: 20141210070831) do
 
   add_index "memberships", ["repo_id", "user_id"], name: "index_memberships_on_repo_id_and_user_id", using: :btree
 
-  create_table "repos", force: true do |t|
-    t.integer  "github_id",                        null: false
-    t.boolean  "active",           default: false, null: false
+  create_table "repos", force: :cascade do |t|
+    t.integer  "github_id",                                    null: false
+    t.boolean  "active",                       default: false, null: false
     t.integer  "hook_id"
-    t.string   "full_github_name",                 null: false
+    t.string   "full_github_name", limit: 255,                 null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "private"
@@ -52,39 +52,39 @@ ActiveRecord::Schema.define(version: 20141210070831) do
   add_index "repos", ["active"], name: "index_repos_on_active", using: :btree
   add_index "repos", ["github_id"], name: "index_repos_on_github_id", using: :btree
 
-  create_table "subscriptions", force: true do |t|
-    t.datetime "created_at",                                                   null: false
-    t.datetime "updated_at",                                                   null: false
-    t.integer  "user_id",                                                      null: false
-    t.integer  "repo_id",                                                      null: false
-    t.string   "stripe_subscription_id",                                       null: false
+  create_table "subscriptions", force: :cascade do |t|
+    t.datetime "created_at",                                                               null: false
+    t.datetime "updated_at",                                                               null: false
+    t.integer  "user_id",                                                                  null: false
+    t.integer  "repo_id",                                                                  null: false
+    t.string   "stripe_subscription_id", limit: 255,                                       null: false
     t.datetime "deleted_at"
-    t.decimal  "price",                  precision: 8, scale: 2, default: 0.0, null: false
+    t.decimal  "price",                              precision: 8, scale: 2, default: 0.0, null: false
   end
 
   add_index "subscriptions", ["repo_id"], name: "index_subscriptions_on_repo_id", using: :btree
   add_index "subscriptions", ["user_id"], name: "index_subscriptions_on_user_id", using: :btree
 
-  create_table "users", force: true do |t|
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
-    t.string   "github_username",                    null: false
-    t.string   "remember_token",                     null: false
-    t.boolean  "refreshing_repos",   default: false
-    t.string   "email_address"
-    t.string   "stripe_customer_id"
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at",                                     null: false
+    t.datetime "updated_at",                                     null: false
+    t.string   "github_username",    limit: 255,                 null: false
+    t.string   "remember_token",     limit: 255,                 null: false
+    t.boolean  "refreshing_repos",               default: false
+    t.string   "email_address",      limit: 255
+    t.string   "stripe_customer_id", limit: 255
   end
 
   add_index "users", ["remember_token"], name: "index_users_on_remember_token", using: :btree
 
-  create_table "violations", force: true do |t|
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.integer  "build_id",                    null: false
-    t.string   "filename",                    null: false
+  create_table "violations", force: :cascade do |t|
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
+    t.integer  "build_id",                                null: false
+    t.string   "filename",       limit: 255,              null: false
     t.integer  "patch_position"
     t.integer  "line_number"
-    t.text     "messages",       default: [], null: false, array: true
+    t.text     "messages",                   default: [], null: false, array: true
   end
 
   add_index "violations", ["build_id"], name: "index_violations_on_build_id", using: :btree

--- a/lib/tasks/repo.rake
+++ b/lib/tasks/repo.rake
@@ -2,15 +2,19 @@ namespace :repo do
   desc 'Find 3,000 repos without privacy or organization information and update with info from GitHub'
   task backfill_privacy_and_organization: :environment do
     puts 'Finding repos ...'
+
     where_condition = <<-SQL
-(private IS NULL OR in_organization IS NULL) AND updated_at IS NULL
+      (private IS NULL OR in_organization IS NULL)
     SQL
+
     repo_ids = Repo.where(where_condition).limit(3_000).pluck(:id)
     puts 'Scheduling RepoInformationJob jobs for repos ...'
+
     repo_ids.each do |repo_id|
       JobQueue.push(RepoInformationJob, repo_id)
     end
-    puts 'Done scheduling jobs.'
+
+    puts 'Done scheduling jobs (max 3000). Rerun as necessary.'
   end
 
   desc "Delete repos with no memberships"


### PR DESCRIPTION
* Inactivate repositories which lack privacy or org information
* Add rake task to update repo information

https://trello.com/c/oPFtmreZ/393-builds-are-being-run-for-active-repos-missing-privacy-and-organization-information