### PR TITLE
Update email link in SECURITY

### DIFF
--- a/doc/SECURITY.md
+++ b/doc/SECURITY.md
@@ -15,7 +15,7 @@ Vulnerability Reporting
 -----------------------
 
 For security inquiries or vulnerability reports, please email
-[security@thoughtbot.com](security@thoughtbot.com).
+<security@thoughtbot.com>.
 If you'd like, you can use our [PGP key] when reporting vulnerabilities.
 
 [PGP key]: http://pgp.thoughtbot.com


### PR DESCRIPTION
Previously clicking on the `security@` email link would open https://github.com/thoughtbot/hound/blob/master/doc/security@thoughtbot.com, which 404's.  Now it opens a mail client.