### PR TITLE
Account for comments that change patch position

### DIFF
--- a/app/policies/commenting_policy.rb
+++ b/app/policies/commenting_policy.rb
@@ -18,8 +18,15 @@ class CommentingPolicy
 
   def previous_comments_on_line(violation)
     existing_comments.select do |comment|
-      comment.path == violation.filename &&
-        comment.original_position == violation.patch_position
+      comment.path == violation.filename && on_same_line?(violation, comment)
+    end
+  end
+
+  def on_same_line?(violation, comment)
+    if comment.position
+      comment.position == violation.patch_position
+    else
+      comment.original_position == violation.patch_position
     end
   end
 

--- a/spec/policies/commenting_policy_spec.rb
+++ b/spec/policies/commenting_policy_spec.rb
@@ -67,11 +67,33 @@ describe CommentingPolicy do
           expect(commenting_policy).to be_allowed_for(violation)
         end
       end
+
+      context "when commented line changes patch location" do
+        it "returns false" do
+          violation = stub_violation(
+            filename: "foo.rb",
+            messages: ["Trailing whitespace detected"],
+          )
+          comment = stub_comment(
+            body: "Trailing whitespace detected<br>Extra newline",
+            position: violation.patch_position,
+            original_position: violation.patch_position + 3,
+            path: violation.filename,
+          )
+          pull_request = stub_pull_request(comments: [comment])
+          commenting_policy = CommentingPolicy.new(pull_request)
+
+          expect(commenting_policy).not_to be_allowed_for(violation)
+        end
+      end
     end
   end
 
   def stub_comment(options = {})
-    double(:comment, options)
+    defaults = {
+      position: nil
+    }
+    double(:comment, defaults.merge(options))
   end
 
   def stub_violation(options = {})


### PR DESCRIPTION
When fetching comments on a pull request, the GitHub api includes two values indicating the position of the comment in the patch: `position` and `original_position`. Most of the time, `position` is nil, and `original_position` contains the relevant value. However, if an event causes the patch to change, e.g. a new commit is pushed, both `position` and `original_position` will contain values. This change looks for the presence of `position`, using it for the comparison when appropriate.

I have found basically no documentation about the semantics of these two values. From the cases I've looked at, it appears that the values are swapped. It seems appropriate to me that `position` would be the present value that majority of the time, and `original_position` would only exist when something changes. :confused: 