### PR TITLE
Refactor invitation to organization

### DIFF
--- a/app/jobs/accept_org_invitations_job.rb
+++ b/app/jobs/accept_org_invitations_job.rb
@@ -1,10 +1,10 @@
-class OrgInvitationJob
+class AcceptOrgInvitationsJob
   extend Retryable
 
   @queue = :high
 
   def self.perform
-    github = GithubApi.new
+    github = GithubApi.new(ENV["HOUND_GITHUB_TOKEN"])
     github.accept_pending_invitations
   rescue Resque::TermException
     Resque.enqueue(self)

--- a/app/jobs/repo_information_job.rb
+++ b/app/jobs/repo_information_job.rb
@@ -7,7 +7,7 @@ class RepoInformationJob
     repo = Repo.find(repo_id)
     repo.touch
 
-    github = GithubApi.new
+    github = GithubApi.new(ENV["HOUND_GITHUB_TOKEN"])
     github_data = github.repo(repo.full_github_name)
 
     repo.update_attributes!(

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -44,7 +44,7 @@ class PullRequest
   end
 
   def api
-    @api ||= GithubApi.new
+    @api ||= GithubApi.new(ENV["HOUND_GITHUB_TOKEN"])
   end
 
   def number

--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -80,6 +80,6 @@ class BuildRunner
   end
 
   def github
-    @github ||= GithubApi.new
+    @github ||= GithubApi.new(ENV["HOUND_GITHUB_TOKEN"])
   end
 end

--- a/app/services/repo_activator.rb
+++ b/app/services/repo_activator.rb
@@ -47,7 +47,7 @@ class RepoActivator
 
   def enqueue_org_invitation
     if repo.in_organization?
-      JobQueue.push(OrgInvitationJob)
+      JobQueue.push(AcceptOrgInvitationsJob)
     end
   end
 

--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -1,3 +1,4 @@
+require "attr_extras"
 require "octokit"
 require "base64"
 require "active_support/core_ext/object/with_options"
@@ -6,12 +7,10 @@ class GithubApi
   SERVICES_TEAM_NAME = "Services"
   PREVIEW_MEDIA_TYPE = "application/vnd.github.moondragon-preview+json"
 
-  def initialize(token = ENV["HOUND_GITHUB_TOKEN"])
-    @token = token
-  end
+  pattr_initialize :token
 
   def client
-    @client ||= Octokit::Client.new(access_token: @token, auto_paginate: true)
+    @client ||= Octokit::Client.new(access_token: token, auto_paginate: true)
   end
 
   def repos

--- a/spec/jobs/accept_org_invitations_job_spec.rb
+++ b/spec/jobs/accept_org_invitations_job_spec.rb
@@ -1,15 +1,15 @@
 require "spec_helper"
 
-describe OrgInvitationJob do
+describe AcceptOrgInvitationsJob do
   it "is retryable" do
-    expect(OrgInvitationJob).to be_a(Retryable)
+    expect(AcceptOrgInvitationsJob).to be_a(Retryable)
   end
 
   it "accepts invitations" do
     github = double("GithubApi", accept_pending_invitations: nil)
     allow(GithubApi).to receive(:new).and_return(github)
 
-    OrgInvitationJob.perform
+    AcceptOrgInvitationsJob.perform
 
     expect(github).to have_received(:accept_pending_invitations)
   end
@@ -18,9 +18,9 @@ describe OrgInvitationJob do
     allow(GithubApi).to receive(:new).and_raise(Resque::TermException.new(1))
     allow(Resque).to receive(:enqueue)
 
-    OrgInvitationJob.perform
+    AcceptOrgInvitationsJob.perform
 
     expect(Resque).to have_received(:enqueue).
-      with(OrgInvitationJob)
+      with(AcceptOrgInvitationsJob)
   end
 end

--- a/spec/lib/github_api_spec.rb
+++ b/spec/lib/github_api_spec.rb
@@ -61,7 +61,8 @@ describe GithubApi do
         full_repo_name = "jimtom/repo"
         callback_endpoint = "http://example.com"
         stub_failed_hook_creation_request(full_repo_name, callback_endpoint)
-        api = GithubApi.new
+        hound_token = ENV["HOUND_GITHUB_TOKEN"]
+        api = GithubApi.new(hound_token)
 
         expect do
           api.create_hook(full_repo_name, callback_endpoint)
@@ -72,7 +73,8 @@ describe GithubApi do
         full_repo_name = "jimtom/repo"
         callback_endpoint = "http://example.com"
         stub_failed_hook_creation_request(full_repo_name, callback_endpoint)
-        api = GithubApi.new
+        hound_token = ENV["HOUND_GITHUB_TOKEN"]
+        api = GithubApi.new(hound_token)
 
         expect(api.create_hook(full_repo_name, callback_endpoint)).to eq true
       end
@@ -84,7 +86,8 @@ describe GithubApi do
       repo_name = "test-user/repo"
       hook_id = "123"
       stub_hook_removal_request(repo_name, hook_id)
-      api = GithubApi.new
+      hound_token = ENV["HOUND_GITHUB_TOKEN"]
+      api = GithubApi.new(hound_token)
 
       response = api.remove_hook(repo_name, hook_id)
 
@@ -95,7 +98,8 @@ describe GithubApi do
       repo_name = "test-user/repo"
       hook_id = "123"
       stub_hook_removal_request(repo_name, hook_id)
-      api = GithubApi.new
+      hound_token = ENV["HOUND_GITHUB_TOKEN"]
+      api = GithubApi.new(hound_token)
       yielded = false
 
       api.remove_hook(repo_name, hook_id) do
@@ -108,7 +112,8 @@ describe GithubApi do
 
   describe "#pull_request_files" do
     it "returns changed files in a pull request" do
-      api = GithubApi.new
+      hound_token = ENV["HOUND_GITHUB_TOKEN"]
+      api = GithubApi.new(hound_token)
       pull_request = double(:pull_request, full_repo_name: "thoughtbot/hound")
       pr_number = 123
       commit_sha = "abc123"
@@ -157,7 +162,8 @@ describe GithubApi do
 
     describe "#pull_request_comments" do
       it "returns comments added to pull request" do
-        api = GithubApi.new
+        hound_token = ENV["HOUND_GITHUB_TOKEN"]
+        api = GithubApi.new(hound_token)
         pull_request = double(:pull_request, full_repo_name: "thoughtbot/hound")
         pull_request_id = 253
         commit_sha = "abc253"
@@ -183,7 +189,8 @@ describe GithubApi do
 
     describe "#accept_pending_invitations" do
       it "finds and accepts pending org invitations" do
-        api = GithubApi.new
+        hound_token = ENV["HOUND_GITHUB_TOKEN"]
+        api = GithubApi.new(hound_token)
         memberships_request = stub_memberships_request
         membership_update_request = stub_membership_update_request
 
@@ -198,7 +205,8 @@ describe GithubApi do
       teams = ["thoughtbot"]
       client = double(user_teams: teams)
       allow(Octokit::Client).to receive(:new).and_return(client)
-      api = GithubApi.new
+      hound_token = ENV["HOUND_GITHUB_TOKEN"]
+      api = GithubApi.new(hound_token)
 
       user_teams = api.user_teams
 
@@ -208,7 +216,8 @@ describe GithubApi do
 
   describe "#create_pending_status" do
     it "makes request to GitHub for creating a pending status" do
-      api = GithubApi.new
+      hound_token = ENV["HOUND_GITHUB_TOKEN"]
+      api = GithubApi.new(hound_token)
       request = stub_status_request(
         "test/repo",
         "sha",
@@ -224,7 +233,8 @@ describe GithubApi do
     describe "when setting the status returns 404" do
       it "does not crash" do
         sha = "abc"
-        api = GithubApi.new
+        hound_token = ENV["HOUND_GITHUB_TOKEN"]
+        api = GithubApi.new(hound_token)
         repo_name = "test/repo"
         stub_failed_status_creation_request(
           repo_name,
@@ -242,7 +252,8 @@ describe GithubApi do
 
   describe "#create_success_status" do
     it "makes request to GitHub for creating a success status" do
-      api = GithubApi.new
+      hound_token = ENV["HOUND_GITHUB_TOKEN"]
+      api = GithubApi.new(hound_token)
       request = stub_status_request(
         "test/repo",
         "sha",
@@ -320,7 +331,8 @@ describe GithubApi do
   describe "#update_team" do
     it "makes a request" do
       team_id = 123
-      api = GithubApi.new
+      hound_token = ENV["HOUND_GITHUB_TOKEN"]
+      api = GithubApi.new(hound_token)
       request = stub_update_team_permission_request(team_id)
 
       api.update_team(team_id, permissions: "push")

--- a/spec/models/github_user_spec.rb
+++ b/spec/models/github_user_spec.rb
@@ -5,7 +5,8 @@ describe GithubUser, '#has_admin_access_through_team?' do
     context 'when user belongs team' do
       it 'returns true' do
         team_id = 4567 # from fixture
-        api = GithubApi.new
+        token = "something"
+        api = GithubApi.new(token)
         user = GithubUser.new(api)
         teams = [double(permission: 'admin', id: team_id)]
         allow(api).to receive(:user_teams).and_return(teams)
@@ -16,7 +17,8 @@ describe GithubUser, '#has_admin_access_through_team?' do
 
     context 'when user does not belong to team' do
       it 'returns false' do
-        api = GithubApi.new
+        token = "something"
+        api = GithubApi.new(token)
         user = GithubUser.new(api)
         team_id = 1111
         teams = [double(permission: 'admin', id: 4567)]
@@ -30,7 +32,8 @@ describe GithubUser, '#has_admin_access_through_team?' do
   context 'when team is not admin team' do
     context 'when user belongs to team' do
       it 'returns false' do
-        api = GithubApi.new
+        token = "something"
+        api = GithubApi.new(token)
         user = GithubUser.new(api)
         team_id = 4567
         teams = [double(permission: "push", id: 4567)]

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -42,6 +42,8 @@ describe BuildRunner, '#run' do
     end
 
     it "comments a maximum number of times" do
+      allow(ENV).to receive(:[]).with("HOUND_GITHUB_TOKEN").
+        and_return("something")
       allow(ENV).to receive(:[]).with("MAX_COMMENTS").and_return("1")
       build_runner = make_build_runner
       stubbed_commenter

--- a/spec/services/repo_activator_spec.rb
+++ b/spec/services/repo_activator_spec.rb
@@ -4,14 +4,14 @@ describe RepoActivator do
   describe "#activate" do
     context "with org repo" do
       it "will enqueue org invitation job" do
-        allow(JobQueue).to receive(:push).with(OrgInvitationJob)
+        allow(JobQueue).to receive(:push).with(AcceptOrgInvitationsJob)
         repo = create(:repo, in_organization: true)
         stub_github_api
         activator = build_activator(repo: repo)
 
         activator.activate
 
-        expect(JobQueue).to have_received(:push).with(OrgInvitationJob)
+        expect(JobQueue).to have_received(:push).with(AcceptOrgInvitationsJob)
       end
 
       it "marks repo as active" do
@@ -28,7 +28,7 @@ describe RepoActivator do
 
     context "without org repo" do
       it "will not enqueue org invitation job" do
-        allow(JobQueue).to receive(:push).with(OrgInvitationJob)
+        allow(JobQueue).to receive(:push).with(AcceptOrgInvitationsJob)
         repo = create(:repo)
         stub_github_api
         activator = build_activator(repo: repo)
@@ -36,7 +36,8 @@ describe RepoActivator do
         activator.activate
 
         expect(repo.in_organization).to be_falsy
-        expect(JobQueue).not_to have_received(:push).with(OrgInvitationJob)
+        expect(JobQueue).not_to have_received(:push).
+          with(AcceptOrgInvitationsJob)
       end
 
       it "marks repo as active" do


### PR DESCRIPTION
- Rename `OrgInvitationJob` to `AcceptOrgInvitationsJob`
  - Be explicit that it accepts the org invitations, not sending them
- Explicitly provide github token to `GithubApi`