### PR TITLE
Display failure status when config is invalid

### DIFF
--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -8,7 +8,11 @@ class RepoConfig
   HOUND_CONFIG_FILE = ".hound.yml"
   STYLE_GUIDES = %w(ruby coffee_script java_script)
 
-  pattr_initialize :commit
+  attr_reader :style_guides
+
+  pattr_initialize :commit do
+    @style_guides = {}
+  end
 
   def enabled_for?(style_guide_name)
     style_guide_name == "ruby" && legacy_config? ||
@@ -109,9 +113,5 @@ class RepoConfig
   rescue JSON::ParserError
     @invalid = true
     {}
-  end
-
-  def style_guides
-    @style_guides ||= {}
   end
 end

--- a/app/models/style_checker.rb
+++ b/app/models/style_checker.rb
@@ -2,10 +2,8 @@
 # Builds style guide based on file extension.
 # Delegates to style guide for line violations.
 class StyleChecker
-  def initialize(pull_request, repo_config)
-    @pull_request = pull_request
+  pattr_initialize :pull_request, :config do
     @style_guides = {}
-    @config = repo_config
   end
 
   def violations

--- a/app/models/style_checker.rb
+++ b/app/models/style_checker.rb
@@ -2,9 +2,10 @@
 # Builds style guide based on file extension.
 # Delegates to style guide for line violations.
 class StyleChecker
-  def initialize(pull_request)
+  def initialize(pull_request, repo_config)
     @pull_request = pull_request
     @style_guides = {}
+    @config = repo_config
   end
 
   def violations
@@ -13,7 +14,7 @@ class StyleChecker
 
   private
 
-  attr_reader :pull_request, :style_guides
+  attr_reader :pull_request, :config, :style_guides
 
   def violations_in_checked_files
     files_to_check.flat_map do |file|
@@ -47,9 +48,5 @@ class StyleChecker
     else
       StyleGuide::Unsupported
     end
-  end
-
-  def config
-    @config ||= RepoConfig.new(pull_request.head_commit)
   end
 end

--- a/app/models/violation.rb
+++ b/app/models/violation.rb
@@ -5,7 +5,6 @@ class Violation < ActiveRecord::Base
   belongs_to :build
 
   validates :build, presence: true
-  validates :filename, presence: true
 
   attr_writer :line
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,9 +2,9 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
+  active_repos: 'Active repos'
+  authenticate: 'Sign In with GitHub'
+  invalid_config: "Invalid configuration syntax"
+  search_placeholder: 'search by repo or organization name'
   sync_repos: 'Refresh repo list'
   syncing_repos: 'Loading repos...'
-  authenticate: 'Sign In with GitHub'
-  active_repos: 'Active repos'
-  search_placeholder: 'search by repo or organization name'
-  invalid_config: "%{config_file_name} is empty or has syntax errors"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,3 +7,4 @@ en:
   authenticate: 'Sign In with GitHub'
   active_repos: 'Active repos'
   search_placeholder: 'search by repo or organization name'
+  invalid_config: "%{config_file_name} is empty or has syntax errors"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,8 +3,8 @@
 
 en:
   active_repos: 'Active repos'
-  authenticate: 'Sign In with GitHub'
+  authenticate: "Sign In with GitHub"
   invalid_config: "Invalid configuration syntax"
   search_placeholder: 'search by repo or organization name'
-  sync_repos: 'Refresh repo list'
-  syncing_repos: 'Loading repos...'
+  sync_repos: "Refresh repo list"
+  syncing_repos: "Loading repos..."

--- a/db/migrate/20141226175517_remove_null_constraint_from_violations_file_name.rb
+++ b/db/migrate/20141226175517_remove_null_constraint_from_violations_file_name.rb
@@ -1,0 +1,11 @@
+class RemoveNullConstraintFromViolationsFileName < ActiveRecord::Migration
+  def up
+    change_column_default(:violations, :filename, nil)
+    change_column_null(:violations, :filename, true)
+  end
+
+  def down
+    change_column_default(:violations, :filename, "")
+    change_column_null(:violations, :filename, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141210070831) do
+ActiveRecord::Schema.define(version: 20141226175517) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,7 +81,7 @@ ActiveRecord::Schema.define(version: 20141210070831) do
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
     t.integer  "build_id",                    null: false
