### PR TITLE
increment/decrement quantity instead of new subscription

### DIFF
--- a/app/models/payment_gateway_customer.rb
+++ b/app/models/payment_gateway_customer.rb
@@ -1,5 +1,10 @@
 class PaymentGatewayCustomer
-  pattr_initialize :user
+  attr_reader :user
+
+  def initialize(user, customer: nil)
+    @user = user
+    @customer = customer
+  end
 
   def email
     customer.email
@@ -19,6 +24,23 @@ class PaymentGatewayCustomer
     end
   end
 
+  def find_or_create_subscription(plan:, repo_id:)
+    subscriptions.detect { |subscription| subscription.plan == plan } ||
+      create_subscription(plan: plan, metadata: { repo_ids: [repo_id] })
+  end
+
+  def subscriptions
+    customer.subscriptions.map do |subscription|
+      PaymentGatewaySubscription.new(subscription)
+    end
+  end
+
+  def retrieve_subscription(stripe_subscription_id)
+    PaymentGatewaySubscription.new(
+      customer.subscriptions.retrieve(stripe_subscription_id)
+    )
+  end
+
   def update_card(card_token)
     customer.card = card_token
     customer.save
@@ -33,6 +55,13 @@ class PaymentGatewayCustomer
   end
 
   private
+
+  def create_subscription(options)
+    PaymentGatewaySubscription.new(
+      customer.subscriptions.create(options),
+      new_subscription: true,
+    )
+  end
 
   def default_card
     customer.cards.detect { |card| card.id == customer.default_card } ||

--- a/app/models/payment_gateway_subscription.rb
+++ b/app/models/payment_gateway_subscription.rb
@@ -1,0 +1,66 @@
+class PaymentGatewaySubscription
+  attr_reader :stripe_subscription
+
+  delegate :id, :metadata, :save, :delete, to: :stripe_subscription
+
+  def initialize(stripe_subscription, new_subscription: false)
+    @stripe_subscription = stripe_subscription
+    @new_subscription = new_subscription
+  end
+
+  def subscribe(repo_id)
+    append_repo_id_to_metadata(repo_id)
+    if existing_subscription?
+      increment_quantity
+    end
+  end
+
+  def unsubscribe(repo_id)
+    if stripe_subscription.quantity > 1
+      remove_repo_id_from_metadata(repo_id)
+      decrement_quantity
+    else
+      delete
+    end
+  end
+
+  def increment_quantity
+    stripe_subscription.quantity += 1
+    save
+  end
+
+  def decrement_quantity
+    stripe_subscription.quantity -= 1
+    save
+  end
+
+  def plan
+    stripe_subscription.plan.id
+  end
+
+  def existing_subscription?
+    !@new_subscription
+  end
+
+  private
+
+  def current_repo_ids
+    Array(metadata["repo_ids"] || metadata["repo_id"])
+  end
+
+  def append_repo_id_to_metadata(repo_id)
+    repo_ids = current_repo_ids + [repo_id]
+
+    if metadata["repo_id"]
+      metadata["repo_id"] = nil
+    end
+
+    metadata["repo_ids"] = repo_ids.map(&:to_s)
+  end
+
+  def remove_repo_id_from_metadata(repo_id)
+    metadata["repo_ids"] = current_repo_ids.reject do |id|
+      id.to_s == repo_id.to_s
+    end
+  end
+end

--- a/app/services/update_stripe_metadata.rb
+++ b/app/services/update_stripe_metadata.rb
@@ -11,7 +11,7 @@ class UpdateStripeMetadata
       )
 
       if stripe_subscription
-        stripe_subscription.metadata = { repo_id: repo.id }
+        stripe_subscription.metadata = { repo_ids: [repo.id.to_s] }
         stripe_subscription.save
       end
     end

--- a/spec/models/payment_gateway_customer_spec.rb
+++ b/spec/models/payment_gateway_customer_spec.rb
@@ -106,4 +106,18 @@ describe PaymentGatewayCustomer do
       expect(customer).to be payment_gateway_customer.customer
     end
   end
+
+  describe "#new with_customer" do
+    it "returns a new instance with customer set" do
+      user = build_stubbed(:user, stripe_customer_id: nil)
+      customer = :customer
+
+      payment_gateway_customer = PaymentGatewayCustomer.new(
+        user,
+        customer: customer,
+      )
+
+      expect(payment_gateway_customer.customer).to eq customer
+    end
+  end
 end

