### PR TITLE
Move Owner.upsert to BuildRunner

### DIFF
--- a/app/jobs/buildable.rb
+++ b/app/jobs/buildable.rb
@@ -3,11 +3,6 @@ require 'resque'
 module Buildable
   def perform(payload_data)
     payload = Payload.new(payload_data)
-    Owner.upsert(
-      github_id: payload.repository_owner_id,
-      name: payload.repository_owner_name,
-      organization: payload.repository_owner_is_organization?
-    )
     build_runner = BuildRunner.new(payload)
     build_runner.run
   rescue Resque::TermException

--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -12,6 +12,7 @@ class BuildRunner
       )
       commenter.comment_on_violations(priority_violations)
       create_success_status
+      upsert_owner
       track_subscribed_build_completed
     end
   end
@@ -76,6 +77,14 @@ class BuildRunner
       payload.full_repo_name,
       payload.head_sha,
       "Hound has reviewed the changes."
+    )
+  end
+
+  def upsert_owner
+    Owner.upsert(
+      github_id: payload.repository_owner_id,
+      name: payload.repository_owner_name,
+      organization: payload.repository_owner_is_organization?
     )
   end
 


### PR DESCRIPTION
Hound receives payloads for events that aren't the PullRequest payloads we care
for. Thus, moving this into `BuildRunner#run` ensures the payload is relevant.

Related error: https://app.getsentry.com/hound-1/production/group/54752935/