### PR TITLE
Update documentation

### DIFF
--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -52,7 +52,7 @@
           ruby:
             config_file: .ruby-style.yml
 
-          javascript:
+          java_script:
             ignore_file: .javascript_ignore
 
       %p


### PR DESCRIPTION
Correct the first example, change `javascript` to `java_script`.

It might be a good idea to support both to avoid issues.