### PR TITLE
Upgrade rails_serve_static_assets for Rails 4.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
     rails_12factor (0.0.2)
       rails_serve_static_assets
       rails_stdout_logging
-    rails_serve_static_assets (0.0.2)
+    rails_serve_static_assets (0.0.4)
     rails_stdout_logging (0.0.3)
     railties (4.2.0)
       actionpack (= 4.2.0)


### PR DESCRIPTION
Fixes:

> DEPRECATION WARNING: The configuration option
> `config.serve_static_assets` has been renamed to
> `config.serve_static_files` to clarify its role
> (it merely enables serving everything in the `public` folder
> and is unrelated to the asset pipeline).
> The `serve_static_assets` alias will be removed in Rails 5.0.
> Please migrate your configuration files accordingly.