### PR TITLE
Cache file content requested from GitHub

### DIFF
--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -8,7 +8,12 @@ class GithubApi
   PREVIEW_MEDIA_TYPE = "application/vnd.github.moondragon-preview+json"
   SERVICES_TEAM_NAME = "Services"
 
-  pattr_initialize :token
+  attr_reader :file_cache, :token
+
+  def initialize(token = ENV["HOUND_GITHUB_TOKEN"])
+    @token = token
+    @file_cache = {}
+  end
 
   def client
     @client ||= Octokit::Client.new(access_token: token, auto_paginate: true)
@@ -76,7 +81,8 @@ class GithubApi
   end
 
   def file_contents(full_repo_name, filename, sha)
-    client.contents(full_repo_name, path: filename, ref: sha)
+    file_cache["#{full_repo_name}/#{sha}/#{filename}"] ||=
+      client.contents(full_repo_name, path: filename, ref: sha)
   end
 
   def accept_pending_invitations

--- a/spec/lib/github_api_spec.rb
+++ b/spec/lib/github_api_spec.rb
@@ -17,6 +17,35 @@ describe GithubApi do
     end
   end
 
+  describe "#file_contents" do
+    context "used multiple times with same arguments" do
+      it "requests file content once" do
+        client = double("Octokit::Client", contents: "filecontent")
+        allow(Octokit::Client).to receive(:new).and_return(client)
+        token = "authtoken"
+        github = GithubApi.new(token)
+        repo = "jimtom/wow"
+        filename = ".hound.yml"
+        sha = "abc123"
+
+        contents = github.file_contents(repo, filename, sha)
+        same_contents = github.file_contents(repo, filename, sha)
+
+        expect(contents).to eq "filecontent"
+        expect(same_contents).to eq contents
+        expect(Octokit::Client).to have_received(:new).with(
+          access_token: token,
+          auto_paginate: true
+        )
+        expect(client).to have_received(:contents).with(
+          repo,
+          path: filename,
+          ref: sha
+        ).once
+      end
+    end
+  end
+
   describe "#create_hook" do
     context "when hook does not exist" do
       it "creates pull request web hook" do


### PR DESCRIPTION
This should help us avoid hitting our rate limit by not making multiple requests to GitHub for the same file content.