### PR TITLE
Ignore certain directories by default

### DIFF
--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -8,6 +8,7 @@ class RepoConfig
     "coffee_script" => "json",
     "scss" => "yaml",
   }
+  DEFAULT_IGNORED_DIRECTORIES = ["vendor"]
 
   pattr_initialize :commit
 
@@ -38,6 +39,11 @@ class RepoConfig
     else
       []
     end
+  end
+
+  def ignored_directories
+    remote_hound_config = load_file(HOUND_CONFIG, "yaml")
+    remote_hound_config["ignored_directories"] || DEFAULT_IGNORED_DIRECTORIES
   end
 
   private

--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -42,8 +42,7 @@ class RepoConfig
   end
 
   def ignored_directories
-    remote_hound_config = load_file(HOUND_CONFIG, "yaml")
-    remote_hound_config["ignored_directories"] || DEFAULT_IGNORED_DIRECTORIES
+    hound_config["ignored_directories"] || DEFAULT_IGNORED_DIRECTORIES
   end
 
   private

--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -8,7 +8,7 @@ class RepoConfig
     "coffee_script" => "json",
     "scss" => "yaml",
   }
-  DEFAULT_IGNORED_DIRECTORIES = ["vendor"]
+  DEFAULT_IGNORED_DIRECTORIES = ["vendor/**"]
 
   pattr_initialize :commit
 
@@ -41,8 +41,8 @@ class RepoConfig
     end
   end
 
-  def ignored_directories
-    hound_config["ignored_directories"] || DEFAULT_IGNORED_DIRECTORIES
+  def ignored_paths
+    hound_config["ignored_paths"] || DEFAULT_IGNORED_DIRECTORIES
   end
 
   private

--- a/app/models/style_guide/base.rb
+++ b/app/models/style_guide/base.rb
@@ -16,8 +16,8 @@ module StyleGuide
     private
 
     def directory_excluded?(file)
-      repo_config.ignored_directories.any? do |directory|
-        File.fnmatch?("#{directory}/*", file.filename)
+      repo_config.ignored_paths.any? do |pattern|
+        File.fnmatch?(pattern, file.filename)
       end
     end
 

--- a/app/models/style_guide/base.rb
+++ b/app/models/style_guide/base.rb
@@ -15,6 +15,12 @@ module StyleGuide
 
     private
 
+    def directory_not_excluded?(file)
+      !repo_config.ignored_directories.any? do |directory|
+        file.filename.start_with? directory
+      end
+    end
+
     def name
       self.class.name.demodulize.underscore
     end

--- a/app/models/style_guide/base.rb
+++ b/app/models/style_guide/base.rb
@@ -17,7 +17,7 @@ module StyleGuide
 
     def directory_excluded?(file)
       repo_config.ignored_directories.any? do |directory|
-        file.filename.start_with? directory
+        File.fnmatch?("#{directory}/*", file.filename)
       end
     end
 

--- a/app/models/style_guide/base.rb
+++ b/app/models/style_guide/base.rb
@@ -15,8 +15,8 @@ module StyleGuide
 
     private
 
-    def directory_not_excluded?(file)
-      !repo_config.ignored_directories.any? do |directory|
+    def directory_excluded?(file)
+      repo_config.ignored_directories.any? do |directory|
         file.filename.start_with? directory
       end
     end

--- a/app/models/style_guide/java_script.rb
+++ b/app/models/style_guide/java_script.rb
@@ -17,7 +17,7 @@ module StyleGuide
     end
 
     def file_included?(file)
-      !excluded_files.any? { |pattern| File.fnmatch?(pattern, file.filename) }
+      directory_not_excluded?(file) && file_not_excluded?(file)
     end
 
     private
@@ -28,6 +28,12 @@ module StyleGuide
         custom_config["predef"] |= default_config["predef"]
       end
       default_config.merge(custom_config)
+    end
+
+    def file_not_excluded?(file)
+      !excluded_files.any? do |pattern|
+        File.fnmatch?(pattern, file.filename)
+      end
     end
 
     def excluded_files

