### PR TITLE
Remove duplicated preferred methods in Ruby guide

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -102,10 +102,8 @@ Style/CollectionMethods:
   PreferredMethods:
     collect: map
     collect!: map!
-    inject: reduce
-    detect: find
-    find_all: select
     find: detect
+    find_all: select
     reduce: inject
 Style/CommentAnnotation:
   Description: Checks formatting of special comments (TODO, FIXME, OPTIMIZE, HACK,


### PR DESCRIPTION
Commit d86435b (#669) introduced two duplicate/conflicting lines in the
Ruby configuration file for preferred methods. The conflicts involved
`reduce`/`inject` and `find`/`detect`.

This commit removes the duplicates, preferring `inject` over `reduce`
and `detect` over `find`. Note that these conflict with [bbatsov]'s
style guide, which is linked to just above these settings in the config
file.

[bbatsov]: https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size

(The [thoughtbot] style guide also prefers `reduce` over `detect`, but it's
unclear from the changes in d86435b if that's the intention is for Hound.
Let me know if I've got it backwards and I'll correct the PR.)

[thoughtbot]: https://github.com/thoughtbot/guides/blob/48f47748328c0b5f8575ed6f89f9a77c203b7063/style/ruby/README.md