-    t.string   "filename",                    null: false
+    t.string   "filename"
     t.integer  "patch_position"
     t.integer  "line_number"
     t.text     "messages",       default: [], null: false, array: true

--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -6,6 +6,9 @@ class GithubApi
   SERVICES_TEAM_NAME = "Services"
   PREVIEW_MEDIA_TYPE =
     ::Octokit::Client::Organizations::ORG_INVITATIONS_PREVIEW_MEDIA_TYPE
+  FAILURE_STATUS = "failure"
+  PENDING_STATUS = "pending"
+  SUCCESS_STATUS = "success"
 
   def initialize(token = ENV["HOUND_GITHUB_TOKEN"])
     @token = token
@@ -107,6 +110,15 @@ class GithubApi
     end
   end
 
+  def create_failure_status(full_repo_name, sha, description)
+    create_status(
+      repo: full_repo_name,
+      sha: sha,
+      state: FAILURE_STATUS,
+      description: description
+    )
+  end
+
   def create_pending_status(full_repo_name, sha, description)
     create_status(
       repo: full_repo_name,
@@ -120,7 +132,7 @@ class GithubApi
     create_status(
       repo: full_repo_name,
       sha: sha,
-      state: "success",
+      state: SUCCESS_STATUS,
       description: description
     )
   end

--- a/spec/lib/github_api_spec.rb
+++ b/spec/lib/github_api_spec.rb
@@ -328,13 +328,29 @@ describe GithubApi do
     end
   end
 
+  describe "#create_failure_status" do
+    it "makes request to GitHub for creating a failed status" do
+      api = GithubApi.new
+      request = stub_status_request(
+        "test/repo",
+        "sha",
+        GithubApi::FAILURE_STATUS,
+        "description"
+      )
+
+      api.create_failure_status("test/repo", "sha", "description")
+
+      expect(request).to have_been_requested
+    end
+  end
+
   describe "#create_pending_status" do
     it "makes request to GitHub for creating a pending status" do
       api = GithubApi.new
       request = stub_status_request(
         "test/repo",
         "sha",
-        "pending",
+        GithubApi::PENDING_STATUS,
         "description"
       )
 
@@ -368,7 +384,7 @@ describe GithubApi do
       request = stub_status_request(
         "test/repo",
         "sha",
-        "success",
+        GithubApi::SUCCESS_STATUS,
         "description"
       )
 

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -150,12 +150,12 @@ describe RepoConfig do
 
         config.load_style_guides
 
-        expect(config.instance_variable_get("@invalid")).to eq true
+        expect(config).to be_invalid
       end
     end
 
     context "when CoffeeScript config has formatting errors" do
-      it "set invalid flag" do
+      it "is invalid" do
         file_name = "coffeelint.json"
         hound_config = <<-EOS
           coffee_script:
@@ -170,12 +170,12 @@ describe RepoConfig do
 
         config.load_style_guides
 
-        expect(config.instance_variable_get("@invalid")).to eq true
+        expect(config).to be_invalid
       end
     end
 
     context "when Ruby config has formatting errors" do
-      it "sets invalid flag" do
+      it "is invalid" do
         file_name = "config/rubocop.yml"
         hound_config = <<-EOS
           ruby:
@@ -190,12 +190,12 @@ describe RepoConfig do
 
         config.load_style_guides
 
-        expect(config.instance_variable_get("@invalid")).to eq true
+        expect(config).to be_invalid
       end
     end
 
     context "when config does not have formatting errors" do
-      it "does not set invalid flag" do
+      it "is not invalid" do
         hound_config = <<-EOS
           java_script:
             enabled: true
@@ -221,29 +221,6 @@ describe RepoConfig do
         config = RepoConfig.new(commit)
 
         config.load_style_guides
-
-        expect(config.instance_variable_get("@invalid")).not_to eq true
-      end
-    end
-
-  end
-
-  describe "#invalid?" do
-    context "when repo config is invalid" do
-      it "returns true" do
-        commit = double("Commit")
-        config = RepoConfig.new(commit)
-        config.instance_variable_set("@invalid", true)
-
-        expect(config).to be_invalid
-      end
-    end
-
-    context "when repo config is valid" do
-      it "returns false" do
-        commit = double("Commit")
-        config = RepoConfig.new(commit)
-        config.instance_variable_set("@invalid", false)
 
         expect(config).not_to be_invalid
       end

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -133,9 +133,9 @@ describe RepoConfig do
     end
   end
 
-  describe "#validate" do
+  describe "#load_style_guides" do
     context "when JavaScript config has formatting errors" do
-      it "adds errors" do
+      it "sets invalid flag" do
         file_name = "javascript.json"
         hound_config = <<-EOS
           java_script:
@@ -147,19 +147,15 @@ describe RepoConfig do
           file_name => invalid_config
         )
         config = RepoConfig.new(commit)
