### PR TITLE
Fix toggle and account breakdowns styles

### DIFF
--- a/app/assets/stylesheets/_account.scss
+++ b/app/assets/stylesheets/_account.scss
@@ -39,7 +39,7 @@
   }
 
   dd {
-    @include position(absolute, 0 .65em 0 0);
+    @include position(absolute, null .65em null null);
     display: inline-block;
     font-size: 1.25em;
     margin-top: -.25em;

--- a/app/assets/stylesheets/_repo-list.scss
+++ b/app/assets/stylesheets/_repo-list.scss
@@ -170,7 +170,7 @@
 
       &:before {
         @include size(20px);
-        @include position(absolute, 0px null null 0px);
+        @include position(absolute, null null null 1px);
         @include transition(all 0.25s linear);
         background-color: rgb(255,255,255);
         border: 1px solid $base-border-color;
@@ -203,7 +203,7 @@
         border-color: $green;
 
         &:before {
-          @include position(absolute, 0px null null 26px);
+          @include position(absolute, null null null 27px);
           border-color: $green;
           border-color: #fff;
         }


### PR DESCRIPTION
Fixes styles in account breakdowns page
Fixes styles for ui toggle

---------

BEFORE
![screen shot 2015-01-07 at 10 58 30 am](https://cloud.githubusercontent.com/assets/1174461/5651719/a01d8776-965e-11e4-9217-8bcc30b7c9e0.png)
![screen shot 2015-01-07 at 10 58 21 am](https://cloud.githubusercontent.com/assets/1174461/5651720/a024588a-965e-11e4-8984-f17ead8ccdd8.png)

AFTER
![screen shot 2015-01-07 at 11 14 54 am](https://cloud.githubusercontent.com/assets/1174461/5651722/a5cccd76-965e-11e4-8d96-08b26bedde1a.png)
![screen shot 2015-01-07 at 11 15 02 am](https://cloud.githubusercontent.com/assets/1174461/5651721/a5c3881a-965e-11e4-9462-95ab708c5beb.png)
 