### PR TITLE
Ignore non-pr payloads

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -4,7 +4,9 @@ class BuildsController < ApplicationController
   skip_before_action :authenticate, only: [:create]
 
   def create
-    JobQueue.push(build_job_class, payload.data)
+    if payload.pull_request?
+      JobQueue.push(build_job_class, payload.data)
+    end
     head :ok
   end
 

--- a/app/models/payload.rb
+++ b/app/models/payload.rb
@@ -33,6 +33,10 @@ class Payload
     data['zen']
   end
 
+  def pull_request?
+    pull_request.present?
+  end
+
   def repository_owner_id
     repository["owner"]["id"]
   end

--- a/spec/controllers/builds_controller_spec.rb
+++ b/spec/controllers/builds_controller_spec.rb
@@ -57,4 +57,15 @@ describe BuildsController, '#create' do
       )
     end
   end
+
+  context "when payload is not for pull request" do
+    it "does not schedule a job" do
+      payload_data = File.read("spec/support/fixtures/push_event.json")
+      allow(JobQueue).to receive(:push)
+
+      post :create, payload: payload_data
+
+      expect(JobQueue).not_to have_received(:push)
+    end
+  end
 end

--- a/spec/models/payload_spec.rb
+++ b/spec/models/payload_spec.rb
@@ -1,6 +1,7 @@
 require "fast_spec_helper"
 require "attr_extras"
 require "app/models/payload"
+require "lib/github_api"
 
 describe Payload do
   describe '#changed_files' do
@@ -49,6 +50,28 @@ describe Payload do
       payload = Payload.new(data)
 
       expect(payload.data).to eq data
+    end
+  end
+
+  describe "#pull_request?" do
+    context "when payload for push of a commit" do
+      it "returns false" do
+        push_event = File.read("spec/support/fixtures/push_event.json")
+        payload = Payload.new(push_event)
+
+        expect(payload).not_to be_pull_request
+      end
+    end
+
+    context "when payload for pull request" do
+      it "returns true" do
+        push_event = File.read(
+          "spec/support/fixtures/pull_request_opened_event.json"
+        )
+        payload = Payload.new(push_event)
+
+        expect(payload).to be_pull_request
+      end
     end
   end
 

--- a/spec/support/fixtures/push_event.json
+++ b/spec/support/fixtures/push_event.json
@@ -1,0 +1,161 @@
+{
+  "ref": "refs/heads/gh-pages",
+  "before": "4d2ab4e76d0d405d17d1a0f2b8a6071394e3ab40",
+  "after": "7700ca29dd050d9adacc0803f866d9b539513535",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/baxterthehacker/public-repo/compare/4d2ab4e76d0d...7700ca29dd05",
+  "commits": [
+    {
+      "id": "7700ca29dd050d9adacc0803f866d9b539513535",
+      "distinct": true,
+      "message": "Trigger pages build",
+      "timestamp": "2014-10-09T17:10:36-07:00",
+      "url": "https://github.com/baxterthehacker/public-repo/commit/7700ca29dd050d9adacc0803f866d9b539513535",
+      "author": {
+        "name": "Kyle Daigle",
+        "email": "kyle.daigle@github.com",
+        "username": "kdaigle"
+      },
+      "committer": {
+        "name": "Kyle Daigle",
+        "email": "kyle.daigle@github.com",
+        "username": "kdaigle"
+      },
+      "added": [
+
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+        "index.html"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "7700ca29dd050d9adacc0803f866d9b539513535",
+    "distinct": true,
+    "message": "Trigger pages build",
+    "timestamp": "2014-10-09T17:10:36-07:00",
+    "url": "https://github.com/baxterthehacker/public-repo/commit/7700ca29dd050d9adacc0803f866d9b539513535",
+    "author": {
+      "name": "Kyle Daigle",
+      "email": "kyle.daigle@github.com",
+      "username": "kdaigle"
+    },
+    "committer": {
+      "name": "Kyle Daigle",
+      "email": "kyle.daigle@github.com",
+      "username": "kdaigle"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "index.html"
+    ]
+  },
+  "repository": {
+    "id": 20000106,
+    "name": "public-repo",
+    "full_name": "baxterthehacker/public-repo",
+    "owner": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com"
+    },
+    "private": false,
+    "html_url": "https://github.com/baxterthehacker/public-repo",
+    "description": "",
+    "fork": false,
+    "url": "https://github.com/baxterthehacker/public-repo",
+    "forks_url": "https://api.github.com/repos/baxterthehacker/public-repo/forks",
+    "keys_url": "https://api.github.com/repos/baxterthehacker/public-repo/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/baxterthehacker/public-repo/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/baxterthehacker/public-repo/teams",
+    "hooks_url": "https://api.github.com/repos/baxterthehacker/public-repo/hooks",
+    "issue_events_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/baxterthehacker/public-repo/events",
+    "assignees_url": "https://api.github.com/repos/baxterthehacker/public-repo/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/baxterthehacker/public-repo/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/tags",
+    "blobs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/baxterthehacker/public-repo/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/baxterthehacker/public-repo/languages",
+    "stargazers_url": "https://api.github.com/repos/baxterthehacker/public-repo/stargazers",
+    "contributors_url": "https://api.github.com/repos/baxterthehacker/public-repo/contributors",
+    "subscribers_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscribers",
+    "subscription_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscription",
+    "commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/baxterthehacker/public-repo/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/comments/{number}",
+    "contents_url": "https://api.github.com/repos/baxterthehacker/public-repo/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/baxterthehacker/public-repo/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/baxterthehacker/public-repo/merges",
+    "archive_url": "https://api.github.com/repos/baxterthehacker/public-repo/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/baxterthehacker/public-repo/downloads",
+    "issues_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/baxterthehacker/public-repo/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
+    "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "created_at": 1400625583,
+    "updated_at": "2014-07-25T16:37:51Z",
+    "pushed_at": 1412899789,
+    "git_url": "git://github.com/baxterthehacker/public-repo.git",
+    "ssh_url": "git@github.com:baxterthehacker/public-repo.git",
+    "clone_url": "https://github.com/baxterthehacker/public-repo.git",
+    "svn_url": "https://github.com/baxterthehacker/public-repo",
+    "homepage": null,
+    "size": 665,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": null,
+    "has_issues": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": true,
+    "forks_count": 0,
+    "mirror_url": null,
+    "open_issues_count": 24,
+    "forks": 0,
+    "open_issues": 24,
+    "watchers": 0,
+    "default_branch": "master",
+    "stargazers": 0,
+    "master_branch": "master"
+  },
+  "pusher": {
+    "name": "baxterthehacker",
+    "email": "baxterthehacker@users.noreply.github.com"
+  },
+  "sender": {
+    "login": "baxterthehacker",
+    "id": 6752317,
+    "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=2",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/baxterthehacker",
+    "html_url": "https://github.com/baxterthehacker",
+    "followers_url": "https://api.github.com/users/baxterthehacker/followers",
+    "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
+    "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
+    "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
+    "repos_url": "https://api.github.com/users/baxterthehacker/repos",
+    "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}


### PR DESCRIPTION
Don't schedule jobs for payloads that are not for a pull request
(e.g. commit push). No reason to waste the backround job round trip just to
do nothing.