### PR TITLE
Ignore return status of deactivation cleanup

### DIFF
--- a/app/services/repo_activator.rb
+++ b/app/services/repo_activator.rb
@@ -27,7 +27,8 @@ class RepoActivator
 
   def deactivate_repo
     change_repository_state_quietly do
-      remove_hound_from_repo && delete_webhook && repo.deactivate
+      remove_hound_from_repo
+      delete_webhook && repo.deactivate
     end
   end
 


### PR DESCRIPTION
If removing @houndci from the organization and repo fails for some reason, we
don't care, as we just want to make sure the hook is removed and the repo is
deactivated.