### PR TITLE
Whitelist Regexp for yaml loading

### DIFF
--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -93,7 +93,7 @@ class RepoConfig
   end
 
   def parse_yaml(content)
-    YAML.safe_load(content)
+    YAML.safe_load(content, [Regexp])
   rescue Psych::SyntaxError
     {}
   end

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -154,6 +154,27 @@ describe RepoConfig do
           "LineLength" => { "Max" => 90 },
         )
       end
+
+      context "with unsafe yaml" do
+        it "raises error" do
+          config = config_for_file("config/rubocop.yml", <<-EOS.strip_heredoc)
+            StringLiterals: !ruby/object
+              foo:
+          EOS
+
+          expect { config.for("ruby") }.to raise_error Psych::DisallowedClass
+        end
+      end
+
+      context "with ruby regex in yaml" do
+        it "does not raise an error" do
+          config = config_for_file("config/rubocop.yml", <<-EOS.strip_heredoc)
+            WordRegex: !ruby/regexp /\A[\p{Word}]+\z/
+          EOS
+
+          expect { config.for("ruby") }.not_to raise_error
+        end
+      end
     end
 
     context "when CoffeeScript config file is specified" do


### PR DESCRIPTION
The RuboCop config uses a Ruby regex line in the config

Related error:

https://app.getsentry.com/hound-1/production/group/56103505/