### PR TITLE
Blacklist public repos on demand

### DIFF
--- a/app/models/payload.rb
+++ b/app/models/payload.rb
@@ -45,6 +45,10 @@ class Payload
     repository["owner"]["type"] == GithubApi::ORGANIZATION_TYPE
   end
 
+  def private_repo?
+    repository["private"]
+  end
+
   private
 
   def parse_data

--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -2,7 +2,7 @@ class BuildRunner
   pattr_initialize :payload
 
   def run
-    if repo && relevant_pull_request?
+    if repo && relevant_pull_request? && !repo_blacklisted?
       track_subscribed_build_started
       create_pending_status
       repo.builds.create!(
@@ -90,5 +90,13 @@ class BuildRunner
 
   def github
     @github ||= GithubApi.new(ENV["HOUND_GITHUB_TOKEN"])
+  end
+
+  def repo_blacklisted?
+    if ENV["IGNORE_PUBLIC_REPOS"] == "true"
+      !payload.private_repo?
+    else
+      false
+    end
   end
 end


### PR DESCRIPTION
When we are having problems (like hitting our rate limit) we should have a way
to favor paying customers over free.

Setting `ENV["IGNORE_PUBLIC_REPOS"]` allows us to ignore builds for public
repos.