### PR TITLE
Update repo owner on each build

### DIFF
--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -7,6 +7,7 @@ class BuildRunner
     if repo && relevant_pull_request?
       track_subscribed_build_started
       create_pending_status
+      upsert_owner
       repo.builds.create!(
         violations: violations,
         pull_request_number: payload.pull_request_number,
@@ -14,7 +15,6 @@ class BuildRunner
       )
       commenter.comment_on_violations(priority_violations)
       create_success_status
-      upsert_owner
       track_subscribed_build_completed
     end
   end
@@ -83,11 +83,12 @@ class BuildRunner
   end
 
   def upsert_owner
-    Owner.upsert(
+    owner = Owner.upsert(
       github_id: payload.repository_owner_id,
       name: payload.repository_owner_name,
       organization: payload.repository_owner_is_organization?
     )
+    repo.update(owner: owner)
   end
 
   def github

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -124,7 +124,6 @@ describe BuildRunner, '#run' do
         repository_owner_name: owner_name,
         repository_owner_is_organization?: true,
       )
-      allow(Owner).to receive(:upsert)
       build_runner = BuildRunner.new(payload)
       stubbed_pull_request
       stubbed_style_checker_with_violations
@@ -133,11 +132,13 @@ describe BuildRunner, '#run' do
 
       build_runner.run
 
-      expect(Owner).to have_received(:upsert).with(
-        github_id: owner_github_id,
-        name: owner_name,
-        organization: true
+      owner_attributes = Owner.first.slice(:name, :github_id, :organization)
+      expect(owner_attributes).to eq(
+        "name" => owner_name,
+        "github_id" => owner_github_id,
+        "organization" => true
       )
+      expect(repo.reload.owner).to eq Owner.first
     end
   end
 


### PR DESCRIPTION
If the repo has been transfered, this will be picked up during a build. Also,
this will populate our empty `repo.owner_id` fields.