### PR TITLE
Ensure uniqueness of repository name

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -10,7 +10,7 @@ class Repo < ActiveRecord::Base
   delegate :type, :price, to: :plan, prefix: true
   delegate :price, to: :subscription, prefix: true
 
-  validates :full_github_name, presence: true
+  validates :full_github_name, uniqueness: true, presence: true
   validates :github_id, uniqueness: true, presence: true
 
   def self.active
@@ -18,8 +18,12 @@ class Repo < ActiveRecord::Base
   end
 
   def self.find_or_create_with(attributes)
-    repo = where(github_id: attributes[:github_id]).first_or_initialize
-    repo.update_attributes(attributes)
+    repo = find_by(full_github_name: attributes[:full_github_name]) ||
+      find_by(github_id: attributes[:github_id]) ||
+      Repo.new
+
+    repo.update!(attributes)
+
     repo
   end
 

--- a/app/services/repo_synchronization.rb
+++ b/app/services/repo_synchronization.rb
@@ -20,10 +20,11 @@ class RepoSynchronization
   private
 
   def repo_attributes(attributes)
-    attributes.slice(:private).merge(
+    {
+      private: attributes[:private],
       github_id: attributes[:id],
       full_github_name: attributes[:full_name],
       in_organization: attributes[:owner][:type] == ORGANIZATION_TYPE
-    )
+    }
   end
 end

--- a/db/migrate/20150108003045_add_uniqueness_on_full_github_name_to_repos.rb
+++ b/db/migrate/20150108003045_add_uniqueness_on_full_github_name_to_repos.rb
@@ -1,0 +1,5 @@
+class AddUniquenessOnFullGithubNameToRepos < ActiveRecord::Migration
+  def change
+    add_index :repos, :full_github_name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141219224840) do
+ActiveRecord::Schema.define(version: 20150108003045) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20141219224840) do
   end
 
   add_index "repos", ["active"], name: "index_repos_on_active", using: :btree
+  add_index "repos", ["full_github_name"], name: "index_repos_on_full_github_name", unique: true, using: :btree
   add_index "repos", ["github_id"], name: "index_repos_on_github_id", using: :btree
 
   create_table "subscriptions", force: :cascade do |t|

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -106,24 +106,40 @@ describe Repo do
   end
 
   describe ".find_or_create_with" do
-    context "with existing repo" do
+    context "with existing github name" do
       it "updates attributes" do
-        repo = create(:repo)
+        repo = create(:repo, github_id: 1)
+        new_attributes = { github_id: 2, full_github_name: repo.name }
 
-        found_repo = Repo.find_or_create_with(github_id: repo.github_id)
+        Repo.find_or_create_with(new_attributes)
+        repo.reload
 
         expect(Repo.count).to eq 1
-        expect(found_repo).to eq repo
+        expect(repo.name).to eq new_attributes[:full_github_name]
+        expect(repo.github_id).to eq new_attributes[:github_id]
+      end
+    end
+
+    context "with existing github id" do
+      it "updates attributes" do
+        repo = create(:repo, full_github_name: "foo")
+        new_attributes = { github_id: repo.github_id, full_github_name: "bar" }
+
+        Repo.find_or_create_with(new_attributes)
+        repo.reload
+
+        expect(Repo.count).to eq 1
+        expect(repo.github_id).to eq new_attributes[:github_id]
+        expect(repo.name).to eq new_attributes[:full_github_name]
       end
     end
 
     context "with new repo" do
       it "creates repo with attributes" do
-        attributes = build(:repo).attributes
-        repo = Repo.find_or_create_with(attributes)
+        repo = Repo.find_or_create_with(attributes_for(:repo))
 
         expect(Repo.count).to eq 1
-        expect(repo).to be_present
+        expect(repo.reload).to be_present
       end
     end
   end


### PR DESCRIPTION
* add a uniquness constraint on `full_github_name`
* attempt to find the repo based on name first, then by id, then update it

https://trello.com/c/2Kl8oLFV