-        error_message = I18n.t(
-          "invalid_config",
-          config_file_name: file_name
-        )
 
-        config.validate
+        config.load_style_guides
 
-        expect(config.errors).to match_array([error_message])
+        expect(config.instance_variable_get("@invalid")).to eq true
       end
     end
 
     context "when CoffeeScript config has formatting errors" do
-      it "adds errors" do
+      it "set invalid flag" do
         file_name = "coffeelint.json"
         hound_config = <<-EOS
           coffee_script:
@@ -171,19 +167,15 @@ describe RepoConfig do
           file_name => invalid_config
         )
         config = RepoConfig.new(commit)
-        error_message = I18n.t(
-          "invalid_config",
-          config_file_name: file_name
-        )
 
-        config.validate
+        config.load_style_guides
 
-        expect(config.errors).to match_array([error_message])
+        expect(config.instance_variable_get("@invalid")).to eq true
       end
     end
 
     context "when Ruby config has formatting errors" do
-      it "adds errors" do
+      it "sets invalid flag" do
         file_name = "config/rubocop.yml"
         hound_config = <<-EOS
           ruby:
@@ -195,19 +187,15 @@ describe RepoConfig do
           file_name => invalid_config
         )
         config = RepoConfig.new(commit)
-        error_message = I18n.t(
-          "invalid_config",
-          config_file_name: file_name
-        )
 
-        config.validate
+        config.load_style_guides
 
-        expect(config.errors).to match_array([error_message])
+        expect(config.instance_variable_get("@invalid")).to eq true
       end
     end
 
     context "when config does not have formatting errors" do
-      it "does not add errors" do
+      it "does not set invalid flag" do
         hound_config = <<-EOS
           java_script:
             enabled: true
@@ -232,9 +220,32 @@ describe RepoConfig do
         )
         config = RepoConfig.new(commit)
 
-        config.validate
+        config.load_style_guides
 
-        expect(config.errors).to be_empty
+        expect(config.instance_variable_get("@invalid")).not_to eq true
+      end
+    end
+
+  end
+
+  describe "#invalid?" do
+    context "when repo config is invalid" do
+      it "returns true" do
+        commit = double("Commit")
+        config = RepoConfig.new(commit)
+        config.instance_variable_set("@invalid", true)
+
+        expect(config).to be_invalid
+      end
+    end
+
+    context "when repo config is valid" do
+      it "returns false" do
+        commit = double("Commit")
+        config = RepoConfig.new(commit)
+        config.instance_variable_set("@invalid", false)
+
+        expect(config).not_to be_invalid
       end
     end
   end

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -133,6 +133,163 @@ describe RepoConfig do
     end
   end
 