--- a/app/models/style_guide/java_script.rb
+++ b/app/models/style_guide/java_script.rb
@@ -17,7 +17,8 @@ module StyleGuide
     end
 
     def file_included?(file)
-      directory_not_excluded?(file) && file_not_excluded?(file)
+      directory_not_excluded?(file) &&
+        file_not_excluded?(file)
     end
 
     private
@@ -28,6 +29,10 @@ module StyleGuide
         custom_config["predef"] |= default_config["predef"]
       end
       default_config.merge(custom_config)
+    end
+
+    def directory_not_excluded?(file)
+      !directory_excluded?(file)
     end
 
     def file_not_excluded?(file)

--- a/app/models/style_guide/scss.rb
+++ b/app/models/style_guide/scss.rb
@@ -5,7 +5,7 @@ module StyleGuide
     def violations_in_file(file)
       require "scss_lint"
 
-      if config.excluded_file?(file.filename)
+      if excluded_file?(file)
         []
       else
         runner = build_runner
@@ -18,14 +18,18 @@ module StyleGuide
             filename: file.filename,
             line: line,
             line_number: violation.location.line,
-            messages: [violation.description],
-            patch_position: line.patch_position,
+            messages: [violation.description], patch_position: line.patch_position,
           )
         end
       end
     end
 
     private
+
+    def excluded_file?(file)
+      directory_excluded?(file) ||
+        config.excluded_file?(file.filename)
+    end
 
     def build_runner
       SCSSLint::Runner.new(config)

--- a/app/models/style_guide/scss.rb
+++ b/app/models/style_guide/scss.rb
@@ -18,7 +18,8 @@ module StyleGuide
             filename: file.filename,
             line: line,
             line_number: violation.location.line,
-            messages: [violation.description], patch_position: line.patch_position,
+            messages: [violation.description],
+            patch_position: line.patch_position,
           )
         end
       end

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -255,7 +255,7 @@ describe RepoConfig do
       end
     end
 
-    describe "#jshint_ignore_file" do
+    describe "#ignored_javascript_files" do
       context "no specific configuration is present" do
         it "attempts to load a .jshintignore file" do
           ignored_files = <<-EOIGNORE.strip_heredoc

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -306,6 +306,40 @@ describe RepoConfig do
       end
     end
 
+    describe "#ignored_directories" do
+      it "ignores `vendor` by default" do
+        hound_config = <<-EOS
+            java_script:
+              enabled: true
+              ignore_file: ".js_ignore"
+        EOS
+        commit = stub_commit(hound_config: hound_config)
+        repo_config = RepoConfig.new(commit)
+
+        expect(repo_config.ignored_directories).to eq ["vendor"]
+      end
+
+      it "can be configured to allow `vendor` by the repository's config" do
+        hound_config = <<-EOS
+            java_script:
+              enabled: true
+              ignore_file: ".js_ignore"
+        EOS
+
+        repo_hound_config = <<-EOS
+            ignored_directories:
+              - tmp
+        EOS
+        commit = stub_commit(
+          hound_config: hound_config,
+          ".hound.yml" => repo_hound_config,
+        )
+        repo_config = RepoConfig.new(commit)
+
+        expect(repo_config.ignored_directories).to eq ["tmp"]
+      end
+    end
+
     def stub_commit(configuration)
       commit = double("Commit")
       hound_config = configuration.delete(:hound_config)

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -306,8 +306,8 @@ describe RepoConfig do
       end
     end
 
-    describe "#ignored_directories" do
-      it "returns `vendor` by default" do
+    describe "#ignored_paths" do
+      it "defaults to `vendor`" do
         hound_config = <<-EOS
           java_script:
             enabled: true
@@ -316,7 +316,9 @@ describe RepoConfig do
         commit = stub_commit(hound_config: hound_config)
         repo_config = RepoConfig.new(commit)
 
