### PR TITLE
Move logic of adding Hound to an repo

### DIFF
--- a/app/services/add_hound_to_repo.rb
+++ b/app/services/add_hound_to_repo.rb
@@ -1,0 +1,86 @@
+# Adds @hounci user to the a private repository as collaborator,
+# or to an organization team that has access to the repository
+# This is necessary for making comments as the houndci user
+class AddHoundToRepo
+  SERVICES_TEAM_NAME = "Services"
+
+  pattr_initialize :repo_name, :github
+
+  def self.run(repo_name, github)
+    new(repo_name, github).run
+  end
+
+  def run
+    if repo.organization
+      add_user_to_org
+    else
+      add_collaborator_to_repo
+    end
+  end
+
+  private
+
+  def repo
+    @repo ||= github.repo(repo_name)
+  end
+
+  def add_collaborator_to_repo
+    github.add_collaborator(repo_name, github_username)
+  end
+
+  def add_user_to_org
+    if team_with_admin_access
+      github.add_user_to_team(github_username, team_with_admin_access.id)
+    else
+      add_user_and_repo_to_services_team
+    end
+  end
+
+  def team_with_admin_access
+    @team_with_admin_access ||= begin
+      repo_teams = github.repo_teams(repo_name)
+      token_bearer = GithubUser.new(github)
+
+      repo_teams.detect do |repo_team|
+        token_bearer.has_admin_access_through_team?(repo_team.id)
+      end
+    end
+  end
+
+  def add_user_and_repo_to_services_team
+    team = find_services_team
+
+    if team
+      ensure_push_permission(team)
+      github.add_repo_to_team(team.id, repo_name)
+    else
+      team = github.create_team(
+        team_name: SERVICES_TEAM_NAME,
+        org_name: org_name,
+        repo_name: repo_name
+      )
+    end
+
+    github.add_user_to_team(github_username, team.id)
+  end
+
+  def find_services_team
+    github.org_teams(org_name).detect do |team|
+      team.name.downcase == SERVICES_TEAM_NAME.downcase
+    end
+  end
+
+  def ensure_push_permission(team)
+    if team.permission == "pull"
+      github.update_team(team.id, permission: "push")
+    end
+  end
+
+  def org_name
+    repo.organization.login
+  end
+
+  def github_username
+    @github_username ||= ENV.fetch("HOUND_GITHUB_USERNAME")
+  end
+end

--- a/app/services/repo_activator.rb
+++ b/app/services/repo_activator.rb
@@ -32,8 +32,7 @@ class RepoActivator
   end
 
   def add_hound_to_repo
-    github_username = ENV.fetch("HOUND_GITHUB_USERNAME")
-    github.add_user_to_repo(github_username, repo.full_github_name)
+    AddHoundToRepo.run(repo.full_github_name, github)
   end
 
   def github

--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -18,16 +18,6 @@ class GithubApi
     user_repos + org_repos
   end
 
-  def add_user_to_repo(username, repo_name)
-    repo = repo(repo_name)
-
-    if repo.organization
-      add_user_to_org(username, repo)
-    else
-      client.add_collaborator(repo.full_name, username)
-    end
-  end
-
   def repo(repo_name)
     client.repository(repo_name)
   end
@@ -89,10 +79,6 @@ class GithubApi
     client.contents(full_repo_name, path: filename, ref: sha)
   end
 
-  def user_teams
-    client.user_teams
-  end
-
   def accept_pending_invitations
     pending_memberships = client.organization_memberships(state: "pending")
     pending_memberships.each do |pending_membership|
@@ -121,66 +107,44 @@ class GithubApi
     )
   end
 
-  private
-
-  def add_user_to_org(username, repo)
-    repo_teams = client.repository_teams(repo.full_name)
-    admin_team = admin_access_team(repo_teams)
-
-    if admin_team
-      add_user_to_team(username, admin_team.id)
-    else
-      add_user_and_repo_to_services_team(username, repo)
-    end
+  def add_collaborator(repo_name, username)
+    client.add_collaborator(repo_name, username)
   end
 
-  def admin_access_team(repo_teams)
-    token_bearer = GithubUser.new(self)
-
-    repo_teams.detect do |repo_team|
-      token_bearer.has_admin_access_through_team?(repo_team.id)
-    end
+  def user_teams
+    client.user_teams
   end
 
-  def add_user_and_repo_to_services_team(username, repo)
-    team = find_team(SERVICES_TEAM_NAME, repo)
+  def repo_teams(repo_name)
+    client.repository_teams(repo_name)
+  end
 
-    if team
-      ensure_push_permission(team)
-      client.add_team_repository(team.id, repo.full_name)
-    else
-      team = create_team(SERVICES_TEAM_NAME, repo)
-    end
+  def org_teams(org_name)
+    client.org_teams(org_name)
+  end
 
