### PR TITLE
Use only the data required for builds in jobs

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -5,7 +5,7 @@ class BuildsController < ApplicationController
 
   def create
     if payload.pull_request?
-      build_job_class.perform_later(payload.data)
+      build_job_class.perform_later(payload.build_data)
     end
     head :ok
   end

--- a/spec/controllers/builds_controller_spec.rb
+++ b/spec/controllers/builds_controller_spec.rb
@@ -35,7 +35,7 @@ describe BuildsController, '#create' do
       post :create, payload: payload_data
 
       expect(SmallBuildJob).to have_received(:perform_later).with(
-        JSON.parse(payload_data)
+        payload.build_data
       )
     end
   end
@@ -51,7 +51,7 @@ describe BuildsController, '#create' do
       post :create, payload: payload_data
 
       expect(LargeBuildJob).to have_received(:perform_later).with(
-        JSON.parse(payload_data)
+        payload.build_data
       )
     end
   end


### PR DESCRIPTION
Somehow this was lost during the switch to `ActiveJob`.