### PR TITLE
Read MAX_COMMENTS using ENV#fetch

### DIFF
--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -1,4 +1,6 @@
 class BuildRunner
+  MAX_COMMENTS = ENV.fetch("MAX_COMMENTS").to_i
+
   pattr_initialize :payload
 
   def run
@@ -28,7 +30,7 @@ class BuildRunner
   end
 
   def priority_violations
-    violations.take(ENV["MAX_COMMENTS"].to_i)
+    violations.take(MAX_COMMENTS)
   end
 
   def style_checker

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -44,7 +44,7 @@ describe BuildRunner, '#run' do
     it "comments a maximum number of times" do
       allow(ENV).to receive(:[]).with("HOUND_GITHUB_TOKEN").
         and_return("something")
-      allow(ENV).to receive(:[]).with("MAX_COMMENTS").and_return("1")
+      stub_const("::BuildRunner::MAX_COMMENTS", 1)
       build_runner = make_build_runner
       stubbed_commenter
       violations = build_list(:violation, 2)
@@ -56,7 +56,7 @@ describe BuildRunner, '#run' do
       build_runner.run
 
       expect(commenter).to have_received(:comment_on_violations).
-        with(violations.take(ENV["MAX_COMMENTS"].to_i))
+        with(violations.take(BuildRunner::MAX_COMMENTS))
     end
 
     it 'initializes StyleChecker with modified files and config' do


### PR DESCRIPTION
Given a PR with violations in the diff, if `MAX_COMMENTS` is not set Hound will not report any violations. This is a kind of silent failure, which I think we should avoid.