### PR TITLE
Return unique list of repos from repos.json

### DIFF
--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -11,7 +11,8 @@ class ReposController < ApplicationController
         repos = current_user.
           repos.
           order(active: :desc, full_github_name: :asc).
-          includes(:subscription)
+          includes(:subscription).
+          uniq
 
         render json: repos
       end

--- a/spec/controllers/repos_controller_spec.rb
+++ b/spec/controllers/repos_controller_spec.rb
@@ -27,4 +27,19 @@ describe ReposController do
       end
     end
   end
+
+  context "when current user has duplicate memberships" do
+    it "returns unique list of repos" do
+      user = create(:user)
+      repo = create(:repo)
+      repo.users << user
+      repo.users << user
+      stub_sign_in(user)
+
+      get :index, format: :json
+
+      response_body = JSON.parse(response.body)
+      expect(response_body.length).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
Currently, it is possible for there to be duplicate `memberships` tying a `user`
to `repos` and as a result, the user can sometimes see duplicate `repos` on
houndci.com. This update solves the UI problem. We'll have to dig a bit deeper
to figure out where the duplicates are coming from in the first place.

Part of
https://trello.com/c/GnvVhljg/532-repos-json-endpoint-returns-duplicate-repos