### PR TITLE
Don't prompt user for credit card if one has already been set up

### DIFF
--- a/app/assets/javascripts/directives/repo.js.coffee.erb
+++ b/app/assets/javascripts/directives/repo.js.coffee.erb
@@ -1,4 +1,4 @@
-App.directive 'repo', ['Subscription', 'StripeCheckout', (Subscription, StripeCheckout) ->
+App.directive 'repo', ['Subscription', 'StripeCheckout', 'User', (Subscription, StripeCheckout, User) ->
   scope: true
   templateUrl: '/templates/repo'
   link: (scope, element, attributes) ->
@@ -16,15 +16,37 @@ App.directive 'repo', ['Subscription', 'StripeCheckout', (Subscription, StripeCh
         .catch(-> alert('Your repo failed to deactivate.'))
         .finally(-> scope.processing = false)
 
-    createSubscription = (stripeToken) ->
-      scope.processing = true
+    showCreditCardForm = ->
+      StripeCheckout.open(
+        name: scope.repo.full_plan_name,
+        amount: scope.repo.price_in_cents,
+        createSubscriptionWithNewCard
+      )
 
+    createSubscription = (user) ->
+      if scope.repo.price_in_cents > 0
+        if user.card_exists
+          createSubscriptionWithExistingCard()
+        else
+          showCreditCardForm()
+      else
+        activateRepo()
+
+    createSubscriptionWithExistingCard = ->
+      scope.processing = true
+      subscription = new Subscription(repo_id: scope.repo.id)
+      saveSubscription(subscription)
+
+    createSubscriptionWithNewCard = (stripeToken) ->
+      scope.processing = true
       subscription = new Subscription(
         repo_id: scope.repo.id
         card_token: stripeToken.id
         email_address: stripeToken.email
       )
+      saveSubscription(subscription)
 
+    saveSubscription = (subscription) ->
       subscription.$save().then((response) ->
         scope.repo.active = true
         scope.repo.stripe_subscription_id = response.stripe_subscription_id
@@ -55,12 +77,5 @@ App.directive 'repo', ['Subscription', 'StripeCheckout', (Subscription, StripeCh
         else
           deactivateRepo()
       else
-        if scope.repo.price_in_cents > 0
-          StripeCheckout.open(
-            name: scope.repo.full_plan_name,
-            amount: scope.repo.price_in_cents,
-            createSubscription
-          )
-        else
-          activateRepo()
+        User.get().$promise.then(createSubscription)
 ]

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -46,7 +46,7 @@ class Report
   end
 
   def self.cancellations
-    generate_report("Subscriptions") do |week|
+    generate_report("Cancellations") do |week|
       <<-SQL
         SELECT COUNT(*)
         FROM subscriptions

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,7 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :github_username, :refreshing_repos
+  attributes :id, :github_username, :card_exists, :refreshing_repos
+
+  def card_exists
+    object.stripe_customer_id.present?
+  end
 end

--- a/app/services/repo_subscriber.rb
+++ b/app/services/repo_subscriber.rb
@@ -10,9 +10,8 @@ class RepoSubscriber
   end
 
   def subscribe
-    customer = if user.stripe_customer_id
-      payment_gateway_customer.card = card_token
-      payment_gateway_customer.save
+    customer = if user.stripe_customer_id.present?
+      payment_gateway_customer
     else
       create_stripe_customer
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,18 +1,21 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe UsersController do
-  describe '#show' do
-    it 'returns current user in json' do
+  describe "#show" do
+    it "returns current user in json" do
       user = create(:user)
       stub_sign_in(user)
 
       get :show, format: :json
 
-      expect(response.body).to eq user_json(user)
+      expect(response.body).to eq(
+        {
+          id: user.id,
+          github_username: user.github_username,
+          card_exists: false,
+          refreshing_repos: user.refreshing_repos
+        }.to_json
+      )
     end
-  end
-
-  def user_json(user)
-    user.attributes.slice('id', 'github_username', 'refreshing_repos').to_json
   end
 end

--- a/spec/services/repo_subscriber_spec.rb
+++ b/spec/services/repo_subscriber_spec.rb
@@ -17,7 +17,7 @@ describe RepoSubscriber do
         RepoSubscriber.subscribe(repo, user, "cardtoken")
 
         expect(subscription_request).to have_been_requested
-        expect(update_request).to have_been_requested
+        expect(update_request).not_to have_been_requested
         expect(repo.subscription.stripe_subscription_id).
           to eq(stripe_subscription_id)
         expect(repo.subscription_price).to(eq(Plan::PRICES[:private]))
@@ -27,7 +27,7 @@ describe RepoSubscriber do
     context "when Stripe customer does not exist" do
       it "creates a new Stripe customer, subscription and repo subscription" do
         repo = create(:repo)
-        user = create(:user, repos: [repo])
+        user = create(:user, repos: [repo], stripe_customer_id: "")
         customer_request = stub_customer_create_request(user)
         subscription_request =
           stub_subscription_create_request(plan: repo.plan_type)


### PR DESCRIPTION
This change skips Stripe Checkout when a card has already been entered. I also added some view logic to not show the "Update Credit Card" link if no Stripe customer exists.