### PR TITLE
Deactivate repos deleted on github

### DIFF
--- a/spec/services/repo_synchronization_spec.rb
+++ b/spec/services/repo_synchronization_spec.rb
@@ -94,6 +94,41 @@ describe RepoSynchronization do
         to eq membership.repo.github_id
     end
 
+    describe "when a repo is deleted on github" do
+      it "deactivates the repo" do
+        user = create(:user)
+        unchanged_repo = create_subscriber_repo_for(user)
+        renamed_repo = create_subscriber_repo_for(user)
+        deleted_repo = create_subscriber_repo_for(user)
+        unchanged_repo_attributes = attributes_for(unchanged_repo)
+        renamed_repo_attributes = attributes_for(renamed_repo)
+        renamed_repo_attributes[:full_name] = "something/different"
+        unchaged_resource =
+          double(:resource, to_hash: unchanged_repo_attributes)
+        renamed_resource = double(:resource, to_hash: renamed_repo_attributes)
+        api = double(:github_api, repos: [unchaged_resource, renamed_resource])
+        allow(GithubApi).to receive(:new).and_return(api)
+        github_token = "token"
+        synchronization = RepoSynchronization.new(user, github_token)
+        allow(RepoSubscriber).to receive(:unsubscribe)
+
+        synchronization.start
+        deleted_repo.reload
+        unchanged_repo.reload
+        renamed_repo.reload
+
+        expect(unchanged_repo).to be_active
+        expect(RepoSubscriber).not_to have_received(:unsubscribe).
+          with(unchanged_repo, user)
+        expect(renamed_repo).to be_active
+        expect(RepoSubscriber).not_to have_received(:unsubscribe).
+          with(renamed_repo, user)
+        expect(deleted_repo).not_to be_active
+        expect(RepoSubscriber).to have_received(:unsubscribe).
+          with(deleted_repo, user)
+      end
+    end
+
     describe 'when a repo membership already exists' do
       it 'creates another membership' do
         first_membership = create(:membership)
@@ -118,5 +153,23 @@ describe RepoSynchronization do
         expect(second_user.reload.repos.size).to eq(1)
       end
     end
+  end
+
+  def create_subscriber_repo_for(user)
+    repo = create(:repo, private: true, active: true)
+    create(:membership, repo: repo, user: user)
+    create(:subscription, repo: repo, user: user)
+    repo
+  end
+
+  def attributes_for(repo)
+    {
+      full_name: repo.full_github_name,
+      id: repo.github_id,
+      private: repo.private,
+      owner: {
+        type: "User"
+      }
+    }
   end
 end


### PR DESCRIPTION
Adds a check to the synchronization process that identifies deleted repos and deactivates them.

The added spec is quite big, but I think the assertions it makes are important (I'm paranoid about unintentionally deactivating repos). Maybe it should be broken into smaller specs? Also, because I'm paranoid, I'd appreciate multiple eyes on the logic for determining which repos where deleted. :eyes: 

https://trello.com/c/SBKDsHjl