-    add_user_to_team(username, team.id)
+  def create_team(team_name:, org_name:, repo_name:)
+    team_options = {
+      name: team_name,
+      repo_names: [repo_name],
+      permission: "push"
+    }
+    client.create_team(org_name, team_options)
+  end
+
+  def add_repo_to_team(team_id, repo_name)
+    client.add_team_repository(team_id, repo_name)
   end
 
   def add_user_to_team(username, team_id)
     client.add_team_membership(team_id, username)
-  rescue Octokit::NotFound
-    false
   end
 
-  def ensure_push_permission(team)
-    if team[:permission] == "pull"
-      client.update_team(team.id, permission: "push")
-    end
+  def update_team(team_id, options)
+    client.update_team(team_id, options)
   end
 
-  def find_team(name, repo)
-    client.org_teams(repo.organization.login).detect do |team|
-      team.name.downcase == name.downcase
-    end
-  end
-
-  def create_team(name, repo)
-    team_options = {
-      name: name,
-      repo_names: [repo.full_name],
-      permission: "push"
-    }
-    client.create_team(repo.organization.login, team_options)
-  end
+  private
 
   def user_repos
     authorized_repos(client.repos)

--- a/spec/features/repo_list_spec.rb
+++ b/spec/features/repo_list_spec.rb
@@ -59,7 +59,7 @@ feature "Repo list", js: true do
     repo.users << user
     hook_url = "http://#{ENV["HOST"]}/builds"
     stub_repo_request(repo.full_github_name, token)
-    stub_add_collaborator_request(repo.full_github_name, token)
+    stub_add_collaborator_request("houndci", repo.full_github_name, token)
     stub_hook_creation_request(repo.full_github_name, hook_url, token)
     stub_memberships_request
     stub_membership_update_request

--- a/spec/lib/github_api_spec.rb
+++ b/spec/lib/github_api_spec.rb
@@ -5,155 +5,11 @@ require "json"
 require "app/models/github_user"
 
 describe GithubApi do
-  let(:user_token) { "usergithubtoken" }
-  let(:api) { GithubApi.new(user_token) }
-
-  describe "#add_user_to_repo" do
-    let(:username) { "testuser" }
-    let(:organization) { "testing" }
-    let(:repo_name) { "#{organization}/repo" }
-    let(:team_id) { 4567 }
-
-    context "when repo is part of an organization" do
-      context "when repo is part of a team" do
-        context "when request succeeds" do
-          it "adds Hound user to first repo team with admin access and return true" do
-            stub_common_requests(user_token)
-            add_user_request =
-              stub_add_user_to_team_request(username, team_id, user_token)
-
-            expect(api.add_user_to_repo(username, repo_name)).to be_truthy
-            expect(add_user_request).to have_been_requested
-          end
-        end
-
-        context "when request fails" do
-          it "tries to add Hound user to first repo team with admin access and returns false" do
-            stub_common_requests(user_token)
-            add_user_request = stub_failed_add_user_to_team_request(
-              username,
-              team_id,
-              user_token
-            )
-
-            expect(api.add_user_to_repo(username, repo_name)).to be_falsy
-            expect(add_user_request).to have_been_requested
-          end
-        end
-
-        def stub_common_requests(token)
-          stub_repo_with_org_request(repo_name, token)
-          stub_repo_teams_request(repo_name, token)
-          stub_user_teams_request(token)
-        end
-      end
-
-      context "when repo is not part of a team" do
-        context "when Services team does not exist" do
-          it "creates a Services team and adds user to the new team" do
-            team_id = 1234 # from fixture
-            stub_repo_with_org_request(repo_name, user_token)
-            stub_empty_repo_teams_request(repo_name, user_token)
-            stub_team_creation_request(organization, repo_name, user_token)
-            stub_org_teams_request(organization, user_token)
-            add_user_request =
-              stub_add_user_to_team_request(username, team_id, user_token)
-
-            expect(api.add_user_to_repo(username, repo_name)).to be_truthy
-            expect(add_user_request).to have_been_requested
-          end
-        end
-
-        context "when 'Services' team exists" do
-          context "when Services team is not on the first page of results" do
-            it "adds user to Services team" do
-              stub_repo_with_org_request(repo_name, user_token)
-              stub_empty_repo_teams_request(repo_name, user_token)
-              stub_paginated_org_teams_request(organization, user_token)
-              add_repo_request =
-                stub_add_repo_to_team_request(repo_name, team_id, user_token)
-              add_user_request =
-                stub_add_user_to_team_request(username, team_id, user_token)
-
-              api.add_user_to_repo(username, repo_name)
-
-              expect(add_user_request).to have_been_requested
-              expect(add_repo_request).to have_been_requested
-            end
-          end
-
-          context "when Services team has pull access" do
-            it "updates permissions to push access" do
-              stub_repo_with_org_request(repo_name, user_token)
-              stub_empty_repo_teams_request(repo_name, user_token)
-              stub_org_teams_with_pull_permission_services_request(
-                organization,
-                user_token
-              )
-              stub_add_repo_to_team_request(repo_name, team_id, user_token)
-              stub_add_user_to_team_request(username, team_id, user_token)
-              update_team_request =
-                stub_update_team_permission_request(team_id, user_token)
-
-              api.add_user_to_repo(username, repo_name)
-
-              expect(update_team_request).to have_been_requested
-            end
-          end
-
-          it "adds user to 'Services' team" do
-            stub_repo_with_org_request(repo_name, user_token)
-            stub_empty_repo_teams_request(repo_name, user_token)
-            stub_org_teams_with_services_request(organization, user_token)
-            add_repo_request =
-              stub_add_repo_to_team_request(repo_name, team_id, user_token)
-            add_user_request =
-              stub_add_user_to_team_request(username, team_id, user_token)
-
-            api.add_user_to_repo(username, repo_name)
-
-            expect(add_user_request).to have_been_requested
-            expect(add_repo_request).to have_been_requested
-          end
-        end
-
-        context "when 'services' team exists" do
-          it "adds user to 'services' team" do
-            stub_repo_with_org_request(repo_name, user_token)
-            stub_empty_repo_teams_request(repo_name, user_token)
-            stub_org_teams_with_lowercase_services_request(
-              organization,
-              user_token
-            )
-            add_repo_request =
-              stub_add_repo_to_team_request(repo_name, team_id, user_token)
-            add_user_request =
-              stub_add_user_to_team_request(username, team_id, user_token)
-
-            api.add_user_to_repo(username, repo_name)
-
-            expect(add_user_request).to have_been_requested
-            expect(add_repo_request).to have_been_requested
-          end
-        end
-      end
-    end
-
-    context "when repo is not part of an organization" do
-      it "adds user as collaborator" do
-        stub_repo_request(repo_name, user_token)
-        add_user_request =
-          stub_add_user_to_repo_request(username, repo_name, user_token)
-
-        expect(api.add_user_to_repo(username, repo_name)).to be_truthy
-        expect(add_user_request).to have_been_requested
-      end
-    end
-  end
-
   describe "#repos" do
     it "fetches all repos from Github" do
