### PR TITLE
Set user.refreshing_repos to true

### DIFF
--- a/app/controllers/repo_syncs_controller.rb
+++ b/app/controllers/repo_syncs_controller.rb
@@ -1,6 +1,8 @@
 class RepoSyncsController < ApplicationController
   def create
     unless current_user.refreshing_repos?
+      current_user.update_attribute(:refreshing_repos, true)
+
       RepoSynchronizationJob.perform_later(
         current_user,
         session[:github_token]

--- a/spec/controllers/repo_syncs_controller_spec.rb
+++ b/spec/controllers/repo_syncs_controller_spec.rb
@@ -16,7 +16,7 @@ describe RepoSyncsController, "#create" do
   end
 
   context "user is not refreshing repos" do
-    it "enqueues repo sync job" do
+    it "sets user to refreshing repos true and enqueues repo sync job" do
       token = "usergithubtoken"
       user = create(:user)
       stub_sign_in(user, token)
@@ -24,6 +24,7 @@ describe RepoSyncsController, "#create" do
 
       post :create
 
+      expect(user.reload).to be_refreshing_repos
       expect(RepoSynchronizationJob).
         to have_received(:perform_later).with(user, token)
     end


### PR DESCRIPTION
This update allows for the user's repo filtering to work after synced repos get
loaded up again.

![repo_search](https://cloud.githubusercontent.com/assets/2181356/6476355/9f790dfe-c1c9-11e4-8240-b64d92617845.gif)


https://trello.com/c/6RlXlvgP/529-show-repos-after-searching-and-refreshing