### PR TITLE
Display detailed error message if activation fails

### DIFF
--- a/app/assets/javascripts/directives/repo.js.coffee.erb
+++ b/app/assets/javascripts/directives/repo.js.coffee.erb
@@ -6,8 +6,14 @@ App.directive 'repo', ['Subscription', 'StripeCheckout', 'User', (Subscription, 
       scope.processing = true
 
       scope.repo.$activate()
-        .catch(-> alert('Your repo failed to activate.'))
+        .catch((response) -> alert(errorMessage(response.data)))
         .finally(-> scope.processing = false)
+
+    errorMessage = (responseData) ->
+      if responseData.errors.length > 0
+        responseData.errors.join("\n")
+      else
+        "Your repo failed to activate"
 
     deactivateRepo = ->
       scope.processing = true

--- a/app/controllers/activations_controller.rb
+++ b/app/controllers/activations_controller.rb
@@ -9,10 +9,9 @@ class ActivationsController < ApplicationController
   def create
     if activator.activate
       analytics.track_repo_activated(repo)
-
       render json: repo, status: :created
     else
-      head 502
+      render json: { errors: activator.errors }, status: 502
     end
   end
 
@@ -25,7 +24,7 @@ class ActivationsController < ApplicationController
   end
 
   def activator
-    RepoActivator.new(repo: repo, github_token: github_token)
+    @activator ||= RepoActivator.new(repo: repo, github_token: github_token)
   end
 
   def repo

--- a/app/services/repo_activator.rb
+++ b/app/services/repo_activator.rb
@@ -1,7 +1,10 @@
 class RepoActivator
+  attr_reader :errors
+
   def initialize(github_token:, repo:)
     @github_token = github_token
     @repo = repo
+    @errors = []
   end
 
   def activate
@@ -27,6 +30,7 @@ class RepoActivator
   def change_repository_state_quietly
     yield
   rescue Octokit::Error => error
+    add_error(error)
     Raven.capture_exception(error)
     false
   end
@@ -67,5 +71,10 @@ class RepoActivator
     else
       "http"
     end
+  end
+
+  def add_error(error)
+    error_message = ErrorMessageTranslation.from_error_response(error)
+    errors.push(error_message).compact!
   end
 end

--- a/lib/error_message_translation.rb
+++ b/lib/error_message_translation.rb
@@ -1,0 +1,12 @@
+module ErrorMessageTranslation
+  ERROR_CODE_AND_MESSAGE = /.*(\d{3})\s\-\s(.*)\s\/\/.*/
+  FORBIDDEN_ERROR_CODE = "403"
+
+  def self.from_error_response(error)
+    matches = error.message.match(ERROR_CODE_AND_MESSAGE)
+
+    if matches.present? && matches.captures[0] == FORBIDDEN_ERROR_CODE
+      matches.captures[1]
+    end
+  end
+end

--- a/spec/lib/error_message_translation_spec.rb
+++ b/spec/lib/error_message_translation_spec.rb
@@ -1,0 +1,48 @@
+require "fast_spec_helper"
+require "lib/error_message_translation"
+
+describe ErrorMessageTranslation do
+  describe ".from_error_response" do
+    context "when error status is 403" do
+      it "returns error message" do
+        error = double("error", message: octokit_403_error_message)
+        expected_message = "You must be an admin to add a team membership."
+
+        result = ErrorMessageTranslation.from_error_response(error)
+
+        expect(result).to eq expected_message
+      end
+    end
+
+    context "when error status is not 403" do
+      it "returns nil" do
+        error = double("error", message: octokit_400_error_message)
+
+        result = ErrorMessageTranslation.from_error_response(error)
+
+        expect(result).to be_nil
+      end
+    end
+
+    context "when error does not adhere to expected formatting" do
+      it "returns nil" do
+        message = "error"
+        error = double("error", message: message)
+
+        result = ErrorMessageTranslation.from_error_response(error)
+
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  private
+
+  def octokit_403_error_message
+    "PUT https://api.github.com/teams/3675/memberships/houndci: 403 - You must be an admin to add a team membership. // See: https://developer.github.com/v3"
+  end
+
+  def octokit_400_error_message
+    "PUT https://api.github.com/teams/3675/memberships/houndci: 400 - Problems parsing JSON. // See: https://developer.github.com/v3"
+  end
+end

--- a/spec/services/repo_activator_spec.rb
+++ b/spec/services/repo_activator_spec.rb
@@ -98,7 +98,7 @@ describe RepoActivator do
       end
     end
 
-    context "when adding hound to rope results in an error" do
+    context "when adding hound to repo results in an error" do
       it "returns false" do
         activator = build_activator
         allow(AddHoundToRepo).to receive(:run).and_raise(Octokit::Error.new)
@@ -106,6 +106,18 @@ describe RepoActivator do
         result = activator.activate
 
         expect(result).to be_falsy
+      end
+
+      it "adds an error" do
+        activator = build_activator
+        error_message = "error"
+        allow(AddHoundToRepo).to receive(:run).and_raise(Octokit::Forbidden.new)
+        allow(ErrorMessageTranslation).to receive(:from_error_response).
+          and_return(error_message)
+
+        activator.activate
+
+        expect(activator.errors).to match_array([error_message])
       end
 
       it "reports raised exception to Sentry" do


### PR DESCRIPTION
* Currently when repo activation fails a generic error message
  is displayed to the user. This commit introduces support for
  displaying detailed, actionable error messages when repo activation fails.
* Update `RepoActivator` to add and expose errors when repo activation
  fails due to a GitHub permissions issue.
* Update `ActivationsController#create` to return error messages when
  error messages are present.
* Introduce `ErrorMessageTranslation` to handle translating
  non-user-friendly Octokit error messages into messages that can be
  displayed to the end user.
* Update client-side error handling to display error messages included
  in response body
* https://trello.com/c/KYuTdbXS/405-when-a-user-tries-to-enable-a-repo-and-it-fails-they-get-no-feedback-as-to-why-enabling-the-repo-failed