-      stub_repo_requests(user_token)
+      token = "something"
+      api = GithubApi.new(token)
+      stub_repo_requests(token)
 
       repos = api.repos
 
@@ -166,10 +22,12 @@ describe GithubApi do
       it "creates pull request web hook" do
         full_repo_name = "jimtom/repo"
         callback_endpoint = "http://example.com"
+        token = "something"
+        api = GithubApi.new(token)
         request = stub_hook_creation_request(
           full_repo_name,
           callback_endpoint,
-          user_token
+          token
         )
 
         api.create_hook(full_repo_name, callback_endpoint)
@@ -180,10 +38,12 @@ describe GithubApi do
       it "yields hook" do
         full_repo_name = "jimtom/repo"
         callback_endpoint = "http://example.com"
+        token = "something"
+        api = GithubApi.new(token)
         request = stub_hook_creation_request(
           full_repo_name,
           callback_endpoint,
-          user_token
+          token
         )
         yielded = false
 
@@ -214,8 +74,7 @@ describe GithubApi do
         stub_failed_hook_creation_request(full_repo_name, callback_endpoint)
         api = GithubApi.new
 
-        expect(api.create_hook(full_repo_name, callback_endpoint)).
-          to eq true
+        expect(api.create_hook(full_repo_name, callback_endpoint)).to eq true
       end
     end
   end
@@ -392,6 +251,79 @@ describe GithubApi do
       )
 
       api.create_success_status("test/repo", "sha", "description")
