### PR TITLE
Use inidividual tokens for as much as possible

### DIFF
--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -1,4 +1,6 @@
 class ReposController < ApplicationController
+  before_action :save_token
+
   def index
     respond_to do |format|
       format.html
@@ -15,6 +17,14 @@ class ReposController < ApplicationController
 
         render json: repos
       end
+    end
+  end
+
+  private
+
+  def save_token
+    if current_user.token.blank?
+      current_user.update!(token: session[:github_token])
     end
   end
 end

--- a/app/jobs/retryable.rb
+++ b/app/jobs/retryable.rb
@@ -5,5 +5,6 @@ module Retryable
 
   @retry_limit = 10
   @retry_delay = ENV.fetch("RESQUE_RETRY_DELAY", 30).to_i
+
   @fatal_exceptions = [Octokit::Unauthorized]
 end

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -1,18 +1,18 @@
 class PullRequest
-  pattr_initialize :payload
+  pattr_initialize :payload, :token
 
   def comments
-    @comments ||= api.pull_request_comments(full_repo_name, number)
+    @comments ||= user_github.pull_request_comments(full_repo_name, number)
   end
 
   def pull_request_files
-    @pull_request_files ||= api.
+    @pull_request_files ||= user_github.
       pull_request_files(full_repo_name, number).
       map { |file| build_commit_file(file) }
   end
 
   def comment_on_violation(violation)