--- a/spec/models/payment_gateway_subscription_spec.rb
+++ b/spec/models/payment_gateway_subscription_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+describe PaymentGatewaySubscription do
+  context ".subscribe" do
+    context "existing subscription" do
+      it "appends id to repo_ids metadata" do
+        stripe_subscription = MockStripeSubscription.new(repo_ids: [1])
+        subscription = PaymentGatewaySubscription.new(stripe_subscription)
+
+        expect(stripe_subscription.metadata["repo_ids"]).to eq ["1"]
+
+        subscription.subscribe(2)
+
+        expect(stripe_subscription.metadata["repo_ids"]).to eq ["1", "2"]
+      end
+
+      it "converts legacy format to new format" do
+        legacy_subscription = MockLegacyStripeSubscription.new(repo_id: 1)
+        subscription = PaymentGatewaySubscription.new(legacy_subscription)
+
+        expect(legacy_subscription.metadata["repo_id"]).to eq "1"
+
+        subscription.subscribe(2)
+
+        expect(legacy_subscription.metadata["repo_id"]).to be_nil
+        expect(legacy_subscription.metadata["repo_ids"]).to eq ["1", "2"]
+      end
+    end
+  end
+
+  context ".unsubscribe" do
+    it "removes repo_id from repo_ids" do
+      stripe_subscription = MockStripeSubscription.new(repo_ids: [1, 2])
+      allow(stripe_subscription).to receive(:delete)
+      allow(stripe_subscription).to receive(:save)
+      subscription = PaymentGatewaySubscription.new(stripe_subscription)
+
+      subscription.unsubscribe(2)
+
+      expect(stripe_subscription.metadata["repo_ids"]).to eq ["1"]
+      expect(stripe_subscription).not_to have_received(:delete)
+      expect(stripe_subscription).to have_received(:save)
+    end
+
+    it "doesn't blow up when unsubscribing from a legacy subscription" do
+      legacy_subscription = MockLegacyStripeSubscription.new(repo_id: 1)
+      allow(legacy_subscription).to receive(:delete)
+      allow(legacy_subscription).to receive(:save)
+      subscription = PaymentGatewaySubscription.new(legacy_subscription)
+
+      subscription.unsubscribe(1)
+
+      expect(legacy_subscription).to have_received(:delete)
+      expect(legacy_subscription).not_to have_received(:save)
+    end
+  end
+
+  class MockStripeSubscription
+    attr_accessor :quantity, :metadata
+
+    def initialize(repo_ids:)
+      @quantity = repo_ids.count
+      @metadata = { "repo_ids" => repo_ids.map(&:to_s) }
+    end
+
+    def save; end
+
+    def delete; end
+  end
+
+  class MockLegacyStripeSubscription < MockStripeSubscription
+    def initialize(repo_id:)
+      @quantity = 1
+      @metadata = { "repo_id" => repo_id.to_s }
+    end
+  end
+end

--- a/spec/support/fixtures/stripe_customer_find_with_subscriptions.json
+++ b/spec/support/fixtures/stripe_customer_find_with_subscriptions.json
@@ -1,0 +1,84 @@
+{
+  "object": "customer",
+  "created": 1380227987,
+  "id": "cus_2e3fqARc1uHtCv",
+  "livemode": false,
+  "description": null,
+  "email": "scott@thoughtbot.com",
+  "delinquent": false,
+  "metadata": {
+  },
+  "subscriptions": {
+    "object": "list",
+    "total_count": 0,
+    "has_more": false,
+    "url": "/v1/customers/cus_2e3fqARc1uHtCv/subscriptions",
+    "data": [{
+      "id": "sub_488ZZngNkyRMiR",
+      "plan": {
+        "interval": "month",
+        "name": "Personal",
+        "created": 1401465831,
+        "amount": 900,
+        "currency": "usd",
+        "id": "private",
+        "object": "plan",
+        "livemode": false,
+        "interval_count": 1,
+        "trial_period_days": null,
+        "metadata": {
+        },
+        "statement_description": null
+      },
+      "object": "subscription",
+      "start": 1407216749,
+      "status": "active",
+      "customer": "cus_2e3fqARc1uHtCv",
+      "cancel_at_period_end": false,
+      "current_period_start": 1407216749,
+      "current_period_end": 1409895149,
+      "ended_at": null,
+      "trial_start": null,
+      "trial_end": null,
+      "canceled_at": null,
+      "quantity": 1,
+      "application_fee_percent": null,
+      "discount": null,
+      "metadata": {
+      }
+    }]
+  },
+  "discount": null,
+  "account_balance": 0,
+  "currency": "usd",
+  "cards": {
+    "object": "list",
+    "total_count": 1,
+    "has_more": false,
+    "url": "/v1/customers/cus_2e3fqARc1uHtCv/cards",
+    "data": [
+      {
+        "id": "card_102e3c2QAwplLIsJn2oXQKvB",
+        "object": "card",
+        "last4": "4242",
+        "type": "Visa",
+        "exp_month": 12,
+        "exp_year": 2013,
+        "fingerprint": "EEsAljuM0b4ras7N",
+        "country": "US",
+        "name": null,
+        "address_line1": null,
+        "address_line2": null,
+        "address_city": null,
+        "address_state": null,
+        "address_zip": null,
+        "address_country": null,
+        "cvc_check": "pass",
+        "address_line1_check": null,
+        "address_zip_check": null,
+        "customer": "cus_2e3fqARc1uHtCv"
+      }
+    ]
+  },
+  "default_card": "card_102e3c2QAwplLIsJn2oXQKvB"
+}

