### PR TITLE
Hide credit card link if Stripe customer hasn't been set up

### DIFF
--- a/app/views/accounts/show.haml
+++ b/app/views/accounts/show.haml
@@ -7,9 +7,10 @@
   %h2.label-text
     Your monthly cost
 
-    %span.section-action
-      %a{ 'ng-controller' => 'accountController', 'ng-click' => 'showStripeForm()' }
-        Update Credit Card
+    - if current_user.stripe_customer_id.present?
+      %span.section-action
+        %a{ 'ng-controller' => 'accountController', 'ng-click' => 'showStripeForm()' }
+          Update Credit Card
 
   .account-content.account-breakdown
     %table

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -1,6 +1,24 @@
 require "spec_helper"
 
 feature "Account" do
+  scenario "user without Stripe Customer ID" do
+    user = create(:user, stripe_customer_id: nil)
+
+    sign_in_as(user)
+    visit account_path
+
+    expect(page).not_to have_text("Update Credit Card")
+  end
+
+  scenario "user with Stripe Customer ID" do
+    user = create(:user, stripe_customer_id: "123")
+
+    sign_in_as(user)
+    visit account_path
+
+    expect(page).to have_text("Update Credit Card")
+  end
+
   scenario "user with multiple subscriptions views account page" do
     user = create(:user)
     individual_repo = create(:repo, users: [user])


### PR DESCRIPTION
This avoids a potential issue where a users without subscriptions, or Stripe Customer set up, updates their card info for some reason.

I think it happened once already.

https://twitter.com/IanWalter/status/561265511133351936