### PR TITLE
Create team with push permissions

### DIFF
--- a/doc/SECURITY.md
+++ b/doc/SECURITY.md
@@ -102,10 +102,11 @@ The database is hosted by [Redis to Go].
 [Redis to Go]: http://redistogo.com
 
 We use your GitHub token to add the [@houndci] GitHub user to your repository
-via the [GitHub collaborator API][api1].
-@houndci is added to a "Services" team within your organization
-and creates the "Services" team if it doesn't exist.
-Your GitHub user will need admin privileges for that repository.
+via the [GitHub collaborator API][api1]. @houndci will be added to a team that
+has access to the enabled repository. If an existing team cannot be found, we'll
+create a "Services" team with *push* access to the enabled repository. This is
+necessary for @houndci to see pull requests, make comments, and update pull
+request statuses.
 
 [@houndci]: https://github.com/houndci
 [api1]: https://developer.github.com/v3/repos/collaborators/#add-collaborator

--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -176,7 +176,7 @@ class GithubApi
     team_options = {
       name: name,
       repo_names: [repo.full_name],
-      permission: "pull"
+      permission: "push"
     }
     client.create_team(repo.organization.login, team_options)
   end

--- a/spec/models/github_user_spec.rb
+++ b/spec/models/github_user_spec.rb
@@ -33,7 +33,7 @@ describe GithubUser, '#has_admin_access_through_team?' do
         api = GithubApi.new
         user = GithubUser.new(api)
         team_id = 4567
-        teams = [double(permission: 'pull', id: 4567)]
+        teams = [double(permission: "push", id: 4567)]
         allow(api).to receive(:user_teams).and_return(teams)
 
         expect(user).not_to have_admin_access_through_team(team_id)

--- a/spec/support/helpers/github_api_helper.rb
+++ b/spec/support/helpers/github_api_helper.rb
@@ -47,7 +47,7 @@ module GithubApiHelper
       body: {
         name: 'Services',
         repo_names: [repo_name],
-        permission: 'pull'
+        permission: "push"
       }.to_json,
       headers: { "Authorization" => "token #{user_token}" }
     ).to_return(
@@ -65,7 +65,7 @@ module GithubApiHelper
       body: {
         name: 'Services',
         repo_names: [repo_name],
-        permission: 'pull'
+        permission: "push"
       }.to_json,
       headers: { "Authorization" => "token #{user_token}" }
     ).to_return(


### PR DESCRIPTION
In order to create/update commit statuses for repositories belonging to an organization, the *Services* team needs **push** access.  No change is required for user owned repositories, because *houndci* is added as a collaborator, which includes push access.

Does this warrant an update to the [security] doc? The relevant section mentions the *Services* team, but it doesn't call out the access level.

https://trello.com/c/Z3GpdyNn

[security]: https://github.com/thoughtbot/hound/blob/b8a1169f0f25a33f04cbb5c75fb83d2edbf89d9d/doc/SECURITY.md#what-happens-when-you-enable-hound-on-your-github-repository