### PR TITLE
Use YAML.safe_load when loading custom config

### DIFF
--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -93,7 +93,7 @@ class RepoConfig
   end
 
   def parse_yaml(content)
-    YAML.load(content)
+    YAML.safe_load(content)
   rescue Psych::SyntaxError
     {}
   end


### PR DESCRIPTION
There's a vulnerability in `YAML.load` which can enable arbitrary code to be run
on our sytems. `YAML.safe_load` does not deserialize unsafe classes.

Related reading:
http://blog.codeclimate.com/blog/2013/01/10/rails-remote-code-execution-vulnerability-explained/
https://github.com/tenderlove/psych/issues/119
http://docs.ruby-lang.org/en/2.1.0/Psych.html#method-c-safe_load