+
+      expect(request).to have_been_requested
+    end
+  end
+
+  describe "#add_user_to_team" do
+    it "makes a request to GitHub" do
+      token = "some_token"
+      username = "houndci"
+      team_id = 123
+      api = GithubApi.new(token)
+      request = stub_add_user_to_team_request(username, team_id, token)
+
+      api.add_user_to_team(username, team_id)
+
+      expect(request).to have_been_requested
+    end
+  end
+
+  describe "#add_repo_to_team" do
+    it "makes a request to GitHub" do
+      token = "some_token"
+      repo_name = "foo/bar"
+      team_id = 123
+      api = GithubApi.new(token)
+      request = stub_add_repo_to_team_request(repo_name, team_id, token)
+
+      api.add_repo_to_team(team_id, repo_name)
+
+      expect(request).to have_been_requested
+    end
+  end
+
+  describe "#create_team" do
+    it "makes a request to GitHub" do
+      token = "some_token"
+      org_name = "foo"
+      repo_name = "foo/bar"
+      team_name = "TestTeam"
+      api = GithubApi.new(token)
+      request = stub_create_team_request(org_name, team_name, repo_name, token)
+
+      api.create_team(
+        org_name: org_name,
+        team_name: team_name,
+        repo_name: repo_name
+      )
+
+      expect(request).to have_been_requested
+    end
+  end
+
+  describe "#add_collaborator" do
+    it "makes a request to GitHub" do
+      username = "houndci"
+      repo_name = "foo/bar"
+      token = "github_token"
+      api = GithubApi.new(token)
+      request = stub_add_collaborator_request(username, repo_name, token)
+
+      api.add_collaborator(repo_name, username)
+
+      expect(request).to have_been_requested
+    end
+  end
+
+  describe "#update_team" do
+    it "makes a request" do
+      team_id = 123
+      api = GithubApi.new
+      request = stub_update_team_permission_request(team_id)
+
+      api.update_team(team_id, permissions: "push")
 
       expect(request).to have_been_requested
     end

--- a/spec/services/add_hound_to_repo_spec.rb
+++ b/spec/services/add_hound_to_repo_spec.rb
@@ -1,0 +1,132 @@
+require "fast_spec_helper"
+require "app/services/add_hound_to_repo"
+require "app/models/github_user"
+
+describe AddHoundToRepo do
+  describe "#run" do
+    context "with org repo" do
+      context "when repo is part of a team" do
+        context "when request succeeds" do
+          it "adds Hound user to first repo team with admin access" do
+            github_team_id = 1001
+            github = build_github(github_team_id: github_team_id)
+            allow(github).to receive(:add_user_to_team).and_return(true)
+
+            result = AddHoundToRepo.run("foo/bar", github)
+
+            expect(result).to eq true
+            expect(github).to have_received(:add_user_to_team).
+              with(hound_github_username, github_team_id)
+          end
+        end
+
+        context "when request fails" do
+          it "returns false" do
+            github = build_github
+            allow(github).to receive(:add_user_to_team).and_return(false)
+
+            result = AddHoundToRepo.run("foo/bar", github)
+
+            expect(result).to eq false
+          end
+        end
+      end
+
+      context "when repo is not part of a team" do
+        context "when Services team does not exist" do
+          it "adds hound to new Services team" do
+            repo_name = "foo/bar"
+            github_team = double("GithubTeam", id: 1001)
+            github = build_github
+            allow(github).to receive(:user_teams).and_return([])
+            allow(github).to receive(:org_teams).and_return([])
+            allow(github).to receive(:add_user_to_team)
+            allow(github).to receive(:create_team).and_return(github_team)
+
+            AddHoundToRepo.run(repo_name, github)
+
+            expect(github).to have_received(:create_team).with(
+              org_name: "foo",
+              team_name: AddHoundToRepo::SERVICES_TEAM_NAME,
+              repo_name: repo_name
+            )
+            expect(github).to have_received(:add_user_to_team).
+              with(hound_github_username, github_team.id)
+          end
+        end
+
+        context "when Services team exists" do
+          it "adds user to existing Services team" do
+            github_team_id = 1001
+            github = build_github(github_team_id: github_team_id)
+            allow(github).to receive(:add_user_to_team)
+
+            AddHoundToRepo.run("foo/bar", github)
+
+            expect(github).to have_received(:add_user_to_team).
+              with(hound_github_username, github_team_id)
+          end
+
+          context "when team name is lowercase" do
+            it "adds user to the team" do
+              github_team_id = 1001
+              github = build_github(github_team_id: github_team_id)
+              allow(github).to receive(:add_user_to_team)
+
+              AddHoundToRepo.run("foo/bar", github)
+
+              expect(github).to have_received(:add_user_to_team).
+                with(hound_github_username, github_team_id)
+            end
+          end
+        end
+      end
+
+      context "when Services team has pull access" do
+        it "updates permissions to push access" do
+          github_team =
+            double("RepoTeams", id: 222, name: "Services", permission: "pull")
+          github = build_github
+          allow(github).to receive(:add_user_to_team)
+          allow(github).to receive(:user_teams).and_return([])
+          allow(github).to receive(:org_teams).and_return([github_team])
+          allow(github).to receive(:update_team)
+          allow(github).to receive(:add_repo_to_team)
+
+          AddHoundToRepo.run("foo/bar", github)
+
+          expect(github).to have_received(:update_team).
+            with(github_team.id, permission: "push")
+        end
+      end
+    end
+
+    context "when repo is not part of an organization" do
+      it "adds user as collaborator" do
+        repo_name = "foo/bar"
+        github_repo = double("GithubRepo", organization: false)
+        github = double("GithubApi", repo: github_repo, add_collaborator: nil)
+
+        AddHoundToRepo.run(repo_name, github)
+
+        expect(github).to have_received(:add_collaborator).
+          with(repo_name, hound_github_username)
+      end
+    end
+  end
+
+  def build_github(github_team_id: 10)
+    github_team = double("GithubTeam", id: github_team_id, permission: "admin")
+    github_repo = double("GithubRepo", organization: double(login: "foo"))
+    double(
+      "GithubApi",
+      repo: github_repo,
+      user_teams: [github_team],
+      repo_teams: [github_team],
+    )
+  end
+
+  def hound_github_username
+    ENV["HOUND_GITHUB_USERNAME"]
+  end
+end

