### PR TITLE
Disable PerceivedComplexity cop

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -528,7 +528,7 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Description: A complexity metric geared towards measuring complexity for a human
     reader.
-  Enabled: true
+  Enabled: false
   Max: 7
 Lint/AssignmentInCondition:
   Description: Don't use assignment in conditions.


### PR DESCRIPTION
We are testing these complexity cops out on Hound itself, I would rather wait until we have some feedback before enabling them for everyone by default.