### PR TITLE
Check if Octokit exception contains errors

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -12,7 +12,7 @@ class Commit
   rescue Octokit::NotFound
     ""
   rescue Octokit::Forbidden => exception
-    if exception.errors.first[:code] == "too_large"
+    if exception.errors.any? && exception.errors.first[:code] == "too_large"
       ""
     else
       raise exception

--- a/spec/models/commit_spec.rb
+++ b/spec/models/commit_spec.rb
@@ -62,6 +62,17 @@ describe Commit do
         expect(commit.file_content("some/file.rb")).to eq ""
       end
     end
+
+    context "when exception contains no errors" do
+      it "raises the error" do
+        github = double("GithubApi")
+        commit = Commit.new("test/test", "abc", github)
+        error = Octokit::Forbidden.new(body: { errors: [] })
+        allow(github).to receive(:file_contents).and_raise(error)
+
+        expect { commit.file_content("some/file.rb") }.to raise_error(error)
+      end
+    end
   end
 
   def build_commit(content)


### PR DESCRIPTION
It appears that sometimes there are no errors associated with an Octokit 
exception as show by:

https://app.getsentry.com/hound-1/production/group/53642463/

This fix checks for presense of an error before fetching `:code` from it.