-        expect(repo_config.ignored_directories).to eq ["vendor"]
+        expect(repo_config.ignored_paths).to eq(
+          RepoConfig::DEFAULT_IGNORED_DIRECTORIES
+        )
       end
 
       context "when configured by the repo's config" do
@@ -325,14 +327,14 @@ describe RepoConfig do
             java_script:
               enabled: true
               ignore_file: ".js_ignore"
-            ignored_directories:
+            ignored_paths:
               - tmp
           EOS
 
           commit = stub_commit(hound_config: hound_config)
           repo_config = RepoConfig.new(commit)
 
-          expect(repo_config.ignored_directories).to eq ["tmp"]
+          expect(repo_config.ignored_paths).to eq ["tmp"]
         end
       end
     end

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -307,11 +307,11 @@ describe RepoConfig do
     end
 
     describe "#ignored_directories" do
-      it "ignores `vendor` by default" do
+      it "returns `vendor` by default" do
         hound_config = <<-EOS
-            java_script:
-              enabled: true
-              ignore_file: ".js_ignore"
+          java_script:
+            enabled: true
+            ignore_file: ".js_ignore"
         EOS
         commit = stub_commit(hound_config: hound_config)
         repo_config = RepoConfig.new(commit)
@@ -319,24 +319,21 @@ describe RepoConfig do
         expect(repo_config.ignored_directories).to eq ["vendor"]
       end
 
-      it "can be configured to allow `vendor` by the repository's config" do
-        hound_config = <<-EOS
+      context "when configured by the repo's config" do
+        it "returns configured directories" do
+          hound_config = <<-EOS
             java_script:
               enabled: true
               ignore_file: ".js_ignore"
-        EOS
-
-        repo_hound_config = <<-EOS
             ignored_directories:
               - tmp
-        EOS
-        commit = stub_commit(
-          hound_config: hound_config,
-          ".hound.yml" => repo_hound_config,
-        )
-        repo_config = RepoConfig.new(commit)
+          EOS
 
-        expect(repo_config.ignored_directories).to eq ["tmp"]
+          commit = stub_commit(hound_config: hound_config)
+          repo_config = RepoConfig.new(commit)
+
+          expect(repo_config.ignored_directories).to eq ["tmp"]
+        end
       end
     end
 

--- a/spec/models/style_guide/java_script_spec.rb
+++ b/spec/models/style_guide/java_script_spec.rb
@@ -106,20 +106,46 @@ describe StyleGuide::JavaScript do
 
   describe "#file_included?" do
     context "file is in excluded file list" do
-      it "returns false" do
-        repo_config = double("RepoConfig", ignored_javascript_files: ["foo.js"])
-        style_guide = StyleGuide::JavaScript.new(repo_config, "ralph")
-        file = double(:file, filename: "foo.js")
+      context "when the file is in the ignored files list" do
+        it "returns false" do
+          repo_config = double(
+            "RepoConfig",
+            ignored_javascript_files: ["foo.js"],
+            ignored_directories: [],
+          )
+          style_guide = StyleGuide::JavaScript.new(repo_config, "ralph")
+          file = double(:file, filename: "foo.js")
 
-        included = style_guide.file_included?(file)
+          included = style_guide.file_included?(file)
 
-        expect(included).to be false
+          expect(included).to be false
+        end
+      end
+
+      context "when the file is inside an ignored directory" do
+        it "returns false" do
+          repo_config = double(
+            "RepoConfig",
+            ignored_javascript_files: ["vendor/bar.js"],
+            ignored_directories: ["vendor"],
+          )
+          style_guide = StyleGuide::JavaScript.new(repo_config, "ralph")
+          file = double("File", filename: "vendor/foo.js")
+
+          included = style_guide.file_included?(file)
+
+          expect(included).to be false
+        end
       end
     end
 
     context "file is not excluded" do
       it "returns true" do
-        repo_config = double("RepoConfig", ignored_javascript_files: ["foo.js"])
+        repo_config = double(
+          "RepoConfig",
+          ignored_javascript_files: ["foo.js"],
+          ignored_directories: [],
+        )
         style_guide = StyleGuide::JavaScript.new(repo_config, "ralph")
         file = double(:file, filename: "bar.js")
 
