### PR TITLE
Deactivate repos the user can't see anymore

### DIFF
--- a/app/services/repo_synchronization.rb
+++ b/app/services/repo_synchronization.rb
@@ -9,15 +9,54 @@ class RepoSynchronization
   end
 
   def start
-    user.repos.clear
-
-    api.repos.each do |resource|
-      attributes = repo_attributes(resource.to_hash)
-      user.repos << Repo.find_or_create_with(attributes)
-    end
+    update_user_repos_from_api
+    deactivate_orphaned_repos
   end
 
   private
+
+  def user_repos
+    user.repos
+  end
+
+  def deactivate_orphaned_repos
+    user_repos.each do |repo|
+      if repo_not_visible_to_anyone?(repo)
+        deactivate_repo(repo)
+      end
+    end
+  end
+
+  def deactivate_repo(repo)
+    repo.deactivate
+    repo.memberships.destroy_all
+    if repo.subscription
+      RepoSubscriber.unsubscribe(repo, user)
+    end
+  end
+
+  def api_repos
+    @api_repos ||= api.repos.map do |resource|
+      find_or_create_repo(resource)
+    end
+  end
+
+  def update_user_repos_from_api
+    api_repos.each do |repo|
+      unless user_repos.include?(repo)
+        user.repos << repo
+      end
+    end
+  end
+
+  def repo_not_visible_to_anyone?(repo)
+    !api_repos.include?(repo) && repo.memberships.count == 1
+  end
+
+  def find_or_create_repo(resource)
+    attributes = repo_attributes(resource.to_hash)
+    Repo.find_or_create_with(attributes)
+  end
 
   def repo_attributes(attributes)
     {

--- a/app/services/repo_synchronization.rb
+++ b/app/services/repo_synchronization.rb
@@ -11,6 +11,7 @@ class RepoSynchronization
   def start
     update_user_repos_from_api
     deactivate_orphaned_repos
+    destroy_stale_memberships
   end
 
   private
@@ -32,6 +33,14 @@ class RepoSynchronization
     repo.memberships.destroy_all
     if repo.subscription
       RepoSubscriber.unsubscribe(repo, user)
+    end
+  end
+
+  def destroy_stale_memberships
+    user.memberships.each do |membership|
+      if !api_repos.include?(membership.repo)
+        membership.destroy
+      end
     end
   end
 

--- a/spec/features/repo_list_spec.rb
+++ b/spec/features/repo_list_spec.rb
@@ -28,6 +28,7 @@ feature "Repo list", js: true do
     token = "usergithubtoken"
     user = create(:user)
     repo = create(:repo, full_github_name: "user1/test-repo")
+    repo.memberships.destroy_all
     user.repos << repo
     stub_repo_requests(token)
 

--- a/spec/services/repo_synchronization_spec.rb
+++ b/spec/services/repo_synchronization_spec.rb
@@ -118,6 +118,21 @@ describe RepoSynchronization do
         expect(repo).to be_active
       end
 
+      it "removes the user's membership when there are other memberships" do
+        removed_membership = create(:membership)
+        repo = removed_membership.repo
+        repo.update(active: true)
+        create(:membership, repo: repo)
+        github_token = "githubtoken"
+        stub_api_repos(repos: [])
+        synchronization =
+          RepoSynchronization.new(removed_membership.user, github_token)
+
+        synchronization.start
+
+        expect(repo.memberships).not_to include(removed_membership)
+      end
+
       it "destroys the users membership when a repo gets deactivated" do
         repo = create(:repo, :active)
         repo.memberships.destroy_all

--- a/spec/services/repo_synchronization_spec.rb
+++ b/spec/services/repo_synchronization_spec.rb
@@ -12,8 +12,7 @@ describe RepoSynchronization do
         }
       }
       resource = double(:resource, to_hash: attributes)
-      api = double(:github_api, repos: [resource])
-      allow(GithubApi).to receive(:new).and_return(api)
+      stub_api_repos(repos: [resource])
       user = create(:user)
       github_token = 'token'
       synchronization = RepoSynchronization.new(user, github_token)
@@ -33,8 +32,7 @@ describe RepoSynchronization do
         }
       }
       resource = double(:resource, to_hash: attributes)
-      api = double(:github_api, repos: [resource])
-      allow(GithubApi).to receive(:new).and_return(api)
+      stub_api_repos(repos: [resource])
       user = create(:user)
       github_token = 'token'
       synchronization = RepoSynchronization.new(user, github_token)