--- a/spec/services/repo_activator_spec.rb
+++ b/spec/services/repo_activator_spec.rb
@@ -3,70 +3,51 @@ require 'spec_helper'
 describe RepoActivator do
   describe '#activate' do
     context 'when repo activation succeeds' do
-      it 'activates repo' do
-        token = "githubtoken"
+      it "marks repo as active" do
         repo = create(:repo)
         stub_github_api
-        allow(JobQueue).to receive(:push).and_return(true)
-        activator = RepoActivator.new(github_token: token, repo: repo)
+        activator = build_activator(repo: repo)
 
         result = activator.activate
 
         expect(result).to be_truthy
-        expect(GithubApi).to have_received(:new).with(token)
         expect(repo.reload).to be_active
       end
 
-      it 'makes Hound a collaborator' do
-        repo = create(:repo)
+      it "adds Hound to the repo" do
+        token = "some_token"
+        repo = build(:repo, name: "foo/bar")
         github = stub_github_api
-        token = "githubtoken"
-        allow(JobQueue).to receive(:push)
-        activator = RepoActivator.new(github_token: token, repo: repo)
+        activator = build_activator(repo: repo, token: token)
 
         activator.activate
 
-        expect(github).to have_received(:add_user_to_repo)
+        expect(GithubApi).to have_received(:new).with(token)
+        expect(AddHoundToRepo).to have_received(:run).with(repo.name, github)
       end
 
-      it 'returns true if the repo activates successfully' do
-        repo = create(:repo)
-        stub_github_api
-        token = "githubtoken"
-        allow(JobQueue).to receive(:push).and_return(true)
-        activator = RepoActivator.new(github_token: token, repo: repo)
+      context "when https is enabled" do
+        it "creates GitHub hook using secure build URL" do
+          github = stub_github_api
+          repo = build(:repo, name: "foo/bar")
+          activator = build_activator(repo: repo)
 
-        result = activator.activate
-
-        expect(result).to be_truthy
-      end
-
-      context 'when https is enabled' do
-        it 'creates GitHub hook using secure build URL' do
           with_https_enabled do
-            repo = create(:repo)
-            token = "githubtoken"
-            github = stub_github_api
-            allow(JobQueue).to receive(:push)
-            activator = RepoActivator.new(github_token: token, repo: repo)
-
             activator.activate
-
-            expect(github).to have_received(:create_hook).with(
-              repo.full_github_name,
-              URI.join("https://#{ENV['HOST']}", 'builds').to_s
-            )
           end
+
+          expect(github).to have_received(:create_hook).with(
+            repo.full_github_name,
+            URI.join("https://#{ENV['HOST']}", "builds").to_s
+          )
         end
       end
 
       context 'when https is disabled' do
         it 'creates GitHub hook using insecure build URL' do
-          repo = create(:repo)
           github = stub_github_api
-          token = "githubtoken"
-          allow(JobQueue).to receive(:push)
-          activator = RepoActivator.new(github_token: token, repo: repo)
+          repo = build(:repo)
+          activator = build_activator(repo: repo)
 
           activator.activate
 
@@ -78,26 +59,20 @@ describe RepoActivator do
       end
     end
 
-    context 'when repo activation fails' do
-      it 'returns false if API request raises' do
-        token = nil
-        repo = build_stubbed(:repo)
-        allow(JobQueue).to receive(:push)
-        expect(GithubApi).to receive(:new).and_raise(Octokit::Error.new)
-        activator = RepoActivator.new(github_token: token, repo: repo)
+    context "when adding hound to rope results in an error" do
+      it "returns false" do
+        activator = build_activator
+        allow(AddHoundToRepo).to receive(:run).and_raise(Octokit::Error.new)
 
         result = activator.activate
 
         expect(result).to be_falsy
       end
 
-      it "reports raised exceptions to Sentry" do
-        token = nil
-        repo = build_stubbed(:repo)
+      it "reports raised exception to Sentry" do
+        activator = build_activator
         error = Octokit::Error.new
