### PR TITLE
Enable all languages by default

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,5 +1,0 @@
-ruby:
-  enabled: true
-
-coffee_script:
-  enabled: true

--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -11,11 +11,6 @@ class RepoConfig
 
   pattr_initialize :commit
 
-  def enabled_for?(style_guide_name)
-    style_guide_name == "ruby" && legacy_config? ||
-      enabled_in_config?(style_guide_name)
-  end
-
   def for(style_guide_name)
     if style_guide_name == "ruby" && legacy_config?
       hound_config
@@ -41,11 +36,6 @@ class RepoConfig
   end
 
   private
-
-  def enabled_in_config?(name)
-    config = hound_config[name] || hound_config[name.camelize]
-    config && (config["enabled"] == true || config["Enabled"] == true)
-  end
 
   def legacy_config?
     (hound_config.keys & STYLE_GUIDES).empty?

--- a/app/models/style_checker.rb
+++ b/app/models/style_checker.rb
@@ -24,7 +24,7 @@ class StyleChecker
   def files_to_check
     pull_request.pull_request_files.reject(&:removed?).select do |file|
       file_style_guide = style_guide(file.filename)
-      file_style_guide.enabled? && file_style_guide.file_included?(file)
+      file_style_guide.file_included?(file)
     end
   end
 

--- a/app/models/style_guide/base.rb
+++ b/app/models/style_guide/base.rb
@@ -3,10 +3,6 @@ module StyleGuide
   class Base
     pattr_initialize :repo_config, :repository_owner
 
-    def enabled?
-      repo_config.enabled_for?(name)
-    end
-
     def violations_in_file(_file)
       raise NotImplementedError.new("must implement ##{__method__}")
     end

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -17,16 +17,6 @@
   %h3 Ruby
 
   %p
-    To enable Ruby style checking, add the following to
-    %em.code .hound.yml
-    in the root of your project
-
-    %code.code-block
-      :preserve
-        ruby:
-          enabled: true
-
-  %p
     Hound uses #{link_to "RuboCop", "https://github.com/bbatsov/rubocop"}
     internally so you can configure Hound by adding a
     #{link_to "RuboCop config", "https://github.com/bbatsov/rubocop/blob/master/config/enabled.yml"}
@@ -37,20 +27,9 @@
     %code.code-block
       :preserve
         ruby:
-          enabled: true
           config_file: config/.rubocop.yml
 
   %h3 CoffeeScript
-
-  %p
-    To enable CoffeeScript style checking, add the following to
-    %em.code .hound.yml
-    in the root of your project
-
-    %code.code-block
-      :preserve
-        coffee_script:
-          enabled: true
 
   %p
     Hound uses #{link_to "CoffeeLint", "http://www.coffeelint.org/"}
@@ -63,20 +42,9 @@
     %code.code-block
       :preserve
         coffee_script:
-          enabled: true
           config_file: config/.coffeelint.json
 
   %h3 JavaScript
-
-  %p
-    To enable JavaScript style checking, add the following to
-    %em.code .hound.yml
-    in the root of your project
-
-    %code.code-block
-      :preserve
-        java_script:
-          enabled: true
 
   %p
     Hound uses #{link_to "JSHint", "https://github.com/jshint/jshint/"}
@@ -89,7 +57,6 @@
     %code.code-block
       :preserve
         java_script:
-          enabled: true
           config_file: config/.jshint.json
 
   %p
@@ -104,7 +71,6 @@
     %code.code-block
       :preserve
         java_script:
-          enabled: true
           ignore_file: config/.javascript_ignore
 
   %p
@@ -119,16 +85,6 @@
   %h3 SCSS
 
   %p
-    To enable SCSS style checking, add the following to
-    %em.code .hound.yml
-    in the root of your project
-
-    %code.code-block
-      :preserve
-        scss:
-          enabled: true
-
-  %p
     Hound uses #{link_to "SCSS-Lint", "https://github.com/causes/scss-lint"}
     internally so you can configure Hound by adding a
     #{link_to "SCSS config", "https://github.com/causes/scss-lint/blob/master/config/default.yml"}
@@ -139,6 +95,5 @@
     %code.code-block
       :preserve
         scss:
-          enabled: true
           config_file: config/scss.yml
 

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -66,129 +66,51 @@ describe StyleChecker, "#violations" do
     end
 
     context "with violations" do
-      context "with CoffeeScript enabled" do
-        it "returns violations" do
-          config = <<-YAML.strip_heredoc
-            coffee_script:
-              enabled: true
-          YAML
-          head_commit = double("Commit", file_content: config)
-          file = stub_commit_file("test.coffee", "foo: ->")
-          pull_request = stub_pull_request(
-            head_commit: head_commit,
-            pull_request_files: [file],
-          )
+      it "returns violations" do
+        file = stub_commit_file("test.coffee", "foo: ->")
+        pull_request = stub_pull_request(pull_request_files: [file])
 
-          violations = StyleChecker.new(pull_request).violations
-          messages = violations.flat_map(&:messages)
+        violations = StyleChecker.new(pull_request).violations
+        messages = violations.flat_map(&:messages)
 