@@ -42,31 +40,6 @@ describe RepoSynchronization do
       synchronization.start
 
       expect(user.repos.first).to be_in_organization
-    end
-
-    it 'replaces existing repos' do
-      attributes = {
-        full_name: 'user/newrepo',
-        id: 456,
-        private: false,
-        owner: {
-          type: 'User'
-        }
-      }
-      resource = double(:resource, to_hash: attributes)
-      github_token = 'token'
-      membership = create(:membership)
-      user = membership.user
-      api = double(:github_api, repos: [resource])
-      allow(GithubApi).to receive(:new).and_return(api)
-      synchronization = RepoSynchronization.new(user, github_token)
-
-      synchronization.start
-
-      expect(GithubApi).to have_received(:new).with(github_token)
-      expect(user.repos.size).to eq(1)
-      expect(user.repos.first.full_github_name).to eq 'user/newrepo'
-      expect(user.repos.first.github_id).to eq 456
     end
 
     it 'renames an existing repo if updated on github' do
@@ -82,9 +55,7 @@ describe RepoSynchronization do
       }
       resource = double(:resource, to_hash: attributes)
       github_token = 'githubtoken'
-
-      api = double(:github_api, repos: [resource])
-      allow(GithubApi).to receive(:new).and_return(api)
+      stub_api_repos(repos: [resource])
       synchronization = RepoSynchronization.new(membership.user, github_token)
 
       synchronization.start
@@ -108,9 +79,8 @@ describe RepoSynchronization do
         }
         resource = double(:resource, to_hash: attributes)
         github_token = 'githubtoken'
+        stub_api_repos(repos: [resource])
         second_user = create(:user)
-        api = double(:github_api, repos: [resource])
-        allow(GithubApi).to receive(:new).and_return(api)
         synchronization = RepoSynchronization.new(second_user, github_token)
 
         synchronization.start
@@ -118,5 +88,70 @@ describe RepoSynchronization do
         expect(second_user.reload.repos.size).to eq(1)
       end
     end
+
+    describe "when a user no longer has access to a repo" do
+      it "deactivates a repo when there are no other memberships" do
+        repo = create(:repo, :active)
+        repo.memberships.destroy_all
+        membership = create(:membership, repo: repo)
+        github_token = "githubtoken"
+        stub_api_repos(repos: [])
+        synchronization = RepoSynchronization.new(membership.user, github_token)
+
+        synchronization.start
+        repo.reload
+
+        expect(repo).not_to be_active
+      end
+
+      it "does not deactivate a repo when there are other memberships" do
+        repo = create(:membership).repo
+        repo.update(active: true)
+        membership = create(:membership, repo: repo)
+        github_token = "githubtoken"
+        stub_api_repos(repos: [])
+        synchronization = RepoSynchronization.new(membership.user, github_token)
+
+        synchronization.start
+        repo.reload
+
+        expect(repo).to be_active
+      end
+
+      it "destroys the users membership when a repo gets deactivated" do
+        repo = create(:repo, :active)
+        repo.memberships.destroy_all
+        membership = create(:membership, repo: repo)
+        user = membership.user
+        github_token = "githubtoken"
+        stub_api_repos(repos: [])
+        synchronization = RepoSynchronization.new(membership.user, github_token)
+
+        synchronization.start
+
+        expect(user.memberships).to be_empty
+      end
+
+      it "unsubscribes the user when a repo gets deactivated" do
+        repo = create(:repo, :active)
+        subscription = create(:subscription, repo: repo)
+        user = subscription.user
+        repo.memberships.destroy_all
+        create(:membership, repo: repo, user: user)
+        github_token = "githubtoken"
+        stub_api_repos(repos: [])
+        allow(RepoSubscriber).to receive(:unsubscribe)
+        synchronization = RepoSynchronization.new(user, github_token)
+
+        synchronization.start
+
+        expect(RepoSubscriber).to have_received(:unsubscribe).with(repo, user)
+      end
+    end
+  end
+
+  def stub_api_repos(attrs)
+    api = double(:github_api, attrs)
+    allow(GithubApi).to receive(:new).and_return(api)
   end
 end


### PR DESCRIPTION
If the user cannot see a repo and the repo has no other memberships. It
will be inactivated and the memberships will be destroyed.

https://trello.com/c/SBKDsHjl