-        allow(JobQueue).to receive(:push)
-        allow(GithubApi).to receive(:new).and_raise(error)
-        activator = RepoActivator.new(github_token: token, repo: repo)
+        allow(AddHoundToRepo).to receive(:run).and_raise(error)
         allow(Raven).to receive(:capture_exception)
 
         activator.activate
@@ -105,73 +80,43 @@ describe RepoActivator do
         expect(Raven).to have_received(:capture_exception).with(error)
       end
 
-      it 'only swallows Octokit errors' do
-        token = "githubtoken"
-        repo = double('repo')
-        allow(JobQueue).to receive(:push)
-        allow(GithubApi).to receive(:new).and_raise(Exception.new)
-        activator = RepoActivator.new(github_token: token, repo: repo)
+      it "only swallows Octokit errors" do
+        activator = build_activator
+        allow(AddHoundToRepo).to receive(:run).and_raise(StandardError.new)
 
-        expect { activator.activate }.to raise_error(Exception)
-      end
-
-      context 'when Hound cannot be added to repo' do
-        it 'returns false' do
-          token = "githubtoken"
-          repo = build_stubbed(:repo, full_github_name: "test/repo")
-          github = double(:github, add_user_to_repo: false)
-          allow(JobQueue).to receive(:push)
-          allow(GithubApi).to receive(:new).and_return(github)
-          activator = RepoActivator.new(github_token: token, repo: repo)
-
-          result = activator.activate
-
-          expect(result).to be_falsy
-        end
+        expect { activator.activate }.to raise_error(StandardError)
       end
     end
 
     context 'hook already exists' do
       it 'does not raise' do
-        token = 'token'
-        repo = build_stubbed(:repo)
-        allow(JobQueue).to receive(:push)
-        github = double(:github, create_hook: nil, add_user_to_repo: true)
+        activator = build_activator
+        github = double("GithubApi", create_hook: nil)
         allow(GithubApi).to receive(:new).and_return(github)
-        activator = RepoActivator.new(github_token: token, repo: repo)
 
-        expect do
-          activator.activate
-        end.not_to raise_error
-
-        expect(GithubApi).to have_received(:new).with(token)
+        expect { activator.activate }.not_to raise_error
       end
     end
   end
 
-  describe '#deactivate' do
-    context 'when repo activation succeeds' do
-      it 'deactivates repo' do
-        stub_github_api
-        token = "githubtoken"
+  describe "#deactivate" do
+    context "when repo deactivation succeeds" do
+      it "marks repo as deactivated" do
         repo = create(:repo)
-        allow(JobQueue).to receive(:push)
         create(:membership, repo: repo)
-        activator = RepoActivator.new(github_token: token, repo: repo)
+        activator = build_activator(repo: repo)
+        stub_github_api
 
         activator.deactivate
 
-        expect(GithubApi).to have_received(:new).with(token)
-        expect(repo.active?).to be_falsy
+        expect(repo.reload).not_to be_active
       end
 
       it 'removes GitHub hook' do
-        github_api = stub_github_api
-        token = "githubtoken"
-        allow(JobQueue).to receive(:push)
         repo = create(:repo)
         create(:membership, repo: repo)
-        activator = RepoActivator.new(github_token: token, repo: repo)
+        activator = build_activator(repo: repo)
+        github_api = stub_github_api
 
         activator.deactivate
 
@@ -179,7 +124,7 @@ describe RepoActivator do
         expect(repo.hook_id).to be_nil
       end
 
-      it 'returns true if the repo activates successfully' do
+      it "returns true" do
         stub_github_api
         token = "githubtoken"
         allow(JobQueue).to receive(:push)
@@ -193,13 +138,10 @@ describe RepoActivator do
       end
     end
 
-    context 'when repo activation succeeds' do
-      it 'returns false if the repo does not activate successfully' do
-        repo = double('repo')
-        token = nil
-        allow(JobQueue).to receive(:push)
-        expect(GithubApi).to receive(:new).and_raise(Octokit::Error.new)
-        activator = RepoActivator.new(github_token: token, repo: repo)
+    context "when repo deactivation fails" do
+      it "returns false" do
+        activator = build_activator
+        allow(GithubApi).to receive(:new).and_raise(Octokit::Error.new)
 
         result = activator.deactivate
 
@@ -207,22 +149,25 @@ describe RepoActivator do
       end
 
       it 'only swallows Octokit errors' do
-        repo = double('repo')
-        token = nil
-        allow(JobQueue).to receive(:push)
-        expect(GithubApi).to receive(:new).and_raise(Exception.new)
-        activator = RepoActivator.new(github_token: token, repo: repo)
+        error = StandardError.new("this should bubble through")
+        activator = build_activator
+        expect(GithubApi).to receive(:new).and_raise(error)
 