-          expect(messages).to eq ["Empty function"]
-        end
-      end
-
-      context "with CoffeeScript disabled" do
-        it "returns no violations" do
-          config = <<-YAML.strip_heredoc
-            coffee_script:
-              enabled: false
-          YAML
-          head_commit = double("Commit", file_content: config)
-          file = stub_commit_file("test.coffee", "alert 'Hello World'")
-          pull_request = stub_pull_request(
-            head_commit: head_commit,
-            pull_request_files: [file],
-          )
-
-          violations = StyleChecker.new(pull_request).violations
-
-          expect(violations).to be_empty
-        end
+        expect(messages).to eq ["Empty function"]
       end
     end
 
     context "without violations" do
-      context "with CoffeeScript enabled" do
-        it "returns no violations" do
-          config = <<-YAML.strip_heredoc
-            coffee_script:
-              enabled: true
-          YAML
-          head_commit = double("Commit", file_content: config)
-          file = stub_commit_file("test.coffee", "alert('Hello World')")
-          pull_request = stub_pull_request(
-            head_commit: head_commit,
-            pull_request_files: [file],
-          )
+      it "returns no violations" do
+        file = stub_commit_file("test.coffee", "alert('Hello World')")
+        pull_request = stub_pull_request(pull_request_files: [file])
 
-          violations = StyleChecker.new(pull_request).violations
+        violations = StyleChecker.new(pull_request).violations
 
-          expect(violations).to be_empty
-        end
+        expect(violations).to be_empty
       end
     end
   end
 
   context "for a JavaScript file" do
     context "with violations" do
-      context "with JavaScript enabled" do
-        it "returns violations" do
-          config = <<-YAML.strip_heredoc
-            java_script:
-              enabled: true
-          YAML
-          head_commit = double("Commit", file_content: config)
-          file = stub_commit_file("test.js", "var test = 'test'")
-          pull_request = stub_pull_request(
-            head_commit: head_commit,
-            pull_request_files: [file],
-          )
+      it "returns violations" do
+        file = stub_commit_file("test.js", "var test = 'test'")
+        pull_request = stub_pull_request(pull_request_files: [file])
 
-          violations = StyleChecker.new(pull_request).violations
-          messages = violations.flat_map(&:messages)
+        violations = StyleChecker.new(pull_request).violations
+        messages = violations.flat_map(&:messages)
 
-          expect(messages).to include "Missing semicolon."
-        end
-      end
-
-      context "with JavaScript disabled" do
-        it "returns no violations" do
-          config = <<-YAML.strip_heredoc
-            java_script:
-              enabled: false
-          YAML
-          head_commit = double("Commit", file_content: config)
-          file = stub_commit_file("test.js", "var test = 'test'")
-          pull_request = stub_pull_request(
-            head_commit: head_commit,
-            pull_request_files: [file],
-          )
-
-          violations = StyleChecker.new(pull_request).violations
-
-          expect(violations).to be_empty
-        end
+        expect(messages).to include "Missing semicolon."
       end
     end
 
     context "without violations" do
-      context "with JavaScript enabled" do
-        it "returns no violations" do
-          config = <<-YAML.strip_heredoc
-            java_script:
-              enabled: true
-          YAML
-          head_commit = double("Commit", file_content: config)
-          file = stub_commit_file("test.js", "var test = 'test';")
-          pull_request = stub_pull_request(
-            head_commit: head_commit,
-            pull_request_files: [file],
-          )
+      it "returns no violations" do
+        file = stub_commit_file("test.js", "var test = 'test';")
+        pull_request = stub_pull_request(pull_request_files: [file])
 
-          violations = StyleChecker.new(pull_request).violations
-          messages = violations.flat_map(&:messages)
+        violations = StyleChecker.new(pull_request).violations
+        messages = violations.flat_map(&:messages)
 
-          expect(messages).not_to include "Missing semicolon."
-        end
+        expect(messages).not_to include "Missing semicolon."
       end
     end
 
@@ -196,7 +118,6 @@ describe StyleChecker, "#violations" do
       it "returns no violations" do
         config = <<-YAML.strip_heredoc
           java_script:
-            enabled: true
             ignore_file: '.jshintignore'
         YAML
 
@@ -220,63 +141,33 @@ describe StyleChecker, "#violations" do
 
   context "for a SCSS file" do
     context "with violations" do
-      context "with SCSS enabled" do
-        it "returns violations" do
-          head_commit = stub_head_commit(".hound.yml" => scss_enabled_config)
-          file = stub_commit_file(
-            "test.scss",
-            ".table p.inner table td { background: red; }"
-          )
-          pull_request = stub_pull_request(
-            head_commit: head_commit,
-            pull_request_files: [file],
-          )
+      it "returns violations" do
+        file = stub_commit_file(
+          "test.scss",
+          ".table p.inner table td { background: red; }"
+        )
+        pull_request = stub_pull_request(pull_request_files: [file])
 