-    api.add_pull_request_comment(
+    hound_github.add_pull_request_comment(
       pull_request_number: number,
       comment: violation.messages.join("<br>"),
       commit: head_commit,
@@ -34,7 +34,7 @@ class PullRequest
   end
 
   def head_commit
-    @head_commit ||= Commit.new(full_repo_name, payload.head_sha, api)
+    @head_commit ||= Commit.new(full_repo_name, payload.head_sha, user_github)
   end
 
   private
@@ -43,8 +43,12 @@ class PullRequest
     CommitFile.new(file, head_commit)
   end
 
-  def api
-    @api ||= GithubApi.new(ENV["HOUND_GITHUB_TOKEN"])
+  def user_github
+    @user_github ||= GithubApi.new(token)
+  end
+
+  def hound_github
+    @hound_github ||= GithubApi.new(ENV["HOUND_GITHUB_TOKEN"])
   end
 
   def number

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,7 +39,24 @@ class User < ActiveRecord::Base
     repos.active.count > 0
   end
 
+  def token=(value)
+    encrypted_token = crypt.encrypt_and_sign(value)
+    write_attribute(:token, encrypted_token)
+  end
+
+  def token
+    encrypted_token = read_attribute(:token)
+    unless encrypted_token.nil?
+      crypt.decrypt_and_verify(encrypted_token)
+    end
+  end
+
   private
+
+  def crypt
+    secret_key_base = Rails.application.secrets.secret_key_base
+    ActiveSupport::MessageEncryptor.new(secret_key_base)
+  end
 
   def payment_gateway_customer
     @payment_gateway_customer ||= PaymentGatewayCustomer.new(self)

--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -44,7 +44,16 @@ class BuildRunner
   end
 
   def pull_request
-    @pull_request ||= PullRequest.new(payload)
+    @pull_request ||= PullRequest.new(payload, token)
+  end
+
+  def token
+    @token ||= user_token || ENV["HOUND_GITHUB_TOKEN"]
+  end
+
+  def user_token
+    user_with_token = repo.users.where.not(token: nil).sample
+    user_with_token && user_with_token.token
   end
 
   def repo
@@ -103,7 +112,7 @@ class BuildRunner
   end
 
   def github
-    @github ||= GithubApi.new(ENV["HOUND_GITHUB_TOKEN"])
+    @github ||= GithubApi.new(token)
   end
 
   def configuration_url

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,3 @@
-ENV["SECRET_KEY_BASE"] = "supersecret"
-
 Houndapp::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
   config.eager_load = false

--- a/db/migrate/20150306184045_add_token_to_users.rb
+++ b/db/migrate/20150306184045_add_token_to_users.rb
@@ -1,0 +1,5 @@
+class AddTokenToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define(version: 20150303212157) do
     t.boolean  "refreshing_repos",               default: false
     t.string   "email_address",      limit: 255
     t.string   "stripe_customer_id", limit: 255
+    t.string   "token"
   end
 
   add_index "users", ["remember_token"], name: "index_users_on_remember_token", using: :btree

--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -9,7 +9,8 @@ class GithubApi
 
   attr_reader :file_cache, :token
 
-  def initialize(token = ENV["HOUND_GITHUB_TOKEN"])
+  # doesn't look like we need a default token
+  def initialize(token)
     @token = token
     @file_cache = {}
   end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -4,10 +4,12 @@ require "app/models/commit"
 require "lib/github_api"
 
 describe PullRequest do
+  let(:token) { "some_github_token" }
+
   describe "#opened?" do
     context "when payload action is opened" do
       it "returns true" do
-        pull_request = PullRequest.new(payload_stub(action: "opened"))
+        pull_request = PullRequest.new(payload_stub(action: "opened"), token)
 
         expect(pull_request).to be_opened
       end
@@ -16,7 +18,7 @@ describe PullRequest do
     context "when payload action is not opened" do
       it "returns false" do
         payload = payload_stub(action: "notopened")
-        pull_request = PullRequest.new(payload)
+        pull_request = PullRequest.new(payload, token)
 
         expect(pull_request).not_to be_opened
       end
@@ -27,7 +29,7 @@ describe PullRequest do
     context "when payload action is synchronize" do
       it "returns true" do
         payload = payload_stub(action: "synchronize")
-        pull_request = PullRequest.new(payload)
+        pull_request = PullRequest.new(payload, token)
 
         expect(pull_request).to be_synchronize
       end
@@ -36,7 +38,7 @@ describe PullRequest do
     context "when payload action is not synchronize" do
       it "returns false" do
         payload = payload_stub(action: "notsynchronize")
-        pull_request = PullRequest.new(payload)
+        pull_request = PullRequest.new(payload, token)
 
         expect(pull_request).not_to be_synchronize
       end
@@ -98,6 +100,6 @@ describe PullRequest do
 
   def pull_request_stub(api, payload = payload_stub)
     allow(GithubApi).to receive(:new).and_return(api)
-    PullRequest.new(payload)
+    PullRequest.new(payload, token)
   end
 end

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -73,6 +73,8 @@ describe BuildRunner, '#run' do
 
     it 'initializes PullRequest with payload and Hound token' do
       repo = create(:repo, :active, github_id: 123)
+      user = create(:user, token: "user_token")
+      user.repos << repo
       payload = stubbed_payload(github_repo_id: repo.github_id)
       build_runner = BuildRunner.new(payload)
       stubbed_pull_request
@@ -82,7 +84,7 @@ describe BuildRunner, '#run' do
 
       build_runner.run
 
-      expect(PullRequest).to have_received(:new).with(payload)
+      expect(PullRequest).to have_received(:new).with(payload, user.token)
     end
 
     it "creates GitHub statuses" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ require "active_support/core_ext"
 Dir["spec/support/**/*.rb"].each { |f| require f }
 
 ENV["HOST"] = "test.host"
-ENV["SECRET_KEY_BASE"] = "test-key"
+ENV["SECRET_KEY_BASE"] = "test-key" * 5
 ENV["HOUND_GITHUB_USERNAME"] = "houndci"
 ENV["HOUND_GITHUB_TOKEN"] = "houndgithubtoken"
 ENV["ENABLE_HTTPS"] = "no"


### PR DESCRIPTION
* Use user's token for PR fetching content, fetching comments, and setting status
* Use Hound's token for commenting and accepting org invites
* Save user's token if he doesn't have one upon viewing repos


Remaining changes?
- [x] Encrypt tokens
- [x] Figure out retry strategy when requests fail