-        expect do
-          activator.deactivate
-        end.to raise_error(Exception)
+        expect { activator.deactivate }.to raise_error(error)
       end
     end
   end
 
+  def build_activator(token: "githubtoken", repo: build(:repo))
+    allow(JobQueue).to receive(:push).and_return(true)
+    allow(AddHoundToRepo).to receive(:run).and_return(true)
+
+    RepoActivator.new(github_token: token, repo: repo)
+  end
+
   def stub_github_api
     hook = double(:hook, id: 1)
-    api = double(:github_api, add_user_to_repo: true, remove_hook: true)
+    api = double(:github_api, remove_hook: true)
     allow(api).to receive(:create_hook).and_yield(hook)
     allow(GithubApi).to receive(:new).and_return(api)
     api

--- a/spec/support/helpers/github_api_helper.rb
+++ b/spec/support/helpers/github_api_helper.rb
@@ -1,9 +1,13 @@
 module GithubApiHelper
-  def stub_add_collaborator_request(full_repo_name, token)
-    url = "https://api.github.com/repos/#{full_repo_name}/collaborators/houndci"
-    stub_request(:put, url).
-      with(headers: { "Authorization" => "token #{token}" }).
-      to_return(status: 204)
+  def stub_add_collaborator_request(username, repo_name, user_token)
+    stub_request(
+      :put,
+      "https://api.github.com/repos/#{repo_name}/collaborators/#{username}"
+    ).with(
+      headers: { "Authorization" => "token #{user_token}" }
+    ).to_return(
+      status: 204,
+    )
   end
 
   def stub_repo_requests(user_token)
@@ -39,13 +43,13 @@ module GithubApiHelper
     )
   end
 
-  def stub_team_creation_request(org, repo_name, user_token)
+  def stub_create_team_request(org, team_name, repo_name, user_token)
     stub_request(
       :post,
       "https://api.github.com/orgs/#{org}/teams"
     ).with(
       body: {
-        name: 'Services',
+        name: team_name,
         repo_names: [repo_name],
         permission: "push"
       }.to_json,
@@ -57,35 +61,17 @@ module GithubApiHelper
     )
   end
 
-  def stub_update_team_permission_request(team_id, user_token)
+  def stub_update_team_permission_request(team_id)
     json_response = File.read("spec/support/fixtures/team_update.json")
     stub_request(
       :patch,
       "https://api.github.com/teams/#{team_id}"
     ).with(
-      headers: { "Authorization" => "token #{user_token}" }
+      headers: { "Authorization" => /^token \w+$/ }
     ).to_return(
       status: 200,
       body: json_response,
       headers: { "Content-Type" => "application/json; charset=utf-8" }
-    )
-  end
-
-  def stub_failed_team_creation_request(org, repo_name, user_token)
-    stub_request(
-      :post,
-      "https://api.github.com/orgs/#{org}/teams"
-    ).with(
-      body: {
-        name: 'Services',
-        repo_names: [repo_name],
-        permission: "push"
-      }.to_json,
-      headers: { "Authorization" => "token #{user_token}" }
-    ).to_return(
-      status: 422,
-      body: File.read('spec/support/fixtures/failed_team_creation.json'),
-      headers: { 'Content-Type' => 'application/json; charset=utf-8' }
     )
   end
 
@@ -115,62 +101,6 @@ module GithubApiHelper
     )
   end
 
