### PR TITLE
Adds repo:update_owners task

### DIFF
--- a/app/services/update_repo_owner.rb
+++ b/app/services/update_repo_owner.rb
@@ -1,0 +1,29 @@
+class UpdateRepoOwner
+  def self.run
+    Repo.where(owner_id: nil).find_each do |repo|
+      response = fetch_repo(repo)
+
+      if response.present?
+        owner_github_id = response["owner"]["id"]
+        owner_github_name = response["owner"]["login"]
+
+        owner = Owner.upsert(
+          github_id: owner_github_id,
+          github_name: owner_github_name
+        )
+
+        puts "Updating repo: #{repo.id}"
+        repo.update(owner_id: owner.id)
+      end
+    end
+  end
+
+  def self.fetch_repo(repo)
+    begin
+      GithubApi.new.repo(repo.name)
+    rescue Octokit::NotFound
+      puts "Could not find #{repo.name}"
+      nil
+    end
+  end
+end

--- a/lib/tasks/repo.rake
+++ b/lib/tasks/repo.rake
@@ -45,4 +45,9 @@ namespace :repo do
       WHERE repos.id = del.id AND del.rn > 1
     SQL
   end
+
+  desc "Update missing owner_id's"
+  task update_owners: :environment do
+    UpdateRepoOwner.run
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
   end
 
   factory :repo do
+    owner
     trait(:active) { active true }
     trait(:inactive) { active false }
     trait(:in_private_org) do

--- a/spec/services/update_repo_owner_spec.rb
+++ b/spec/services/update_repo_owner_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+describe UpdateRepoOwner do
+  context "with a repo with an owner_id" do
+    it "does not update the repo" do
+      repo = create(:repo)
+
+      expect { UpdateRepoOwner.run }.not_to change { repo.updated_at }
+    end
+  end
+
+  context "with a repo missing owner_id" do
+    context "when the repo exists on github" do
+      context "when owner exists" do
+        it "assigns the owner to the repo" do
+          owner = create(:owner, github_id: 154463) # from fixture
+          repo = create(:repo, owner_id: nil)
+          stub_repo_request(repo.name, ENV["HOUND_GITHUB_TOKEN"])
+
+          UpdateRepoOwner.run
+
+          expect(repo.reload.owner_id).to eq(owner.id)
+        end
+      end
+
+      context "when owner does not exist" do
+        it "creates the owner and assigns it to the repo" do
+          owner_github_id = 154463 # from fixture
+          repo = create(:repo, owner_id: nil)
+          stub_repo_request(repo.name, ENV["HOUND_GITHUB_TOKEN"])
+
+          UpdateRepoOwner.run
+          new_owner = Owner.find_by(github_id: owner_github_id)
+
+          expect(repo.reload.owner_id).to eq(new_owner.id)
+        end
+      end
+    end
+
+    context "when the repo does not exist on github" do
+      it "does not update the repo" do
+        repo = create(:repo, owner_id: nil)
+        stub_not_found_repo_request(repo.name, ENV["HOUND_GITHUB_TOKEN"])
+
+        expect { UpdateRepoOwner.run }.not_to change { repo.updated_at }
+      end
+    end
+  end
+end

--- a/spec/support/helpers/github_api_helper.rb
+++ b/spec/support/helpers/github_api_helper.rb
@@ -30,6 +30,18 @@ module GithubApiHelper
     )
   end
 
+  def stub_not_found_repo_request(repo_name, token)
+    stub_request(
+      :get,
+      "https://api.github.com/repos/#{repo_name}"
+    ).with(
+      headers: { 'Authorization' => "token #{token}" }
+    ).to_return(
+      status: 404,
+      headers: { 'Content-Type' => 'application/json; charset=utf-8' }
+    )
+  end
+
   def stub_repo_with_org_request(repo_name, token = hound_token)
     stub_request(
       :get,


### PR DESCRIPTION
  * Introduces `UpdateRepoOwner` service
  * Adds `repo:update_owners` rake task, which allows the backfilling of `repos.owner_id` introduced in https://github.com/thoughtbot/hound/pull/586

https://trello.com/c/zQPwrdf6/475-backfill-repos-owner-id