+  describe "#validate" do
+    context "when JavaScript config has formatting errors" do
+      it "adds errors" do
+        file_name = "javascript.json"
+        hound_config = <<-EOS
+          java_script:
+            enabled: true
+            config_file: #{file_name}
+        EOS
+        commit = stub_commit(
+          hound_config: hound_config,
+          file_name => invalid_config
+        )
+        config = RepoConfig.new(commit)
+        error_message = I18n.t(
+          "invalid_config",
+          config_file_name: file_name
+        )
+
+        config.validate
+
+        expect(config.errors).to match_array([error_message])
+      end
+    end
+
+    context "when CoffeeScript config has formatting errors" do
+      it "adds errors" do
+        file_name = "coffeelint.json"
+        hound_config = <<-EOS
+          coffee_script:
+            enabled: true
+            config_file: #{file_name}
+        EOS
+        commit = stub_commit(
+          hound_config: hound_config,
+          file_name => invalid_config
+        )
+        config = RepoConfig.new(commit)
+        error_message = I18n.t(
+          "invalid_config",
+          config_file_name: file_name
+        )
+
+        config.validate
+
+        expect(config.errors).to match_array([error_message])
+      end
+    end
+
+    context "when Ruby config has formatting errors" do
+      it "adds errors" do
+        file_name = "config/rubocop.yml"
+        hound_config = <<-EOS
+          ruby:
+            enabled: true
+            config_file: #{file_name}
+        EOS
+        commit = stub_commit(
+          hound_config: hound_config,
+          file_name => invalid_config
+        )
+        config = RepoConfig.new(commit)
+        error_message = I18n.t(
+          "invalid_config",
+          config_file_name: file_name
+        )
+
+        config.validate
+
+        expect(config.errors).to match_array([error_message])
+      end
+    end
+
+    context "when config does not have formatting errors" do
+      it "does not add errors" do
+        hound_config = <<-EOS
+          java_script:
+            enabled: true
+            config_file: "javascript.json"
+          ruby:
+            enabled: true
+            config_file: "config/rubocop.yml"
+          coffee_script:
+            enabled: true
+            config_file: coffeelint.json
+        EOS
+        valid_config = <<-EOS.strip_heredoc
+          {
+            "predef": ["myGlobal"]
+          }
+        EOS
+        commit = stub_commit(
+          hound_config: hound_config,
+          "config/rubocop.yml" => valid_config,
+          "coffeelint.json" => valid_config,
+          "javascript.json" => valid_config
+        )
+        config = RepoConfig.new(commit)
+
+        config.validate
+
+        expect(config.errors).to be_empty
+      end
+    end
+  end
+
+  describe "#jshint_ignore_file" do
+    context "no specific configuration is present" do
+      it "attempts to load a .jshintignore file" do
+        ignored_files = <<-EOIGNORE.strip_heredoc
+          app/assets/javascripts/*.js
+          public/javascripts/**.js
+        EOIGNORE
+
+        hound_config = <<-EOS
+          java_script:
+            enabled: true
+        EOS
+
+        commit = stub_commit(
+          hound_config: hound_config,
+          ".jshintignore" => ignored_files
+        )
+
+        ignored_files = RepoConfig.new(commit).ignored_javascript_files
+
+        expect(ignored_files).
+          to eq ["app/assets/javascripts/*.js", "public/javascripts/**.js"]
+      end
+    end
+
+    context "custom jshint ignore path provided" do
+      it "uses the custom ignore file" do
+        hound_config = <<-EOS
+          java_script:
+            enabled: true
+            ignore_file: ".js_ignore"
+        EOS
+
+        ignored_files = <<-EOIGNORE.strip_heredoc
+          app/assets/javascripts/*.js
+          public/javascripts/**.js
+        EOIGNORE
+
+        commit = stub_commit(
+          hound_config: hound_config,
+          ".js_ignore" => ignored_files
+        )
+
+        ignored_files = RepoConfig.new(commit).ignored_javascript_files
+
+        expect(ignored_files).
+          to eq ["app/assets/javascripts/*.js", "public/javascripts/**.js"]
+      end
+    end
+  end
+
   describe "#for" do
     context "when Ruby config file is specified" do
       it "returns parsed config" do
@@ -228,83 +385,33 @@ describe RepoConfig do
         )
       end
     end
+  end
 
-    describe "#jshint_ignore_file" do
-      context "no specific configuration is present" do
-        it "attempts to load a .jshintignore file" do
-          ignored_files = <<-EOIGNORE.strip_heredoc
-            app/assets/javascripts/*.js
-            public/javascripts/**.js
-          EOIGNORE
+  def stub_commit(configuration)
+    commit = double("Commit")
+    hound_config = configuration.delete(:hound_config)
+    allow(commit).to receive(:file_content).
+      with(RepoConfig::HOUND_CONFIG_FILE).and_return(hound_config)
 
-          hound_config = <<-EOS
-            java_script:
-              enabled: true
-          EOS
-
-          commit = stub_commit(
-            hound_config: hound_config,
-            ".jshintignore" => ignored_files
-          )
-
-          ignored_files = RepoConfig.new(commit).ignored_javascript_files
-
-          expect(ignored_files).
-            to eq ["app/assets/javascripts/*.js", "public/javascripts/**.js"]
-        end
-      end
-
-      context "custom jshint ignore path provided" do
-        it "uses the custom ignore file" do
-          hound_config = <<-EOS
-            java_script:
-              enabled: true
-              ignore_file: ".js_ignore"
-          EOS
-
-          ignored_files = <<-EOIGNORE.strip_heredoc
-            app/assets/javascripts/*.js
-            public/javascripts/**.js
-          EOIGNORE
-
-          commit = stub_commit(
-            hound_config: hound_config,
-            ".js_ignore" => ignored_files
-          )
-
-          ignored_files = RepoConfig.new(commit).ignored_javascript_files
-
-          expect(ignored_files).
-            to eq ["app/assets/javascripts/*.js", "public/javascripts/**.js"]
-        end
-      end
-    end
-
-    def stub_commit(configuration)
-      commit = double("Commit")
-      hound_config = configuration.delete(:hound_config)
+    configuration.each do |filename, contents|
       allow(commit).to receive(:file_content).
-        with(RepoConfig::HOUND_CONFIG_FILE).and_return(hound_config)
-
-      configuration.each do |filename, contents|
-        allow(commit).to receive(:file_content).
-          with(filename).and_return(contents)
-      end
-
-      commit
+        with(filename).and_return(contents)
     end
 
-    def config_for_file(file_path, content)
-      hound_config = <<-EOS.strip_heredoc
-        ruby:
-          enabled: true
-          config_file: config/rubocop.yml
+    commit
+  end
 
-        coffee_script:
-          enabled: true
-          config_file: coffeelint.json
+  def config_for_file(file_path, content)
+    hound_config = <<-EOS.strip_heredoc
+      ruby:
+        enabled: true
+        config_file: config/rubocop.yml
 
-        java_script:
+      coffee_script:
+        enabled: true
+        config_file: coffeelint.json
+
+      java_script:
           enabled: true
           config_file: #{file_path}
       EOS
@@ -315,6 +422,9 @@ describe RepoConfig do
       )
 
       RepoConfig.new(commit)
-    end
+  end
+
+  def invalid_config
+    '{ "predef": ["myGlobal";] }'
   end
 end

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -135,7 +135,7 @@ describe RepoConfig do
 
   describe "#load_style_guides" do
     context "when JavaScript config has formatting errors" do
-      it "sets invalid flag" do
+      it "is invalid" do
         file_name = "javascript.json"
         hound_config = <<-EOS
           java_script:

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe StyleChecker, "#violations" do
   it "returns a collection of computed violations" do
-    config = double("RepoConfig", enabled_for?: true, "for" => {})
+    config = double("RepoConfig", enabled_for?: true, for: {})
     stylish_file = stub_commit_file("good.rb", "def good; end")
     violated_file = stub_commit_file("bad.rb", "def bad( a ); a; end  ")
     pull_request =

--- a/spec/models/violation_spec.rb
+++ b/spec/models/violation_spec.rb
@@ -5,7 +5,6 @@ describe Violation do
 
   describe "validations" do
     it { should validate_presence_of(:build) }
-    it { should validate_presence_of(:filename) }
   end
 
   describe "#add_messages" do

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -2,99 +2,148 @@ require 'spec_helper'
 
 describe BuildRunner, '#run' do
   context 'with active repo and opened pull request' do
-    it 'creates a build record with violations' do
-      repo = create(:repo, :active, github_id: 123)
-      payload = stubbed_payload(
-        github_repo_id: repo.github_id,
-        pull_request_number: 5,
-        head_sha: "123abc",
-        full_repo_name: repo.name
-      )
-      build_runner = BuildRunner.new(payload)
-      stubbed_style_checker_with_violations
-      stubbed_commenter
-      stubbed_pull_request
-      stubbed_github_api
+    context "with valid custom config" do
+      it "creates a build record with violations" do
+        repo = create(:repo, :active, github_id: 123)
+        payload = stubbed_payload(
+          github_repo_id: repo.github_id,
+          pull_request_number: 5,
+          head_sha: "123abc",
+          full_repo_name: repo.name
+        )
+        build_runner = BuildRunner.new(payload)
+        stubbed_style_checker_with_violations
+        stubbed_commenter
+        stubbed_pull_request
+        stubbed_github_api
+        stubbed_repo_config
 
-      build_runner.run
-      builds = Build.where(repo_id: repo.id)
-      build = builds.first
+        build_runner.run
+        build = Build.first
 
-      expect(builds.size).to eq 1
-      expect(build).to eq repo.builds.last
-      expect(build.violations.count).to be >= 1
-      expect(build.pull_request_number).to eq 5
-      expect(build.commit_sha).to eq payload.head_sha
-      expect(analytics).to have_tracked("Reviewed Repo").
-        for_user(repo.users.first).
-        with(properties: { name: repo.full_github_name })
+        expect(Build.count).to eq 1
+        expect(build).to eq repo.builds.last
+        expect(build.violations.size).to be >= 1
+        expect(build.pull_request_number).to eq 5
+        expect(build.commit_sha).to eq payload.head_sha
+        expect(analytics).to have_tracked("Reviewed Repo").
+          for_user(repo.users.first).
+          with(properties: { name: repo.full_github_name })
+      end
+
+      it "comments on violations" do
+        build_runner = make_build_runner
+        commenter = stubbed_commenter
+        stubbed_repo_config
+        style_checker = stubbed_style_checker_with_violations
+        allow(Commenter).to receive(:new).and_return(commenter)
+        stubbed_pull_request
+        stubbed_github_api
+
+        build_runner.run
+
+        expect(commenter).to have_received(:comment_on_violations).
+          with(style_checker.violations)
+      end
+
+      it "initializes StyleChecker with modified files and config" do
+        build_runner = make_build_runner
+        pull_request = stubbed_pull_request
+        stubbed_style_checker_with_violations
+        stubbed_commenter
+        stubbed_github_api
+        stubbed_repo_config
+
+        build_runner.run
+
+        expect(StyleChecker).to have_received(:new).with(pull_request)
+      end
+
+      it "initializes PullRequest with payload and Hound token" do
+        repo = create(:repo, :active, github_id: 123)
+        payload = stubbed_payload(github_repo_id: repo.github_id)
+        build_runner = BuildRunner.new(payload)
+        stubbed_pull_request
+        stubbed_style_checker_with_violations
+        stubbed_commenter
+        stubbed_github_api
+        stubbed_repo_config
+
+        build_runner.run
+
+        expect(PullRequest).to have_received(:new).with(payload)
+      end
+
+      it "creates GitHub statuses" do
+        repo = create(:repo, :active, github_id: 123)
+        payload = stubbed_payload(
+          github_repo_id: repo.github_id,
+          full_repo_name: "test/repo",
+          head_sha: "headsha"
+        )
+        build_runner = BuildRunner.new(payload)
+        stubbed_pull_request
+        stubbed_style_checker_with_violations
+        stubbed_commenter
+        stubbed_repo_config
+        github_api = stubbed_github_api
+
+        build_runner.run
+
+        expect(github_api).to have_received(:create_pending_status).with(
+          "test/repo",
+          "headsha",
+          "Hound is reviewing changes."
+        )
+        expect(github_api).to have_received(:create_success_status).with(
+          "test/repo",
+          "headsha",
+          "Hound has reviewed the changes."
+        )
+      end
     end
 
-    it 'comments on violations' do
-      build_runner = make_build_runner
-      commenter = stubbed_commenter
-      style_checker = stubbed_style_checker_with_violations
-      commenter = Commenter.new(stubbed_pull_request)
-      allow(Commenter).to receive(:new).and_return(commenter)
-      stubbed_github_api
+    context "with invalid custom config" do
+      it "creates failure GitHub status" do
+        build_runner = make_build_runner
+        stubbed_pull_request
+        failure_message = "config is invalid"
+        stubbed_repo_config(failure_message)
+        github_api = double("GithubApi", create_failure_status: nil)
+        allow(GithubApi).to receive(:new).and_return(github_api)
 
-      build_runner.run
+        build_runner.run
 
-      expect(commenter).to have_received(:comment_on_violations).
-        with(style_checker.violations)
-    end
+        expect(github_api).to have_received(:create_failure_status).
+          with("foo/bar", "somesha", failure_message)
+      end
 
-    it 'initializes StyleChecker with modified files and config' do
-      build_runner = make_build_runner
-      pull_request = stubbed_pull_request
-      stubbed_style_checker_with_violations
-      stubbed_commenter
-      stubbed_github_api
+      it "creates a build record with violations" do
+        repo = create(:repo, :active, github_id: 123)
+        payload = stubbed_payload(
+          github_repo_id: repo.github_id,
+          pull_request_number: 5,
+          head_sha: "123abc",
+          full_repo_name: repo.name
+        )
+        build_runner = BuildRunner.new(payload)
+        stubbed_pull_request
+        failure_message = "config is invalid"
+        stubbed_repo_config(failure_message)
+        github_api = double("GithubApi", create_failure_status: nil)
+        allow(GithubApi).to receive(:new).and_return(github_api)
 
-      build_runner.run
+        build_runner.run
+        build = Build.first
+        violation = build.violations.first
 
-      expect(StyleChecker).to have_received(:new).with(pull_request)
-    end
-
-    it 'initializes PullRequest with payload and Hound token' do
-      repo = create(:repo, :active, github_id: 123)
-      payload = stubbed_payload(github_repo_id: repo.github_id)
-      build_runner = BuildRunner.new(payload)
-      stubbed_pull_request
-      stubbed_style_checker_with_violations
-      stubbed_commenter
-      stubbed_github_api
-
-      build_runner.run
-
-      expect(PullRequest).to have_received(:new).with(payload)
-    end
-
-    it "creates GitHub statuses" do
-      repo = create(:repo, :active, github_id: 123)
-      payload = stubbed_payload(
-        github_repo_id: repo.github_id,
-        full_repo_name: "test/repo",
-        head_sha: "headsha"
-      )
-      build_runner = BuildRunner.new(payload)
-      stubbed_pull_request
-      stubbed_style_checker_with_violations
-      stubbed_commenter
-      github_api = stubbed_github_api
-
-      build_runner.run
-
-      expect(github_api).to have_received(:create_pending_status).with(
-        "test/repo",
-        "headsha",
-        "Hound is reviewing changes."
-      )
-      expect(github_api).to have_received(:create_success_status).with(
-        "test/repo",
-        "headsha",
-        "Hound has reviewed the changes."
-      )
+        expect(Build.count).to eq 1
+        expect(build).to eq repo.builds.last
+        expect(build.violations.size).to eq 1
+        expect(build.pull_request_number).to eq payload.pull_request_number
+        expect(build.commit_sha).to eq payload.head_sha
+        expect(violation).to eq failure_message
+      end
     end
   end
 
@@ -158,7 +207,8 @@ describe BuildRunner, '#run' do
       :pull_request,
       pull_request_files: [double(:file)],
       config: double(:config),
-      opened?: true
+      opened?: true,
+      head_commit: double("Commit")
     )
     allow(PullRequest).to receive(:new).and_return(pull_request)
 
@@ -174,5 +224,15 @@ describe BuildRunner, '#run' do
     allow(GithubApi).to receive(:new).and_return(github_api)
 
     github_api
+  end
+
+  def stubbed_repo_config(error_messages = nil)
+    repo_config = double(
+      :repo_config,
+      validate: true,
+      errors: [error_messages]
+    )
+    allow(RepoConfig).to receive(:new).and_return(repo_config)
+    repo_config
   end
 end


### PR DESCRIPTION
This PR is a continuation of https://github.com/thoughtbot/hound/pull/525.

* Hound users currently receive no feedback when their Ruby, JavaScript,
  and CoffeeScript configuration files are invalid. This commit
  introduces a new feature to address this disconnect:
  When a config file is empty or can't be parsed, the GitHub status will
  be changed to "failure".
* Validate repo config in `BuildRunner#run`. If config is invalid,
  create failure status and create build record.
* Add `RepoConfig#invalid` and `RepoConfig#load_style_guides`
* Add `GithubApi#create_failure_status`
* Refactor constructor of StyleChecker to accept repo config
* Remove null constraint and presence validation for violation filename
* https://trello.com/c/JLt3FVUb/397-use-status-api-to-tell-user-when-custom-config-is-broken