### PR TITLE
Cache the language config contents in RepoConfig

### DIFF
--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -9,7 +9,9 @@ class RepoConfig
     "scss" => "yaml",
   }
 
-  pattr_initialize :commit
+  pattr_initialize :commit do
+    @language_configs = {}
+  end
 
   def enabled_for?(language)
     options = options_for(language)
@@ -17,17 +19,7 @@ class RepoConfig
   end
 
   def for(language)
-    if language == "ruby" && legacy?
-      hound_config
-    else
-      config_file_path = config_path_for(language)
-
-      if config_file_path
-        load_file(config_file_path, FILE_TYPES.fetch(language))
-      else
-        {}
-      end
-    end
+    @language_configs[language] ||= fetch_language_config(language)
   end
 
   def ignored_javascript_files
@@ -41,6 +33,20 @@ class RepoConfig
   end
 
   private
+
+  def fetch_language_config(language)
+    if language == "ruby" && legacy?
+      hound_config
+    else
+      config_file_path = config_path_for(language)
+
+      if config_file_path
+        load_file(config_file_path, FILE_TYPES.fetch(language))
+      else
+        {}
+      end
+    end
+  end
 
   def options_for(language)
     hound_config[language] || hound_config[language.camelize]

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -137,6 +137,29 @@ describe RepoConfig do
   end
 
   describe "#for" do
+    it "caches the results" do
+      config_filename = "rubocop.yml"
+      ruby_config_content = "foo bar"
+      hound_config = <<-EOS.strip_heredoc
+        ruby:
+          enabled: true
+          config_file: #{config_filename}
+      EOS
+      commit = stub_commit(
+        hound_config: hound_config,
+        config_filename => ruby_config_content
+      )
+      repo_config = RepoConfig.new(commit)
+
+      repo_config.for("ruby")
+      repo_config.for("ruby")
+
+      expect(commit).to have_received(:file_content).
+        with(RepoConfig::HOUND_CONFIG).once
+      expect(commit).to have_received(:file_content).
+        with(config_filename).once
+    end
+
     context "when Ruby config file is specified" do
       it "returns parsed config" do
         config = config_for_file("config/rubocop.yml", <<-EOS.strip_heredoc)


### PR DESCRIPTION
`RepoConfig#for` is called multiple times for a particular language, which
causes a fetch of the file contents from GitHub each time. We don't expect the
config to change within a single build. The caching will prevent unnecessary
requests that count against our API rate limit.