### PR TITLE
Reduce the wait time between failed jobs

### DIFF
--- a/app/jobs/retryable.rb
+++ b/app/jobs/retryable.rb
@@ -4,6 +4,6 @@ module Retryable
   extend Resque::Plugins::Retry
 
   @retry_limit = 10
-  @retry_delay = 120
+  @retry_delay = ENV.fetch("RESQUE_RETRY_DELAY", 30).to_i
   @fatal_exceptions = [Octokit::Unauthorized]
 end


### PR DESCRIPTION
Most of the failures we get are network problems. We shouldn't wait long to
retry jobs anyhow.