### PR TITLE
Disable quote checking by default

### DIFF
--- a/config/style_guides/javascript.json
+++ b/config/style_guides/javascript.json
@@ -26,7 +26,7 @@
     "inject",
     "module"
   ],
-  "quotmark": true,
+  "quotmark": false,
   "trailing": true,
   "undef": true,
   "unused": true

--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -188,7 +188,7 @@ SpecialGlobalVars:
   Enabled: false
 
 StringLiterals:
-  EnforcedStyle: double_quotes
+  Enabled: false
 
 VariableInterpolation:
   Enabled: false

--- a/spec/models/style_guide/ruby_spec.rb
+++ b/spec/models/style_guide/ruby_spec.rb
@@ -392,6 +392,7 @@ end
       it "has one violation" do
         config = {
           "StringLiterals" => {
+            "Enabled" => "true",
             "EnforcedStyle" => "single_quotes"
           },
           "HashSyntax" => {
@@ -424,6 +425,7 @@ end
       it 'allows a cop to be excluded for specific files or directories' do
         config = {
           "StringLiterals" => {
+            "Enabled" => "true",
             "EnforcedStyle" => "single_quotes"
           },
           "HashSyntax" => {


### PR DESCRIPTION
Commenting on double or single quotes has surprised some users. I think it's best to disable the check by default and let each team choose which type of quotes they would like Hound to enforce.