### PR TITLE
Improve local Hound instructions

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,14 +1,10 @@
+CHANGED_FILES_THRESHOLD=300
 ENABLE_HTTPS=no
 GITHUB_CLIENT_ID=github_client_id
 GITHUB_CLIENT_SECRET=github_client_secret
-SECRET_KEY_BASE=secret_key_base
-CHANGED_FILES_THRESHOLD=300
+HOUND_GITHUB_TOKEN=your_github_token
+HOUND_GITHUB_USERNAME=your_github_username
 MAX_COMMENTS=10
-HOUND_GITHUB_USERNAME=houndci
-HOUND_GITHUB_TOKEN=hound_github_token
 QUEUE=high,medium,low
-
-# Visit https://manage.stripe.com/account/apikeys
-# Fill in the Test Secret Key and Test Publishable Key below
-STRIPE_API_KEY=api_key
-STRIPE_PUBLISHABLE_KEY=public_key
+RESQUE_ADMIN_PASSWORD=password
+SECRET_KEY_BASE=secret_key_base

--- a/README.md
+++ b/README.md
@@ -29,27 +29,21 @@ If you have questions about the service, see our [FAQ] or email [hound@thoughtbo
    [Application Settings under Account settings](https://github.com/settings/applications).
 3. Under the GitHub Developer Applications panel - Click on "Register new
    application"
-4. Fill in the application details:
+4. Point [ngrok] to your local Hound instance:
+   `ngrok -subdomain=<your-initials>-hound 5000`
+5. Fill in the application details:
   * Application Name: Hound Development
-  * Homepage URL: http://localhost:5000
-  * Authorization Callback URL: http://localhost:5000
-5. On the confirmation screen, copy the `Client ID` and `Client Secret` to
+  * Homepage URL: http://<your-initials>-hound.ngrok.com
+  * Authorization Callback URL: http://<your-initials>-hound.ngrok.com
+6. On the confirmation screen, copy the `Client ID` and `Client Secret` to
    `.env`. Note the setup script copies `.sample.env` to `.env` for you, if the
    file does not exist.
-6. Generate the [Stripe tokens] and copy them into your `.env` file. Put the
-   'Test Secret Key' as the value for `STRIPE_API_KEY` and 'Test Publishable
-   Key' as the value for `STRIPE_PUBLISHABLE_KEY`.
-7. Create a Stripe plan called "private" for your development environment
-   https://dashboard.stripe.com/test/plans
-> ID: "private"
-> Name: "private"
-
-8. Run `foreman start`. Foreman will start the web server, `redis-server`, and
+7. Run `foreman start`. Foreman will start the web server, `redis-server`, and
    the resque background job queue. NOTE: `rails server` will not load the
    appropriate environment variables and you'll get a "Missing `secret_key_base`
    for 'development' environment" error.
 
-[Stripe tokens]: https://manage.stripe.com/account/apikeys
+[ngrok]: https://ngrok.com
 
 Testing
 -----------

--- a/bin/setup
+++ b/bin/setup
@@ -25,3 +25,14 @@ fi
 if ! grep -qs 'port' .foreman; then
   printf 'port: 5000\n' >> .foreman
 fi
+
+# Stripe credentials
+if ! grep -qs 'STRIPE' .env; then
+  heroku config --app hound-staging | grep "STRIPE" > .env
+  sed -i '' 's/\:/=/' .env
+  sed -i '' 's/ //g' .env
+fi
+
+# GitHub
+printf 'Generate a token at https://github.com/settings/tokens/new\n'
+printf 'Select user:email and repo scopes\n'

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,3 @@
+Raven.configure do |config|
+  config.environments = %w{production staging}
+end


### PR DESCRIPTION
* Use ngrok for GitHub app.
* Get Stripe tokens automatically from staging in `bin/setup`.