### PR TITLE
Adds owners tables and 	assigns owner in repo creation / update

### DIFF
--- a/app/jobs/buildable.rb
+++ b/app/jobs/buildable.rb
@@ -3,6 +3,11 @@ require 'resque'
 module Buildable
   def perform(payload_data)
     payload = Payload.new(payload_data)
+    Owner.upsert(
+      github_id: payload.repository_owner_id,
+      name: payload.repository_owner_name,
+      organization: payload.repository_owner_is_organization?
+    )
     build_runner = BuildRunner.new(payload)
     build_runner.run
   rescue Resque::TermException

--- a/app/models/default_config_file.rb
+++ b/app/models/default_config_file.rb
@@ -2,7 +2,7 @@ class DefaultConfigFile
   CONFIG_DIR = "config/style_guides"
   THOUGHTBOT_CONFIG_DIR = "config/style_guides/thoughtbot"
 
-  pattr_initialize :file_name, :repository_owner
+  pattr_initialize :file_name, :repository_owner_name
 
   def path
     File.join(directory, file_name)
@@ -19,6 +19,6 @@ class DefaultConfigFile
   end
 
   def thoughtbot_repository?
-    repository_owner == "thoughtbot"
+    repository_owner_name == "thoughtbot"
   end
 end

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -1,0 +1,11 @@
+class Owner < ActiveRecord::Base
+  has_many :repos
+
+  def self.upsert(github_id:, name:, organization:)
+    owner = find_or_initialize_by(github_id: github_id)
+    owner.name = name
+    owner.organization = organization
+    owner.save!
+    owner
+  end
+end

--- a/app/models/payload.rb
+++ b/app/models/payload.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 class Payload
   pattr_initialize :unparsed_data
 
@@ -35,8 +33,16 @@ class Payload
     data['zen']
   end
 
-  def repository_owner
+  def repository_owner_id
+    repository["owner"]["id"]
+  end
+
+  def repository_owner_name
     repository["owner"]["login"]
+  end
+
+  def repository_owner_is_organization?
+    repository["owner"]["type"] == GithubApi::ORGANIZATION_TYPE
   end
 
   private

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -21,8 +21,8 @@ class PullRequest
     )
   end
 
-  def repository_owner
-    payload.repository_owner
+  def repository_owner_name
+    payload.repository_owner_name
   end
 
   def opened?

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -1,9 +1,9 @@
 class Repo < ActiveRecord::Base
-  has_many :memberships
-  has_many :users, through: :memberships
   has_many :builds
-
+  has_many :memberships
+  belongs_to :owner
   has_one :subscription
+  has_many :users, through: :memberships
 
   alias_attribute :name, :full_github_name
 

--- a/app/models/style_checker.rb
+++ b/app/models/style_checker.rb
@@ -32,7 +32,7 @@ class StyleChecker
     style_guide_class = style_guide_class(filename)
     style_guides[style_guide_class] ||= style_guide_class.new(
       config,
-      pull_request.repository_owner
+      pull_request.repository_owner_name
     )
   end
 

--- a/app/models/style_guide/base.rb
+++ b/app/models/style_guide/base.rb
@@ -1,7 +1,7 @@
 # Base to contain common style guide logic
 module StyleGuide
   class Base
-    pattr_initialize :repo_config, :repository_owner
+    pattr_initialize :repo_config, :repository_owner_name
 
     def enabled?
       repo_config.enabled_for?(name)

--- a/app/models/style_guide/coffee_script.rb
+++ b/app/models/style_guide/coffee_script.rb
@@ -29,7 +29,10 @@ module StyleGuide
     end
 
     def default_config_file
-      DefaultConfigFile.new(DEFAULT_CONFIG_FILENAME, repository_owner).path
+      DefaultConfigFile.new(
+        DEFAULT_CONFIG_FILENAME,
+        repository_owner_name
+      ).path
     end
   end
 end

