### PR TITLE
Cache file contents in the Commit

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -1,9 +1,19 @@
 class Commit
-  pattr_initialize :repo_name, :sha, :github
+  pattr_initialize :repo_name, :sha, :github do
+    @file_contents = {}
+  end
+
   attr_reader :repo_name, :sha
 
   def file_content(filename)
+    @file_contents[filename] ||= fetch_file(filename)
+  end
+
+  private
+
+  def fetch_file(filename)
     contents = @github.file_contents(repo_name, filename, sha)
+
     if contents && contents.content
       Base64.decode64(contents.content).force_encoding("UTF-8")
     else

--- a/spec/models/commit_spec.rb
+++ b/spec/models/commit_spec.rb
@@ -13,6 +13,19 @@ describe Commit do
       end
     end
 
+    context "when called multiple times for the same filename" do
+      it "requests from GitHub only once" do
+        file_contents = double(content: Base64.encode64("foo"))
+        github = double(:github_api, file_contents: file_contents)
+        commit = Commit.new("test/test", "abc", github)
+
+        commit.file_content("test.rb")
+        commit.file_content("test.rb")
+
+        expect(github).to have_received(:file_contents).once
+      end
+    end
+
     context "when file contains special characters" do
       it "does not error when linters try writing to disk" do
         commit = build_commit("€25.00")


### PR DESCRIPTION
Cache the file contents to avoid hitting the GitHub API unnecessarily. This is
particularly to fix the issue of us fetching the configuration files repeatedly
for each file that we process.