### PR TITLE
Track "Build Started" and "Build Completed" events

### DIFF
--- a/app/controllers/activations_controller.rb
+++ b/app/controllers/activations_controller.rb
@@ -8,7 +8,7 @@ class ActivationsController < ApplicationController
 
   def create
     if activator.activate
-      analytics.track_activated(repo)
+      analytics.track_repo_activated(repo)
 
       render json: repo, status: :created
     else

--- a/app/controllers/deactivations_controller.rb
+++ b/app/controllers/deactivations_controller.rb
@@ -8,7 +8,7 @@ class DeactivationsController < ApplicationController
 
   def create
     if activator.deactivate
-      analytics.track_deactivated(repo)
+      analytics.track_repo_deactivated(repo)
       render json: repo, status: :created
     else
       head 502

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -7,7 +7,7 @@ class SubscriptionsController < ApplicationController
 
   def create
     if activator.activate && create_subscription
-      analytics.track_subscribed(repo)
+      analytics.track_repo_activated(repo)
 
       render json: repo, status: :created
     else
@@ -19,7 +19,7 @@ class SubscriptionsController < ApplicationController
 
   def destroy
     if activator.deactivate && delete_subscription
-      analytics.track_unsubscribed(repo)
+      analytics.track_repo_deactivated(repo)
 
       render json: repo, status: :created
     else

--- a/app/models/analytics.rb
+++ b/app/models/analytics.rb
@@ -10,49 +10,44 @@ class Analytics
     track(event: "Signed In")
   end
 
-  def track_activated(repo)
+  def track_repo_activated(repo)
     track(
-      event: "Activated Public Repo",
-      properties: {
-        name: repo.full_github_name
-      }
-    )
-  end
-
-  def track_deactivated(repo)
-    track(
-      event: "Deactivated Public Repo",
-      properties: {
-        name: repo.full_github_name
-      }
-    )
-  end
-
-  def track_reviewed(repo)
-    track(
-      event: "Reviewed Repo",
-      properties: {
-        name: repo.full_github_name
-      }
-    )
-  end
-
-  def track_subscribed(repo)
-    track(
-      event: "Subscribed Private Repo",
+      event: "Repo Activated",
       properties: {
         name: repo.full_github_name,
-        revenue: repo.plan_price
+        private: repo.private,
+        revenue: repo.plan_price,
       }
     )
   end
 
-  def track_unsubscribed(repo)
+  def track_repo_deactivated(repo)
     track(
-      event: "Unsubscribed Private Repo",
+      event: "Repo Deactivated",
       properties: {
         name: repo.full_github_name,
-        revenue: -repo.plan_price
+        private: repo.private,
+        revenue: -repo.plan_price,
+      }
+    )
+  end
+
+  def track_build_started(repo)
+    track(
+      event: "Build Started",
+      properties: {
+        name: repo.full_github_name,
+        private: repo.private,
+      }
+    )
+  end
+
+  def track_build_completed(repo)
+    track(
+      event: "Build Completed",
+      properties: {
+        name: repo.full_github_name,
+        private: repo.private,
       }
     )
   end

--- a/spec/controllers/activations_controller_spec.rb
+++ b/spec/controllers/activations_controller_spec.rb
@@ -17,9 +17,15 @@ describe ActivationsController, "#create" do
       expect(activator).to have_received(:activate)
       expect(RepoActivator).to have_received(:new).
         with(repo: repo, github_token: token)
-      expect(analytics).to have_tracked("Activated Public Repo").
+      expect(analytics).to have_tracked("Repo Activated").
         for_user(membership.user).
-        with(properties: { name: repo.full_github_name })
+        with(
+          properties: {
+            name: repo.full_github_name,
+            private: false,
+            revenue: 0,
+          }
+        )
     end
   end
 

--- a/spec/controllers/deactivations_controller_spec.rb
+++ b/spec/controllers/deactivations_controller_spec.rb
@@ -17,9 +17,15 @@ describe DeactivationsController, "#create" do
       expect(activator).to have_received(:deactivate)
       expect(RepoActivator).to have_received(:new).
         with(repo: repo, github_token: token)
-      expect(analytics).to have_tracked("Deactivated Public Repo").
+      expect(analytics).to have_tracked("Repo Deactivated").
         for_user(membership.user).
-        with(properties: { name: repo.full_github_name })
+        with(
+          properties: {
+            name: repo.full_github_name,
+            private: false,
+            revenue: 0,
+          }
+        )
     end
   end
 

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -25,9 +25,6 @@ describe BuildRunner, '#run' do
       expect(build.violations.count).to be >= 1
       expect(build.pull_request_number).to eq 5
       expect(build.commit_sha).to eq payload.head_sha
-      expect(analytics).to have_tracked("Reviewed Repo").
-        for_user(repo.users.first).
-        with(properties: { name: repo.full_github_name })
     end
 
     it 'comments on violations' do
@@ -137,6 +134,31 @@ describe BuildRunner, '#run' do
       build_runner.run
 
       expect(Commenter).not_to have_received(:new)
+    end
+  end
+
+  context "with subscribed private repo and opened pull request" do
+    it "tracks build events" do
+      repo = create(:repo, :active, github_id: 123, private: true)
+      create(:subscription, repo: repo)
+      payload = stubbed_payload(
+        github_repo_id: repo.github_id,
+        full_repo_name: repo.name
+      )
+      build_runner = BuildRunner.new(payload)
+      stubbed_style_checker_with_violations
+      stubbed_commenter
+      stubbed_pull_request
+      stubbed_github_api
+
+      build_runner.run
+
+      expect(analytics).to have_tracked("Build Started").
+        for_user(repo.subscription.user).
+        with(properties: { name: repo.full_github_name, private: true })
+      expect(analytics).to have_tracked("Build Completed").
+        for_user(repo.subscription.user).
+        with(properties: { name: repo.full_github_name, private: true })
     end
   end
 


### PR DESCRIPTION
* "Reviewed Repo" is not reporting correctly to Segment/Mixpanel.
* We already have build totals in the North Star Metric.
* Since "Reviewed Repo" is not useful to us, right now,
 we can try a more constrained event tracking approach.
* Track only private (subscribed) repos.
* Track both a "Build Started" and a "Build Completed" event
 to see if there is some code in between that is preventing
 the "Reviewed Repo" (now called "Build Completed") event
 from triggering.