### PR TITLE
Update pull permission teams to push permission

### DIFF
--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -150,6 +150,7 @@ class GithubApi
     team = find_team(SERVICES_TEAM_NAME, repo)
 
     if team
+      ensure_push_permission(team)
       client.add_team_repository(team.id, repo.full_name)
     else
       team = create_team(SERVICES_TEAM_NAME, repo)
@@ -164,6 +165,12 @@ class GithubApi
     end
   rescue Octokit::NotFound
     false
+  end
+
+  def ensure_push_permission(team)
+    if team[:permission] == "pull"
+      client.update_team(team.id, permission: "push")
+    end
   end
 
   def find_team(name, repo)

--- a/spec/lib/github_api_spec.rb
+++ b/spec/lib/github_api_spec.rb
@@ -82,6 +82,25 @@ describe GithubApi do
             end
           end
 
+          context "when Services team has pull access" do
+            it "updates permissions to push access" do
+              stub_repo_with_org_request(repo_name, user_token)
+              stub_empty_repo_teams_request(repo_name, user_token)
+              stub_org_teams_with_pull_permission_services_request(
+                organization,
+                user_token
+              )
+              stub_add_repo_to_team_request(repo_name, team_id, user_token)
+              stub_add_user_to_team_request(username, team_id, user_token)
+              update_team_request =
+                stub_update_team_permission_request(team_id, user_token)
+
+              api.add_user_to_repo(username, repo_name)
+
+              expect(update_team_request).to have_been_requested
+            end
+          end
+
           it "adds user to 'Services' team" do
             stub_repo_with_org_request(repo_name, user_token)
             stub_empty_repo_teams_request(repo_name, user_token)

--- a/spec/support/fixtures/org_teams_with_lowercase_services_team.json
+++ b/spec/support/fixtures/org_teams_with_lowercase_services_team.json
@@ -12,7 +12,7 @@
     "id": 4567,
     "members_url": "https://api.github.com/teams/4567/members{/member}",
     "name": "services",
-    "permission": "pull",
+    "permission": "push",
     "repositories_url": "https://api.github.com/teams/4567/repos",
     "slug": "services",
     "url": "https://api.github.com/teams/4567"

--- a/spec/support/fixtures/org_teams_with_pull_permission_services_team.json
+++ b/spec/support/fixtures/org_teams_with_pull_permission_services_team.json
@@ -12,7 +12,7 @@
     "id": 4567,
     "members_url": "https://api.github.com/teams/4567/members{/member}",
     "name": "Services",
-    "permission": "push",
+    "permission": "pull",
     "repositories_url": "https://api.github.com/teams/4567/repos",
     "slug": "services",
     "url": "https://api.github.com/teams/4567"

--- a/spec/support/fixtures/team_update.json
+++ b/spec/support/fixtures/team_update.json
@@ -1,0 +1,29 @@
+{
+  "id": 1234,
+  "members_count": 0,
+  "members_url": "https://api.github.com/teams/1234/members{/member}",
+  "name": "Testing",
+  "organization": {
+    "avatar_url": "https://avatars.githubusercontent.com/u/5848380?",
+    "created_at": "2013-11-04T06:39:16Z",
+    "events_url": "https://api.github.com/orgs/testing/events",
+    "followers": 0,
+    "following": 0,
+    "html_url": "https://github.com/testing",
+    "id": 5848380,
+    "login": "testing",
+    "members_url": "https://api.github.com/orgs/testing/members{/member}",
+    "public_gists": 0,
+    "public_members_url": "https://api.github.com/orgs/testing/public_members{/member}",
+    "public_repos": 0,
+    "repos_url": "https://api.github.com/orgs/testing/repos",
+    "type": "Organization",
+    "updated_at": "2014-03-26T15:25:00Z",
+    "url": "https://api.github.com/orgs/testing"
+  },
+  "permission": "push",
+  "repos_count": 0,
+  "repositories_url": "https://api.github.com/teams/1234/repos",
+  "slug": "testing",
+  "url": "https://api.github.com/teams/1234"
+}

--- a/spec/support/helpers/github_api_helper.rb
+++ b/spec/support/helpers/github_api_helper.rb
@@ -57,6 +57,20 @@ module GithubApiHelper
     )
   end
 
+  def stub_update_team_permission_request(team_id, user_token)
+    json_response = File.read("spec/support/fixtures/team_update.json")
+    stub_request(
+      :patch,
+      "https://api.github.com/teams/#{team_id}"
+    ).with(
+      headers: { "Authorization" => "token #{user_token}" }
+    ).to_return(
+      status: 200,
+      body: json_response,
+      headers: { "Content-Type" => "application/json; charset=utf-8" }
+    )
+  end
+
   def stub_failed_team_creation_request(org, repo_name, user_token)
     stub_request(
       :post,
@@ -171,6 +185,22 @@ module GithubApiHelper
   def stub_org_teams_with_services_request(org_name, user_token)
     json_response = File.read(
       "spec/support/fixtures/org_teams_with_services_team.json"
+    )
+    stub_request(
+      :get,
+      "https://api.github.com/orgs/#{org_name}/teams?per_page=100"
+    ).with(
+      headers: { "Authorization" => "token #{user_token}" }
+    ).to_return(
+      status: 200,
+      body: json_response,
+      headers: { "Content-Type" => "application/json; charset=utf-8" }
+    )
+  end
+
+  def stub_org_teams_with_pull_permission_services_request(org_name, user_token)
+    json_response = File.read(
+      "spec/support/fixtures/org_teams_with_pull_permission_services_team.json"
     )
     stub_request(
       :get,


### PR DESCRIPTION
Teams created before 855e932 will only have *pull* permission, leaving hound unable to update pull request statuses for repositories of that organization. This change adds a check for *pull* only access during repository activation, and will upgrade the Services team to *push* permission.

I updated the existing team fixtures to have "push" access, to avoid having to stub the update team requests for every spec. I tried to keep the names for the new requests/fixtures in-line with what was there, but they feel cumbersome. If anyone has suggestions for better ones, I'd love to hear them.

https://trello.com/c/kdFGneUh