--- a/app/models/style_guide/java_script.rb
+++ b/app/models/style_guide/java_script.rb
@@ -40,7 +40,10 @@ module StyleGuide
     end
 
     def default_config_file
-      DefaultConfigFile.new(DEFAULT_CONFIG_FILENAME, repository_owner).path
+      DefaultConfigFile.new(
+        DEFAULT_CONFIG_FILENAME,
+        repository_owner_name
+      ).path
     end
   end
 end

--- a/app/models/style_guide/ruby.rb
+++ b/app/models/style_guide/ruby.rb
@@ -61,7 +61,10 @@ module StyleGuide
     end
 
     def default_config_file
-      DefaultConfigFile.new(DEFAULT_CONFIG_FILENAME, repository_owner).path
+      DefaultConfigFile.new(
+        DEFAULT_CONFIG_FILENAME,
+        repository_owner_name
+      ).path
     end
   end
 end

--- a/app/models/style_guide/scss.rb
+++ b/app/models/style_guide/scss.rb
@@ -53,7 +53,10 @@ module StyleGuide
     end
 
     def default_config_file
-      DefaultConfigFile.new(DEFAULT_CONFIG_FILENAME, repository_owner).path
+      DefaultConfigFile.new(
+        DEFAULT_CONFIG_FILENAME,
+        repository_owner_name
+      ).path
     end
   end
 end

--- a/db/migrate/20141211224528_create_owners.rb
+++ b/db/migrate/20141211224528_create_owners.rb
@@ -1,0 +1,13 @@
+class CreateOwners < ActiveRecord::Migration
+  def change
+    create_table :owners do |t|
+      t.timestamps null: false
+      t.integer :github_id, null: false
+      t.string :name, null: false
+      t.boolean :organization, default: false, null: false
+
+      t.index :github_id, unique: true
+      t.index :name, unique: true
+    end
+  end
+end

--- a/db/migrate/20150123224104_add_owner_to_repos.rb
+++ b/db/migrate/20150123224104_add_owner_to_repos.rb
@@ -1,0 +1,6 @@
+class AddOwnerToRepos < ActiveRecord::Migration
+  def change
+    add_reference :repos, :owner, index: true
+    add_foreign_key :repos, :owners
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,6 +40,17 @@ ActiveRecord::Schema.define(version: 20150130051749) do
   add_index "memberships", ["repo_id"], name: "index_memberships_on_repo_id", using: :btree
   add_index "memberships", ["user_id"], name: "index_memberships_on_user_id", using: :btree
 
+  create_table "owners", force: :cascade do |t|
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.integer  "github_id",                    null: false
+    t.string   "name",                         null: false
+    t.boolean  "organization", default: false, null: false
+  end
+
+  add_index "owners", ["github_id"], name: "index_owners_on_github_id", unique: true, using: :btree
+  add_index "owners", ["name"], name: "index_owners_on_name", unique: true, using: :btree
+
   create_table "repos", force: :cascade do |t|
     t.integer  "github_id",                                    null: false
     t.boolean  "active",                       default: false, null: false
@@ -49,11 +60,13 @@ ActiveRecord::Schema.define(version: 20150130051749) do
     t.datetime "updated_at"
     t.boolean  "private"
     t.boolean  "in_organization"
+    t.integer  "owner_id"
   end
 
   add_index "repos", ["active"], name: "index_repos_on_active", using: :btree
   add_index "repos", ["full_github_name"], name: "index_repos_on_full_github_name", unique: true, using: :btree
   add_index "repos", ["github_id"], name: "index_repos_on_github_id", using: :btree
+  add_index "repos", ["owner_id"], name: "index_repos_on_owner_id", using: :btree
 
   create_table "subscriptions", force: :cascade do |t|
     t.datetime "created_at",                                                               null: false
@@ -92,4 +105,5 @@ ActiveRecord::Schema.define(version: 20150130051749) do
 
   add_index "violations", ["build_id"], name: "index_violations_on_build_id", using: :btree
 
+  add_foreign_key "repos", "owners"
 end

