### PR TITLE
Reduce the payload data for build jobs

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -4,7 +4,7 @@ class BuildsController < ApplicationController
   skip_before_action :authenticate, only: [:create]
 
   def create
-    JobQueue.push(build_job_class, payload.data)
+    JobQueue.push(build_job_class, payload.build_data)
     head :ok
   end
 

--- a/app/models/payload.rb
+++ b/app/models/payload.rb
@@ -30,7 +30,7 @@ class Payload
   end
 
   def ping?
-    data['zen']
+    data["zen"]
   end
 
   def repository_owner_id
@@ -43,6 +43,28 @@ class Payload
 
   def repository_owner_is_organization?
     repository["owner"]["type"] == GithubApi::ORGANIZATION_TYPE
+  end
+
+  def build_data
+    {
+      "number" => pull_request_number,
+      "action" => action,
+      "pull_request" => {
+        "changed_files" => changed_files,
+        "head" => {
+          "sha" => head_sha,
+        }
+      },
+      "repository" => {
+        "id" => github_repo_id,
+        "full_name" => full_repo_name,
+        "owner" => {
+          "id" => repository_owner_name,
+          "login" => repository_owner_id,
+          "type" => repository["owner"]["type"],
+        }
+      }
+    }
   end
 
   private

--- a/spec/controllers/builds_controller_spec.rb
+++ b/spec/controllers/builds_controller_spec.rb
@@ -28,33 +28,31 @@ describe BuildsController, '#create' do
 
   context 'when number of changed files is below the threshold' do
     it 'enqueues small build job' do
-      allow(JobQueue).to receive(:push)
       payload_data = File.read(
         'spec/support/fixtures/pull_request_opened_event.json'
       )
+      payload = Payload.new(payload_data)
+      allow(JobQueue).to receive(:push)
 
       post :create, payload: payload_data
 
-      expect(JobQueue).to have_received(:push).with(
-        SmallBuildJob,
-        JSON.parse(payload_data)
-      )
+      expect(JobQueue).to have_received(:push).
+        with(SmallBuildJob, payload.build_data)
     end
   end
 
   context 'when number of changed files is at the threshold or above' do
     it 'enqueues large build job' do
-      allow(JobQueue).to receive(:push)
       payload_data = File.read(
         'spec/support/fixtures/pull_request_event_with_many_files.json'
       )
+      payload = Payload.new(payload_data)
+      allow(JobQueue).to receive(:push)
 
       post :create, payload: payload_data
 
-      expect(JobQueue).to have_received(:push).with(
-        LargeBuildJob,
-        JSON.parse(payload_data)
-      )
+      expect(JobQueue).to have_received(:push).
+        with(LargeBuildJob, payload.build_data)
     end
   end
 end

--- a/spec/models/payload_spec.rb
+++ b/spec/models/payload_spec.rb
@@ -126,4 +126,19 @@ describe Payload do
       end
     end
   end
+
+  describe "#build_data" do
+    it "returns a subset of original data" do
+      fixture_file = "spec/support/fixtures/pull_request_opened_event.json"
+      payload_json = File.read(fixture_file)
+      payload = Payload.new(payload_json)
+
+      expect(payload.build_data).to include(
+        "number",
+        "action",
+        "pull_request" => hash_including("changed_files", "head"),
+        "repository" => hash_including("id", "full_name", "owner"),
+      )
+    end
+  end
 end


### PR DESCRIPTION
We only need a subset of payload data when the jobs run. To reduce the amount of
memory a job takes up, pass a stripped down version of the payload.