### PR TITLE
Fix SCSS linter creating erroneous violations

### DIFF
--- a/app/models/style_guide/scss.rb
+++ b/app/models/style_guide/scss.rb
@@ -8,6 +8,7 @@ module StyleGuide
       if config.excluded_file?(file.filename)
         []
       else
+        runner = build_runner
         runner.run([file.content])
 
         runner.lints.map do |violation|
@@ -26,8 +27,8 @@ module StyleGuide
 
     private
 
-    def runner
-      @runner ||= SCSSLint::Runner.new(config)
+    def build_runner
+      SCSSLint::Runner.new(config)
     end
 
     def config

--- a/spec/models/style_guide/scss_spec.rb
+++ b/spec/models/style_guide/scss_spec.rb
@@ -65,15 +65,33 @@ describe StyleGuide::Scss do
         end
       end
     end
+
+    context "over multiple runs" do
+      it "it reports errors only for the given file" do
+        style_guide = build_style_guide
+        bad_content = ".a { .b { .c { background: #000; } } }"
+        good_content = ".a { margin: 0.5em; }\n"
+
+        bad_run = style_guide.violations_in_file(build_file(bad_content))
+        good_run = style_guide.violations_in_file(build_file(good_content))
+
+        expect(bad_run).not_to be_empty
+        expect(good_run).to be_empty
+      end
+    end
   end
 
   private
 
   def violations_in(content, config = nil)
+    style_guide = build_style_guide(config)
+    style_guide.violations_in_file(build_file(content)).flat_map(&:messages)
+  end
+
+  def build_style_guide(config = nil)
     repo_config = double("RepoConfig", enabled_for?: true, for: config)
     repository_owner = "ralph"
-    style_guide = StyleGuide::Scss.new(repo_config, repository_owner)
-    style_guide.violations_in_file(build_file(content)).flat_map(&:messages)
+    StyleGuide::Scss.new(repo_config, repository_owner)
   end
 
   def build_file(text)


### PR DESCRIPTION
The SCSS linter stores violations in an [instance variable][omg-state], and doesn't clear them between runs or provide a public interface for clearing them. This led to erroneous violations being reported on files when a violation in another file happened to be on the same line number that's included in the diff.

This change uses a newly created linter for every file that's checked, in order to avoid the responsibility of clearing the state between each run.

I think the name/phrasing in the spec need some work, but I'm unable to come up with something better at the moment. Anyone have any suggestions?

Will close #562

https://trello.com/c/qObHGpDB

[omg-state]: https://github.com/causes/scss-lint/blob/8319483e3686e1956613069e6a02a56e62db74bc/lib/scss_lint/runner.rb#L12