--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -4,8 +4,9 @@ require "base64"
 require "active_support/core_ext/object/with_options"
 
 class GithubApi
-  SERVICES_TEAM_NAME = "Services"
+  ORGANIZATION_TYPE = "Organization"
   PREVIEW_MEDIA_TYPE = "application/vnd.github.moondragon-preview+json"
+  SERVICES_TEAM_NAME = "Services"
 
   pattr_initialize :token
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,7 @@
 FactoryGirl.define do
+  sequence(:github_id)
+  sequence(:github_name) { |n| "github_name#{n}" }
+
   factory :build do
     repo
 
@@ -17,13 +20,13 @@ FactoryGirl.define do
     end
 
     sequence(:full_github_name) { |n| "user/repo#{n}" }
-    sequence(:github_id) { |n| n }
+    github_id
     private false
     in_organization false
   end
 
   factory :user do
-    sequence(:github_username) { |n| "github#{n}" }
+    github_username { generate(:github_name) }
 
     ignore do
       repos []
@@ -52,5 +55,10 @@ FactoryGirl.define do
     patch_position 1
     line_number 42
     messages ["Trailing whitespace detected."]
+  end
+
+  factory :owner do
+    github_id
+    name { generate(:github_name) }
   end
 end

--- a/spec/jobs/buildable_spec.rb
+++ b/spec/jobs/buildable_spec.rb
@@ -1,7 +1,4 @@
-require 'fast_spec_helper'
-require 'app/jobs/buildable'
-require 'app/models/payload'
-require 'app/services/build_runner'
+require "spec_helper"
 
 describe Buildable do
   class TestJob
@@ -10,11 +7,16 @@ describe Buildable do
 
   describe '.perform' do
     it 'runs build runner' do
-      payload_data = double(:payload_data)
-      payload = double(:payload)
       build_runner = double(:build_runner, run: nil)
+      payload = double(
+        "Payload",
+        repository_owner_id: 1,
+        repository_owner_name: "test",
+        repository_owner_is_organization?: true
+      )
       allow(Payload).to receive(:new).and_return(payload)
       allow(BuildRunner).to receive(:new).and_return(build_runner)
+      allow(Owner).to receive(:upsert)
 
       TestJob.perform(payload_data)
 
@@ -26,11 +28,42 @@ describe Buildable do
     it 'retries when Resque::TermException is raised' do
       allow(Payload).to receive(:new).and_raise(Resque::TermException.new(1))
       allow(Resque).to receive(:enqueue)
-      payload_data = double(:payload_data)
 
       TestJob.perform(payload_data)
 
       expect(Resque).to have_received(:enqueue).with(TestJob, payload_data)
     end
+
+    it "upserts repository owner" do
+      github_id = "2345"
+      name = "thoughtbot"
+      payload_data = payload_data(
+        github_id: github_id,
+        name: name
+      )
+      build_runner = double("BuildRunner", run: true)
+      allow(BuildRunner).to receive(:new).and_return(build_runner)
+      allow(Owner).to receive(:upsert)
+
+      TestJob.perform(payload_data)
+
+      expect(Owner).to have_received(:upsert).with(
+        github_id: github_id,
+        name: name,
+        organization: true
+      )
+    end
+  end
+
+  def payload_data(github_id: 1234, name: "test")
+    {
+      "repository" => {
+        "owner" => {
+          "id" => github_id,
+          "login" => name,
+          "type" => "Organization"
+        }
+      }
+    }
   end
 end

--- a/spec/models/owner_spec.rb
+++ b/spec/models/owner_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe Owner do
+  it { should have_many(:repos) }
+
+  describe ".upsert" do
+    context "when owner does not exist" do
+      it "creates owner" do
+        github_id = 1234
+        name = "thoughtbot"
+        organization = true
+
+        new_owner = Owner.upsert(
+          github_id: github_id,
+          name: name,
+          organization: organization
+        )
+
+        expect(new_owner).to be_persisted
+      end
+    end
+
+    context "when owner exists" do
+      it "updates owner" do
+        owner = create(:owner)
+        new_name = "ralphbot"
+
+        updated_owner = Owner.upsert(
+          github_id: owner.github_id,
+          name: new_name,
+          organization: true
+        )
+
+        expect(updated_owner.name).to eq new_name
+        expect(updated_owner.organization).to eq true
+      end
+    end
+  end
+end

