### PR TITLE
Scrub parameters before sending exception to Sentry

### DIFF
--- a/app/jobs/accept_org_invitations_job.rb
+++ b/app/jobs/accept_org_invitations_job.rb
@@ -8,5 +8,7 @@ class AcceptOrgInvitationsJob
     github.accept_pending_invitations
   rescue Resque::TermException
     Resque.enqueue(self)
+  rescue => exception
+    Raven.capture_exception(exception, {})
   end
 end

--- a/app/jobs/buildable.rb
+++ b/app/jobs/buildable.rb
@@ -7,5 +7,7 @@ module Buildable
     build_runner.run
   rescue Resque::TermException
     Resque.enqueue(self, payload_data)
+  rescue => exception
+    Raven.capture_exception(exception, payload: { data: payload_data })
   end
 end

--- a/app/jobs/repo_information_job.rb
+++ b/app/jobs/repo_information_job.rb
@@ -16,5 +16,7 @@ class RepoInformationJob
     )
   rescue Resque::TermException
     Resque.enqueue(self, repo_id)
+  rescue => exception
+    Raven.capture_exception(exception, repo: { id: repo_id })
   end
 end

--- a/app/jobs/repo_synchronization_job.rb
+++ b/app/jobs/repo_synchronization_job.rb
@@ -14,5 +14,7 @@ class RepoSynchronizationJob
     user.update_attribute(:refreshing_repos, false)
   rescue Resque::TermException
     Resque.enqueue(self, user_id, github_token)
+  rescue => exception
+    Raven.capture_exception(exception, user: { id: user_id })
   end
 end

--- a/spec/jobs/accept_org_invitations_job_spec.rb
+++ b/spec/jobs/accept_org_invitations_job_spec.rb
@@ -23,4 +23,17 @@ describe AcceptOrgInvitationsJob do
     expect(Resque).to have_received(:enqueue).
       with(AcceptOrgInvitationsJob)
   end
+
+  it "sends the exception to Sentry" do
+    exception = StandardError.new("hola")
+    github = double("GithubApi")
+    allow(GithubApi).to receive(:new).and_return(github)
+    allow(github).to receive(:accept_pending_invitations).and_raise(exception)
+    allow(Raven).to receive(:capture_exception)
+
+    AcceptOrgInvitationsJob.perform
+
+    expect(Raven).to have_received(:capture_exception).
+      with(exception, {})
+  end
 end

--- a/spec/jobs/buildable_spec.rb
+++ b/spec/jobs/buildable_spec.rb
@@ -2,6 +2,7 @@ require "fast_spec_helper"
 require "app/jobs/buildable"
 require "app/models/payload"
 require "app/services/build_runner"
+require "raven"
 
 describe Buildable do
   class TestJob
@@ -32,6 +33,18 @@ describe Buildable do
       TestJob.perform("payload")
 
       expect(Resque).to have_received(:enqueue).with(TestJob, "payload")
+    end
+
+    it "sends the exception to Sentry with the user_id" do
+      exception = StandardError.new("hola")
+      allow(Payload).to receive(:new).and_raise(exception)
+      allow(Raven).to receive(:capture_exception)
+      payload_data = double("PayloadData")
+
+      TestJob.perform(payload_data)
+
+      expect(Raven).to have_received(:capture_exception).
+        with(exception, payload: { data: payload_data })
     end
   end
 

--- a/spec/jobs/repo_information_job_spec.rb
+++ b/spec/jobs/repo_information_job_spec.rb
@@ -25,4 +25,16 @@ describe RepoInformationJob do
 
     expect(Resque).to have_received(:enqueue).with(RepoInformationJob, repo.id)
   end
+
+  it "sends the exception to Sentry with the repo_id" do
+    repo = create(:repo)
+    exception = StandardError.new("hola")
+    allow(Repo).to receive(:find).and_raise(exception)
+    allow(Raven).to receive(:capture_exception)
+
+    RepoInformationJob.perform(repo.id)
+
+    expect(Raven).to have_received(:capture_exception).
+      with(exception, repo: { id: repo.id })
+  end
 end

--- a/spec/jobs/repo_synchronization_job_spec.rb
+++ b/spec/jobs/repo_synchronization_job_spec.rb
@@ -60,5 +60,20 @@ describe RepoSynchronizationJob do
         github_token
       )
     end
+
+    it "sends the exception to Sentry with the user_id" do
+      user = create(:user, refreshing_repos: true)
+      github_token = "token"
+      exception = StandardError.new("hola")
+      synchronization = double(:repo_synchronization)
+      allow(synchronization).to receive(:start).and_raise(exception)
+      allow(RepoSynchronization).to receive(:new).and_return(synchronization)
+      allow(Raven).to receive(:capture_exception)
+
+      RepoSynchronizationJob.perform(user.id, github_token)
+
+      expect(Raven).to have_received(:capture_exception).
+        with(exception, user: { id: user.id })
+    end
   end
 end


### PR DESCRIPTION
Instead send the parameters that might be interesting for the exception,
i.e `user_id`, `payload_data` etc.