### PR TITLE
Use the user's Github token when inviting to org.

### DIFF
--- a/app/jobs/org_invitation_job.rb
+++ b/app/jobs/org_invitation_job.rb
@@ -3,8 +3,8 @@ class OrgInvitationJob
 
   @queue = :high
 
-  def self.perform
-    github = GithubApi.new
+  def self.perform(github_token)
+    github = GithubApi.new(github_token)
     github.accept_pending_invitations
   rescue Resque::TermException
     Resque.enqueue(self)

--- a/app/services/repo_activator.rb
+++ b/app/services/repo_activator.rb
@@ -47,7 +47,7 @@ class RepoActivator
 
   def enqueue_org_invitation
     if repo.in_organization?
-      JobQueue.push(OrgInvitationJob)
+      JobQueue.push(OrgInvitationJob, github_token)
     end
   end
 

--- a/spec/jobs/org_invitation_job_spec.rb
+++ b/spec/jobs/org_invitation_job_spec.rb
@@ -6,19 +6,21 @@ describe OrgInvitationJob do
   end
 
   it "accepts invitations" do
+    github_token = "something"
     github = double("GithubApi", accept_pending_invitations: nil)
     allow(GithubApi).to receive(:new).and_return(github)
 
-    OrgInvitationJob.perform
+    OrgInvitationJob.perform(github_token)
 
     expect(github).to have_received(:accept_pending_invitations)
   end
 
   it "retries when Resque::TermException is raised" do
+    github_token = "something"
     allow(GithubApi).to receive(:new).and_raise(Resque::TermException.new(1))
     allow(Resque).to receive(:enqueue)
 
-    OrgInvitationJob.perform
+    OrgInvitationJob.perform(github_token)
 
     expect(Resque).to have_received(:enqueue).
       with(OrgInvitationJob)

--- a/spec/services/repo_activator_spec.rb
+++ b/spec/services/repo_activator_spec.rb
@@ -4,14 +4,15 @@ describe RepoActivator do
   describe "#activate" do
     context "with org repo" do
       it "will enqueue org invitation job" do
-        allow(JobQueue).to receive(:push).with(OrgInvitationJob)
+        allow(JobQueue).to receive(:push).with(OrgInvitationJob, "githubtoken")
         repo = create(:repo, in_organization: true)
         stub_github_api
         activator = build_activator(repo: repo)
 
         activator.activate
 
-        expect(JobQueue).to have_received(:push).with(OrgInvitationJob)
+        expect(JobQueue).to have_received(:push).
+          with(OrgInvitationJob, "githubtoken")
       end
 
       it "marks repo as active" do
@@ -28,7 +29,8 @@ describe RepoActivator do
 
     context "without org repo" do
       it "will not enqueue org invitation job" do
-        allow(JobQueue).to receive(:push).with(OrgInvitationJob)
+        allow(JobQueue).to receive(:push).
+          with(OrgInvitationJob, "githubtoken")
         repo = create(:repo)
         stub_github_api
         activator = build_activator(repo: repo)
@@ -36,7 +38,8 @@ describe RepoActivator do
         activator.activate
 
         expect(repo.in_organization).to be_falsy
-        expect(JobQueue).not_to have_received(:push).with(OrgInvitationJob)
+        expect(JobQueue).not_to have_received(:push).
+          with(OrgInvitationJob, "githubtoken")
       end
 
       it "marks repo as active" do


### PR DESCRIPTION
To avoid hitting Github's API rate limit, let's use the user's api token as
much as we can. And only use Hound's when we're commenting on violations