-  def stub_empty_repo_teams_request(repo_name, user_token)
-    stub_request(
-      :get,
-      "https://api.github.com/repos/#{repo_name}/teams?per_page=100"
-    ).with(
-      headers: { "Authorization" => "token #{user_token}" }
-    ).to_return(
-      status: 200,
-      body: '[]',
-      headers: { 'Content-Type' => 'application/json; charset=utf-8' }
-    )
-  end
-
-  def stub_org_teams_request(org_name, user_token)
-    stub_request(
-      :get,
-      "https://api.github.com/orgs/#{org_name}/teams?per_page=100"
-    ).with(
-      headers: { "Authorization" => "token #{user_token}" }
-    ).to_return(
-      status: 200,
-      body: File.read('spec/support/fixtures/repo_teams.json'),
-      headers: { 'Content-Type' => 'application/json; charset=utf-8' }
-    )
-  end
-
-  def stub_paginated_org_teams_request(org_name, user_token)
-    json_response =
-      File.read("spec/support/fixtures/org_teams_with_services_team.json")
-
-    stub_request(
-      :get,
-      "https://api.github.com/orgs/#{org_name}/teams?per_page=100"
-    ).with(
-      headers: { "Authorization" => "token #{user_token}" }
-    ).to_return(
-      status: 200,
-      body: "[]",
-      headers: {
-        "Link" => %(<https://api.github.com/orgs/#{org_name}/teams?page=2&per_page=100>; rel="next"),
-        "Content-Type" => "application/json; charset=utf-8"
-      }
-    )
-
-    stub_request(
-      :get,
-      "https://api.github.com/orgs/#{org_name}/teams?page=2&per_page=100"
-    ).with(
-      headers: { "Authorization" => "token #{user_token}" }
-    ).to_return(
-      status: 200,
-      body: json_response,
-      headers: { "Content-Type" => "application/json; charset=utf-8" }
-    )
-  end
-
   def stub_add_repo_to_team_request(repo_name, team_id, user_token)
     stub_request(
       :put,
@@ -182,102 +112,11 @@ module GithubApiHelper
     )
   end
 
-  def stub_org_teams_with_services_request(org_name, user_token)
-    json_response = File.read(
-      "spec/support/fixtures/org_teams_with_services_team.json"
-    )
-    stub_request(
-      :get,
-      "https://api.github.com/orgs/#{org_name}/teams?per_page=100"
-    ).with(
-      headers: { "Authorization" => "token #{user_token}" }
-    ).to_return(
-      status: 200,
-      body: json_response,
-      headers: { "Content-Type" => "application/json; charset=utf-8" }
-    )
-  end
-
-  def stub_org_teams_with_pull_permission_services_request(org_name, user_token)
-    json_response = File.read(
-      "spec/support/fixtures/org_teams_with_pull_permission_services_team.json"
-    )
-    stub_request(
-      :get,
-      "https://api.github.com/orgs/#{org_name}/teams?per_page=100"
-    ).with(
-      headers: { "Authorization" => "token #{user_token}" }
-    ).to_return(
-      status: 200,
-      body: json_response,
-      headers: { "Content-Type" => "application/json; charset=utf-8" }
-    )
-  end
-
-  def stub_org_teams_with_lowercase_services_request(org_name, token)
-    json_response = File.read(
-      "spec/support/fixtures/org_teams_with_lowercase_services_team.json"
-    )
-    stub_request(
-      :get,
-      "https://api.github.com/orgs/#{org_name}/teams?per_page=100"
-    ).with(
-      headers: { "Authorization" => "token #{token}" }
-    ).to_return(
-      status: 200,
-      body: json_response,
-      headers: { "Content-Type" => "application/json; charset=utf-8" }
-    )
-  end
-
-  def stub_chained_org_teams_request(org_name, user_token)
-    no_services_team_json_response =
-      File.read("spec/support/fixtures/repo_teams.json")
-    services_team_json_response =
-      File.read("spec/support/fixtures/org_teams_with_services_team.json")
-    stub_request(
-      :get,
-      "https://api.github.com/orgs/#{org_name}/teams?per_page=100"
-    ).with(
-      headers: { "Authorization" => "token #{user_token}" }
-    ).to_return(
-      status: 200,
-      body: no_services_team_json_response,
-      headers: { "Content-Type" => "application/json; charset=utf-8" }
-    ).then.to_return(
-      status: 200,
-      body: services_team_json_response,
-      headers: { "Content-Type" => "application/json; charset=utf-8" }
-    )
-  end
-
   def stub_add_user_to_team_request(username, team_id, user_token)
     url = "https://api.github.com/teams/#{team_id}/memberships/#{username}"
     stub_request(:put, url).
       with(headers: { "Authorization" => "token #{user_token}" }).
       to_return(status: 200)
-  end
-
-  def stub_failed_add_user_to_team_request(username, team_id, user_github_token)
-    url = "https://api.github.com/teams/#{team_id}/memberships/#{username}"
-    stub_request(:put, url).
-      with(
-        headers: {
-          "Authorization" => "token #{user_github_token}",
-        }
-      ).to_return(status: 404)
-  end
-
-  def stub_add_user_to_repo_request(username, repo_name, user_token)
-    stub_request(
-      :put,
-      "https://api.github.com/repos/#{repo_name}/collaborators/#{username}"
-    ).with(
-      body: '{}',
-      headers: { "Authorization" => "token #{user_token}" }
-    ).to_return(
-      status: 204,
-    )
   end
 
   def stub_hook_creation_request(full_repo_name, callback_endpoint, token)
@@ -558,8 +397,6 @@ module GithubApiHelper
       headers: { "Content-Type" => "application/json; charset=utf-8" }
     )
   end
-
-  private
 
   def hound_token
     ENV["HOUND_GITHUB_TOKEN"]


### PR DESCRIPTION
Extract the logic out of the `GithubApi` into a service. `GithubApi` should
only be a wrapper over Octokit methods and not handle complex logic.
This allows us to test that logic easier in isolation without stubbing
external requests.