--- a/spec/support/helpers/stripe_api_helper.rb
+++ b/spec/support/helpers/stripe_api_helper.rb
@@ -35,6 +35,17 @@ module StripeApiHelper
     )
   end
 
+  def stub_customer_find_request_with_subscriptions
+    stub_request(:get, "#{stripe_base_url}/#{stripe_customer_id}").with(
+      headers: { "Authorization" => "Bearer #{ENV['STRIPE_API_KEY']}" }
+    ).to_return(
+      status: 200,
+      body: File.read(
+        "spec/support/fixtures/stripe_customer_find_with_subscriptions.json"
+      )
+    )
+  end
+
   def stub_customer_update_request(attrs = { card: "card-token" })
     stub_request(
       :post,
@@ -66,11 +77,11 @@ module StripeApiHelper
     )
   end
 
-  def stub_subscription_create_request(plan: "free", repo_id: nil)
-    body = { "plan" => plan }
-    if repo_id
-      body.merge!("metadata" => { "repo_id" => repo_id.to_s })
-    end
+  def stub_subscription_create_request(plan: "free", repo_ids: [])
+    body = {
+      "plan" => plan,
+      "metadata" => { "repo_ids" => repo_ids.map(&:to_s) }
+    }
     stub_request(
       :post,
       "#{stripe_base_url}/#{stripe_customer_id}/subscriptions"
@@ -83,17 +94,37 @@ module StripeApiHelper
     )
   end
 
-  def stub_subscription_find_request(subscription)
+  def stub_subscription_update_request(quantity: 1, repo_ids: nil)
+    body = { "quantity" => quantity.to_s }
+
+    if repo_ids.present?
+      body["metadata"] = { repo_ids: repo_ids.map(&:to_s) }
+    end
+
     stub_request(
-      :get,
+      :post,
       "#{stripe_base_url}/#{stripe_customer_id}/"\
-        "subscriptions/#{subscription.stripe_subscription_id}"
+        "subscriptions/#{stripe_subscription_id}"
     ).with(
+      body: body,
       headers: { "Authorization" => "Bearer #{ENV["STRIPE_API_KEY"]}" }
     ).to_return(
       status: 200,
-      body: File.read("spec/support/fixtures/stripe_subscription_find.json"),
+      body: File.read("spec/support/fixtures/stripe_subscription_update.json"),
     )
+  end
+
+  def stub_subscription_find_request(subscription, quantity: 1)
+    body = JSON.parse(
+      File.read("spec/support/fixtures/stripe_subscription_find.json")
+    )
+    body["quantity"] = quantity
+    request_url = "#{stripe_base_url}/#{stripe_customer_id}/"\
+      "subscriptions/#{subscription.stripe_subscription_id}"
+
+    stub_request(:get, request_url).with(
+      headers: { "Authorization" => "Bearer #{ENV['STRIPE_API_KEY']}" }
+    ).to_return(status: 200, body: body.to_json)
   end
 
   def stub_subscription_delete_request
@@ -115,7 +146,7 @@ module StripeApiHelper
       "#{stripe_base_url}/#{stripe_customer_id}/"\
         "subscriptions/#{stripe_subscription_id}"
     ).with(
-      body: "metadata[repo_id]=#{subscription.repo_id}",
+      body: "metadata[repo_ids][]=#{subscription.repo_id}",
       headers: { "Authorization" => "Bearer #{ENV["STRIPE_API_KEY"]}" }
     ).to_return(
       status: 200,


### PR DESCRIPTION
We increment/decrement existing subscriptions instead of creating a new one for each repo.

https://trello.com/c/XNL81IPQ/539-increment-subscription-quantity-instead-of-charging-for-each-repo-individually