@@ -132,7 +158,8 @@ describe StyleGuide::JavaScript do
     it "matches a glob pattern" do
       repo_config = double(
         "RepoConfig",
-        ignored_javascript_files: ["app/assets/javascripts/*.js"]
+        ignored_javascript_files: ["app/assets/javascripts/*.js"],
+        ignored_directories: [],
       )
 
       style_guide = StyleGuide::JavaScript.new(repo_config, "ralph")

--- a/spec/models/style_guide/java_script_spec.rb
+++ b/spec/models/style_guide/java_script_spec.rb
@@ -111,7 +111,7 @@ describe StyleGuide::JavaScript do
           repo_config = double(
             "RepoConfig",
             ignored_javascript_files: ["foo.js"],
-            ignored_directories: [],
+            ignored_paths: [],
           )
           style_guide = StyleGuide::JavaScript.new(repo_config, "ralph")
           file = double(:file, filename: "foo.js")
@@ -127,7 +127,7 @@ describe StyleGuide::JavaScript do
           repo_config = double(
             "RepoConfig",
             ignored_javascript_files: ["vendor/bar.js"],
-            ignored_directories: ["vendor"],
+            ignored_paths: ["vendor/**"],
           )
           style_guide = StyleGuide::JavaScript.new(repo_config, "ralph")
           file = double("File", filename: "vendor/foo.js")
@@ -144,7 +144,7 @@ describe StyleGuide::JavaScript do
         repo_config = double(
           "RepoConfig",
           ignored_javascript_files: ["foo.js"],
-          ignored_directories: [],
+          ignored_paths: [],
         )
         style_guide = StyleGuide::JavaScript.new(repo_config, "ralph")
         file = double(:file, filename: "bar.js")
@@ -159,7 +159,7 @@ describe StyleGuide::JavaScript do
       repo_config = double(
         "RepoConfig",
         ignored_javascript_files: ["app/assets/javascripts/*.js"],
-        ignored_directories: [],
+        ignored_paths: [],
       )
 
       style_guide = StyleGuide::JavaScript.new(repo_config, "ralph")

--- a/spec/models/style_guide/scss_spec.rb
+++ b/spec/models/style_guide/scss_spec.rb
@@ -103,10 +103,7 @@ describe StyleGuide::Scss do
           style_guide = build_style_guide
           bad_content = ".a { .b { .c { background: #000; } } }"
           file = build_file(bad_content)
-          config_double = double(
-            "SassConfig",
-            excluded_file?: true
-          )
+          config_double = double("SassConfig", excluded_file?: true)
           allow(style_guide).to receive(:config).and_return(config_double)
 
           expect(style_guide.violations_in_file(file)).to eq []

--- a/spec/models/style_guide/scss_spec.rb
+++ b/spec/models/style_guide/scss_spec.rb
@@ -87,7 +87,7 @@ describe StyleGuide::Scss do
             "RepoConfig",
             enabled_for?: true,
             for: nil,
-            ignored_directories: ["vendor"],
+            ignored_paths: ["vendor/**"],
           )
           style_guide = build_style_guide
           allow(style_guide).to receive(:repo_config).and_return(repo_config)
@@ -124,7 +124,7 @@ describe StyleGuide::Scss do
       "RepoConfig",
       enabled_for?: true,
       for: config,
-      ignored_directories: [],
+      ignored_paths: [],
     )
     repository_owner_name = "ralph"
     StyleGuide::Scss.new(repo_config, repository_owner_name)


### PR DESCRIPTION
- Ignore files under `vendor` per default.
- Users can override which directories they want ignored by configuring it in
  their `hound.yml`:

  ```yaml
  # ...
  # ignore `tmp` and `bin` instead of the default `vendor`
  ignored_paths:
    - tmp/**
    - bin/**
  # ...
  ```

https://trello.com/c/1Uhljes3
References #627