--- a/spec/models/payload_spec.rb
+++ b/spec/models/payload_spec.rb
@@ -1,6 +1,6 @@
-require 'fast_spec_helper'
+require "fast_spec_helper"
 require "attr_extras"
-require 'app/models/payload'
+require "app/models/payload"
 
 describe Payload do
   describe '#changed_files' do
@@ -61,7 +61,7 @@ describe Payload do
     end
   end
 
-  describe "#repository_owner" do
+  describe "#repository_owner_name" do
     it "returns the owner of the repo's name" do
       data = {
         "repository" => {
@@ -73,7 +73,57 @@ describe Payload do
 
       payload = Payload.new(data)
 
-      expect(payload.repository_owner).to eq "thoughtbot"
+      expect(payload.repository_owner_name).to eq "thoughtbot"
+    end
+  end
+
+  describe "#repository_owner_id" do
+    it "returns the owner of the repo's ID" do
+      data = {
+        "repository" => {
+          "owner" => {
+            "id" => 1
+          }
+        }
+      }
+
+      payload = Payload.new(data)
+
+      expect(payload.repository_owner_id).to eq 1
+    end
+  end
+
+  describe "#repository_owner_is_organization?" do
+    context "when the repository owner is a user" do
+      it "returns false" do
+        payload_json = {
+          "repository" => {
+            "owner" => {
+              "id" => 1,
+              "type" => "User"
+            }
+          }
+        }
+        payload = Payload.new(payload_json)
+
+        expect(payload.repository_owner_is_organization?).to be false
+      end
+    end
+
+    context "when the repository owner is an organization" do
+      it "returns true" do
+        payload_json = {
+          "repository" => {
+            "owner" => {
+              "id" => 1,
+              "type" => "Organization"
+            }
+          }
+        }
+        payload = Payload.new(payload_json)
+
+        expect(payload.repository_owner_is_organization?).to be true
+      end
     end
   end
 end

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -1,10 +1,11 @@
 require "spec_helper"
 
 describe Repo do
-  it { should have_many(:users).through(:memberships) }
   it { should have_many :builds }
   it { should validate_presence_of :full_github_name }
   it { should validate_presence_of :github_id }
+  it { should belong_to :owner }
+  it { should have_many(:users).through(:memberships) }
 
   it "validates uniqueness of github_id" do
     create(:repo)

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -203,7 +203,7 @@ describe StyleChecker, "#violations" do
       file_content: "",
       head_commit: head_commit,
       pull_request_files: [],
-      repository_owner: "some_org"
+      repository_owner_name: "some_org"
     }
 
     double("PullRequest", defaults.merge(options))

--- a/spec/models/style_guide/coffee_script_spec.rb
+++ b/spec/models/style_guide/coffee_script_spec.rb
@@ -78,7 +78,7 @@ describe StyleGuide::CoffeeScript do
         spy_on_file_read
         config_file = thoughtbot_configuration_file(StyleGuide::CoffeeScript)
 
-        violations_in("var foo = 'bar'", repository_owner: "thoughtbot")
+        violations_in("var foo = 'bar'", repository_owner_name: "thoughtbot")
 
         expect(File).to have_received(:read).
           with(config_file)
@@ -93,7 +93,7 @@ describe StyleGuide::CoffeeScript do
         spy_on_file_read
         config_file = default_configuration_file(StyleGuide::CoffeeScript)
 
-        violations_in("var foo = 'bar'", repository_owner: "not_thoughtbot")
+        violations_in("var foo = 'bar'", repository_owner_name: "foo")
 
         expect(File).to have_received(:read).
           with(config_file)
@@ -104,9 +104,12 @@ describe StyleGuide::CoffeeScript do
 
     private
 
-    def violations_in(content, repository_owner: "ralph")
+    def violations_in(content, repository_owner_name: "ralph")
       repo_config = double("RepoConfig", enabled_for?: true, for: {})
-      style_guide = StyleGuide::CoffeeScript.new(repo_config, repository_owner)
+      style_guide = StyleGuide::CoffeeScript.new(
+        repo_config,
+        repository_owner_name
+      )
       style_guide.violations_in_file(build_file(content)).flat_map(&:messages)
     end
 

--- a/spec/models/style_guide/java_script_spec.rb
+++ b/spec/models/style_guide/java_script_spec.rb
@@ -73,7 +73,11 @@ describe StyleGuide::JavaScript do
         file = double(:file, content: "$(myGlobal).hide();").as_null_object
         repo_config = double("RepoConfig", for: {})
 
-        violations_in(file, repo_config, repository_owner: "not_thoughtbot")
+        violations_in(
+          file,
+          repo_config,
+          repository_owner_name: "not_thoughtbot"
+        )
 
         expect(File).to have_received(:read).with(configuration_file_path)
         expect(Jshintrb).to have_received(:lint).
@@ -91,7 +95,7 @@ describe StyleGuide::JavaScript do
         )
         repo_config = double("RepoConfig", for: {})
 