-          violations = StyleChecker.new(pull_request).violations
-          messages = violations.flat_map(&:messages)
+        violations = StyleChecker.new(pull_request).violations
+        messages = violations.flat_map(&:messages)
 
-          expect(messages).to include(
-            "Selector should have depth of applicability no greater than 2, but was 4"
-          )
-        end
-      end
-
-      context "with SCSS disabled" do
-        it "returns no violations" do
-          head_commit = stub_head_commit(".hound.yml" => scss_disabled_config)
-          file = stub_commit_file(
-            "test.scss",
-            ".table p.inner table td { background: red; }"
-          )
-          pull_request = stub_pull_request(
-            head_commit: head_commit,
-            pull_request_files: [file],
-          )
-
-          violations = StyleChecker.new(pull_request).violations
-
-          expect(violations).to be_empty
-        end
+        expect(messages).to include(
+          "Selector should have depth of applicability no greater than 2, but was 4"
+        )
       end
     end
 
     context "without violations" do
-      context "with SCSS enabled" do
-        it "returns no violations" do
-          head_commit = stub_head_commit(".hound.yml" => scss_enabled_config)
-          file = stub_commit_file("test.scss", "table td { color: green; }")
-          pull_request = stub_pull_request(
-            head_commit: head_commit,
-            pull_request_files: [file],
-          )
+      it "returns no violations" do
+        file = stub_commit_file("test.scss", "table td { color: green; }")
+        pull_request = stub_pull_request(pull_request_files: [file])
 
-          violations = StyleChecker.new(pull_request).violations
-          messages = violations.flat_map(&:messages)
+        violations = StyleChecker.new(pull_request).violations
+        messages = violations.flat_map(&:messages)
 
-          expect(messages).not_to include(
-            "Selector should have depth of applicability no greater than 3"
-          )
-        end
+        expect(messages).not_to include(
+          "Selector should have depth of applicability no greater than 3"
+        )
       end
     end
   end
@@ -345,22 +236,7 @@ describe StyleChecker, "#violations" do
     double(
       "RepoConfig",
       for: {},
-      enabled_for?: true,
       ignored_javascript_files: []
     )
-  end
-
-  def scss_enabled_config
-    <<-YAML.strip_heredoc
-      scss:
-        enabled: true
-    YAML
-  end
-
-  def scss_disabled_config
-    <<-YAML.strip_heredoc
-      scss:
-        enabled: false
-    YAML
   end
 end

--- a/spec/models/style_guide/coffee_script_spec.rb
+++ b/spec/models/style_guide/coffee_script_spec.rb
@@ -7,7 +7,7 @@ describe StyleGuide::CoffeeScript do
     context "with default configuration" do
       context "for long line" do
         it "returns violation" do
-          repo_config = double("RepoConfig", enabled_for?: true, for: {})
+          repo_config = double("RepoConfig", for: {})
           style_guide = StyleGuide::CoffeeScript.new(repo_config, "Ralph")
           line = double("Line", content: "blah", number: 1, patch_position: 2)
           file = double(
@@ -105,7 +105,7 @@ describe StyleGuide::CoffeeScript do
     private
 
     def violations_in(content, repository_owner: "ralph")
-      repo_config = double("RepoConfig", enabled_for?: true, for: {})
+      repo_config = double("RepoConfig", for: {})
       style_guide = StyleGuide::CoffeeScript.new(repo_config, repository_owner)
       style_guide.violations_in_file(build_file(content)).flat_map(&:messages)
     end

--- a/spec/models/style_guide/ruby_spec.rb
+++ b/spec/models/style_guide/ruby_spec.rb
@@ -392,6 +392,7 @@ end
       it "has one violation" do
         config = {
           "StringLiterals" => {
+            "Enabled" => true,
             "EnforcedStyle" => "single_quotes"
           },
           "HashSyntax" => {
@@ -424,6 +425,7 @@ end
       it 'allows a cop to be excluded for specific files or directories' do
         config = {
           "StringLiterals" => {
+            "Enabled" => true,
             "EnforcedStyle" => "single_quotes"
           },
           "HashSyntax" => {
@@ -520,7 +522,7 @@ end
   private
 
   def violations_in(content, config: nil, repository_owner: "ralph")
-    repo_config = double("RepoConfig", enabled_for?: true, for: config)
+    repo_config = double("RepoConfig", for: config)
     style_guide = StyleGuide::Ruby.new(repo_config, repository_owner)
     style_guide.violations_in_file(build_file(content)).flat_map(&:messages)
   end

--- a/spec/models/style_guide/scss_spec.rb
+++ b/spec/models/style_guide/scss_spec.rb
@@ -89,7 +89,7 @@ describe StyleGuide::Scss do
   end
 
   def build_style_guide(config = nil)
-    repo_config = double("RepoConfig", enabled_for?: true, for: config)
+    repo_config = double("RepoConfig", for: config)
     repository_owner = "ralph"
     StyleGuide::Scss.new(repo_config, repository_owner)
   end


### PR DESCRIPTION
This enables all languages by default. Some users have used Hound for months without realizing they need to enable newly added languages. If the defaults are an issue we can make them less opinionated.