### PR TITLE
Add a unique index on `subscriptions` `repo_id`

### DIFF
--- a/db/migrate/20150225001118_add_unique_index_on_subscription_repo_id.rb
+++ b/db/migrate/20150225001118_add_unique_index_on_subscription_repo_id.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexOnSubscriptionRepoId < ActiveRecord::Migration
+  def change
+    remove_index :subscriptions, column: :repo_id
+    add_index :subscriptions, :repo_id,
+      unique: true, where: "deleted_at IS NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150217090319) do
+ActiveRecord::Schema.define(version: 20150225001118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,7 +78,7 @@ ActiveRecord::Schema.define(version: 20150217090319) do
     t.decimal  "price",                              precision: 8, scale: 2, default: 0.0, null: false
   end
 
-  add_index "subscriptions", ["repo_id"], name: "index_subscriptions_on_repo_id", using: :btree
+  add_index "subscriptions", ["repo_id"], name: "index_subscriptions_on_repo_id", unique: true, where: "(deleted_at IS NULL)", using: :btree
   add_index "subscriptions", ["user_id"], name: "index_subscriptions_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe Subscription do
+  context "when creating a duplicate subscription for a repo" do
+    it "raises a unique constraint error" do
+      create(:subscription, repo_id: 1)
+
+      expect { create(:subscription, repo_id: 1) }.
+        to raise_error ActiveRecord::RecordNotUnique
+    end
+  end
+
+  context "when existing subscripion is deleted" do
+    it "does not raise an error" do
+      create(:subscription, repo_id: 1, deleted_at: 1.day.ago)
+
+      expect { create(:subscription, repo_id: 1) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
To prevent duplicate subscription records (and charges) for the same repo. Use a
unique partial index since we don't care for it to be unique if it was deleted.