-        violations_in(file, repo_config, repository_owner: "thoughtbot")
+        violations_in(file, repo_config, repository_owner_name: "thoughtbot")
 
         expect(File).to have_received(:read).with(configuration_file_path)
         expect(Jshintrb).to have_received(:lint).
@@ -140,8 +144,11 @@ describe StyleGuide::JavaScript do
     end
   end
 
-  def violations_in(file, repo_config, repository_owner: "not_thoughtbot")
-    style_guide = StyleGuide::JavaScript.new(repo_config, repository_owner)
+  def violations_in(file, repo_config, repository_owner_name: "not_thoughtbot")
+    style_guide = StyleGuide::JavaScript.new(
+      repo_config,
+      repository_owner_name
+    )
     style_guide.violations_in_file(file)
   end
 

--- a/spec/models/style_guide/ruby_spec.rb
+++ b/spec/models/style_guide/ruby_spec.rb
@@ -461,7 +461,7 @@ end
         end
       CODE
 
-      violations_in(code, repository_owner: "not_thoughtbot")
+      violations_in(code, repository_owner_name: "not_thoughtbot")
 
       expect(RuboCop::ConfigLoader).to have_received(:configuration_from_file).
         with(config_file)
@@ -512,15 +512,15 @@ end
     end
 
     def thoughtbot_violations_in(content)
-      violations_in(content, repository_owner: "thoughtbot")
+      violations_in(content, repository_owner_name: "thoughtbot")
     end
   end
 
   private
 
-  def violations_in(content, config: nil, repository_owner: "ralph")
+  def violations_in(content, config: nil, repository_owner_name: "ralph")
     repo_config = double("RepoConfig", enabled_for?: true, for: config)
-    style_guide = StyleGuide::Ruby.new(repo_config, repository_owner)
+    style_guide = StyleGuide::Ruby.new(repo_config, repository_owner_name)
     style_guide.violations_in_file(build_file(content)).flat_map(&:messages)
   end
 

--- a/spec/models/style_guide/scss_spec.rb
+++ b/spec/models/style_guide/scss_spec.rb
@@ -90,8 +90,8 @@ describe StyleGuide::Scss do
 
   def build_style_guide(config = nil)
     repo_config = double("RepoConfig", enabled_for?: true, for: config)
-    repository_owner = "ralph"
-    StyleGuide::Scss.new(repo_config, repository_owner)
+    repository_owner_name = "ralph"
+    StyleGuide::Scss.new(repo_config, repository_owner_name)
   end
 
   def build_file(text)

