### PR TITLE
Deprecate ShowCopNames over DisplayCopNames

### DIFF
--- a/app/models/analytics.rb
+++ b/app/models/analytics.rb
@@ -62,6 +62,15 @@ class Analytics
     )
   end
 
+  def track_show_cop_names
+    track(
+      event: "Using ShowCopNames",
+      properties: {
+        owner: user
+      }
+    )
+  end
+
   private
 
   def track(options)

--- a/app/models/style_guide/ruby.rb
+++ b/app/models/style_guide/ruby.rb
@@ -54,8 +54,11 @@ module StyleGuide
       RuboCop::Config.new
     end
 
+    # This is deprecated in favor of RuboCop's DisplayCopNames option.
+    # Let's track how often we see this and remove it if we see fit.
     def rubocop_options
-      if config["ShowCopNames"]
+      if config.delete("ShowCopNames")
+        Analytics.new(repository_owner_name).track_show_cop_names
         { debug: true }
       end
     end

--- a/spec/models/style_guide/ruby_spec.rb
+++ b/spec/models/style_guide/ruby_spec.rb
@@ -412,8 +412,8 @@ end
       expect(violations).to eq ["Use the new Ruby 1.9 hash syntax."]
     end
 
-    it "can use custom configuration to show rubocop cop names" do
-      config = { "ShowCopNames" => "true" }
+    it "can use custom configuration to display rubocop cop names" do
+      config = { "AllCops" => { "DisplayCopNames" => "true" } }
 
       violations = violations_with_config(config)
 


### PR DESCRIPTION
RuboCop supports `DisplayCopNames` option now. Having unsupported `ShowCopNames`
option in the RuboCop config seemed to cause issues for our users.