### PR TITLE
Track "Clicked Sign In" event

### DIFF
--- a/app/views/application/_segment_io.haml
+++ b/app/views/application/_segment_io.haml
@@ -17,3 +17,5 @@
         campaign: #{session[:campaign_params].to_json}
       }
     });
+
+= yield :analytics

--- a/app/views/shared/_auth_button.haml
+++ b/app/views/shared/_auth_button.haml
@@ -1,3 +1,8 @@
 = link_to "/auth/github", class: "auth button" do
   %i.fa.fa-github
   %span= t("authenticate")
+
+- content_for :analytics do
+  :javascript
+    var link = document.getElementsByClassName("auth")[0];
+    window.analytics.trackLink(link, "Clicked Sign In");


### PR DESCRIPTION
Find out how many people click, but then drop out of the funnel because they
think the GitHub permissions are too aggressive.