--- a/spec/services/repo_synchronization_spec.rb
+++ b/spec/services/repo_synchronization_spec.rb
@@ -1,91 +1,67 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe RepoSynchronization do
-  describe '#start' do
-    it 'saves privacy flag' do
-      attributes = {
-        full_name: 'user/newrepo',
-        id: 456,
-        private: true,
-        owner: {
-          type: 'User'
-        }
-      }
-      resource = double(:resource, to_hash: attributes)
-      api = double(:github_api, repos: [resource])
-      allow(GithubApi).to receive(:new).and_return(api)
+  describe "#start" do
+    it "saves privacy flag" do
+      stub_github_api_repos(
+        repo_id: 456,
+        owner_id: 1,
+        owner_name: "thoughtbot",
+        repo_name: "user/newrepo"
+      )
       user = create(:user)
-      github_token = 'token'
-      synchronization = RepoSynchronization.new(user, github_token)
+      synchronization = RepoSynchronization.new(user, "githubtoken")
 
       synchronization.start
 
       expect(user.repos.first).to be_private
     end
 
-    it 'saves organization flag' do
-      attributes = {
-        full_name: 'user/newrepo',
-        id: 456,
-        private: false,
-        owner: {
-          type: 'Organization'
-        }
-      }
-      resource = double(:resource, to_hash: attributes)
-      api = double(:github_api, repos: [resource])
-      allow(GithubApi).to receive(:new).and_return(api)
+    it "saves organization flag" do
+      stub_github_api_repos(
+        repo_id: 456,
+        owner_id: 1,
+        owner_name: "thoughtbot",
+        private_repo: false,
+        repo_name: "user/newrepo"
+      )
       user = create(:user)
-      github_token = 'token'
-      synchronization = RepoSynchronization.new(user, github_token)
+      synchronization = RepoSynchronization.new(user, "githubtoken")
 
       synchronization.start
 
       expect(user.repos.first).to be_in_organization
     end
 
-    it 'replaces existing repos' do
-      attributes = {
-        full_name: 'user/newrepo',
-        id: 456,
-        private: false,
-        owner: {
-          type: 'User'
-        }
-      }
-      resource = double(:resource, to_hash: attributes)
-      github_token = 'token'
+    it "replaces existing repos" do
+      stub_github_api_repos(
+        repo_id: 456,
+        owner_id: 1,
+        owner_name: "thoughtbot",
+        private_repo: false,
+        repo_name: "user/newrepo"
+      )
       membership = create(:membership)
       user = membership.user
-      api = double(:github_api, repos: [resource])
-      allow(GithubApi).to receive(:new).and_return(api)
-      synchronization = RepoSynchronization.new(user, github_token)
+      synchronization = RepoSynchronization.new(user, "githubtoken")
 
       synchronization.start
 
-      expect(GithubApi).to have_received(:new).with(github_token)
       expect(user.repos.size).to eq(1)
-      expect(user.repos.first.full_github_name).to eq 'user/newrepo'
+      expect(user.repos.first.full_github_name).to eq "user/newrepo"
       expect(user.repos.first.github_id).to eq 456
     end
 
-    it 'renames an existing repo if updated on github' do
+    it "renames an existing repo if updated on github" do
       membership = create(:membership)
-      repo_name = 'user/newrepo'
-      attributes = {
-        full_name: repo_name,
-        id: membership.repo.github_id,
-        private: true,
-        owner: {
-          type: 'User'
-        }
-      }
-      resource = double(:resource, to_hash: attributes)
-      github_token = 'githubtoken'
-
-      api = double(:github_api, repos: [resource])
-      allow(GithubApi).to receive(:new).and_return(api)
-      synchronization = RepoSynchronization.new(membership.user, github_token)
+      repo_name = "user/newrepo"
+      stub_github_api_repos(
+        repo_id: membership.repo.github_id,
+        owner_id: 1,
+        owner_name: "thoughtbot",
+        repo_name: repo_name
+      )
+      synchronization = RepoSynchronization.new(membership.user, "githubtoken")
 
       synchronization.start
 
