### PR TITLE
Cleanup db connections for Resque workers

### DIFF
--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -14,3 +14,11 @@ Resque::Failure::MultipleWithRetrySuppression.classes = [
   Resque::Failure::Sentry
 ]
 Resque::Failure.backend = Resque::Failure::MultipleWithRetrySuppression
+
+Resque.before_fork do
+  defined?(ActiveRecord::Base) && ActiveRecord::Base.connection.disconnect!
+end
+
+Resque.after_fork do
+  defined?(ActiveRecord::Base) && ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
Attempt to fix:
```
could not receive data from client: Connection reset by peer
```

As per [Heroku docs][1].
[1]: https://devcenter.heroku.com/articles/forked-pg-connections#resque-ruby-queuing