@@ -94,29 +70,86 @@ describe RepoSynchronization do
         to eq membership.repo.github_id
     end
 
-    describe 'when a repo membership already exists' do
-      it 'creates another membership' do
+    describe "when a repo membership already exists" do
+      it "creates another membership" do
         first_membership = create(:membership)
         repo = first_membership.repo
-        attributes = {
-          full_name: repo.full_github_name,
-          id: repo.github_id,
-          private: true,
-          owner: {
-            type: 'User'
-          }
-        }
-        resource = double(:resource, to_hash: attributes)
-        github_token = 'githubtoken'
+        stub_github_api_repos(
+          repo_id: repo.github_id,
+          owner_id: 1,
+          owner_name: "thoughtbot"
+        )
         second_user = create(:user)
-        api = double(:github_api, repos: [resource])
-        allow(GithubApi).to receive(:new).and_return(api)
-        synchronization = RepoSynchronization.new(second_user, github_token)
+        synchronization = RepoSynchronization.new(second_user, "githubtoken")
 
         synchronization.start
 
         expect(second_user.reload.repos.size).to eq(1)
       end
+    end
+
+    describe "repo owners" do
+      context "when the owner doesn't exist" do
+        it "creates and associates an owner to the repo" do
+          user = create(:user)
+          owner_github_id = 1234
+          owner_name = "thoughtbot"
+          repo_github_id = 321
+          stub_github_api_repos(
+            repo_id: repo_github_id,
+            owner_id: owner_github_id,
+            owner_name: owner_name
+          )
+          synchronization = RepoSynchronization.new(user, "githubtoken")
+
+          synchronization.start
+
+          owner = Owner.find_by(github_id: owner_github_id)
+          expect(owner.name).to eq(owner_name)
+          expect(owner.repos.map(&:github_id)).to eq([repo_github_id])
+        end
+      end
+
+      context "when the owner exists" do
+        it "updates and associates an owner to the repo" do
+          owner = create(:owner)
+          user = create(:user)
+          repo_github_id = 321
+          stub_github_api_repos(
+            repo_id: repo_github_id,
+            owner_id: owner.github_id,
+            owner_name: owner.name
+          )
+          synchronization = RepoSynchronization.new(user, "githubtoken")
+
+          synchronization.start
+
+          owner = Owner.find_by(github_id: owner.github_id)
+          expect(owner.repos.map(&:github_id)).to eq([repo_github_id])
+        end
+      end
+    end
+
+    def stub_github_api_repos(
+      repo_id:,
+      owner_id:,
+      owner_name:,
+      private_repo: true,
+      repo_name: "thoughtbot/newrepo"
+    )
+      attributes = {
+        full_name: repo_name,
+        id: repo_id,
+        private: private_repo,
+        owner: {
+          id: owner_id,
+          login: owner_name,
+          type: "Organization",
+        }
+      }
+      resource = double(:resource, to_hash: attributes)
+      api = double("GithubApi", repos: [resource])
+      allow(GithubApi).to receive(:new).and_return(api)
     end
   end
 end


### PR DESCRIPTION
This PR updates the `RepoSynchronization` process and `Build`'s to assign the
`repo` to its parent `owner` (which is either a user or an organization). Tying
the `repo` to the `owner` is a preliminary step to having `owner` level
configuration.

New `repo`'s and updated `repo`'s (updated via the user clicking 'Refresh Repo
List' or via a build) will have their `owner`s populated.  We'll need to
backfill the `repo`'s that are not new and are not refreshed. I propose we merge
this PR as is and then have follow up work that adds an idempotent rake task
(which requires calls to GitHub) that will backfill `repo`'s missing
`owner_id`'s. Once the data is backfilled, we can apply a `null: false`
constraint to `repos.owner_id`.

Part of
https://trello.com/c/V0jY5LWs/452-migrate-existing-config-files-into-database