### PR TITLE
Use display: none to hide loading spinners

### DIFF
--- a/app/assets/stylesheets/repos/_index.scss
+++ b/app/assets/stylesheets/repos/_index.scss
@@ -315,7 +315,6 @@ aside.org-nav {
 
     &:before {
       @include transition(all 0.25s linear);
-      @extend .fa-spin;
       color: $light-font-color;
       content: '\f013';
       display: inline-block;
@@ -438,6 +437,7 @@ aside.org-nav {
       &:before {
         opacity: 1;
         visibility: visible;
+        @extend .fa-spin;
       }
 
       .repo-name {


### PR DESCRIPTION
Turns out, the CPU load was caused by the many animated spinners that
are hidden on the page at any given time. Every repo has a spinner
that's only shown when it's being activated or deactivated.

With `visibility: hidden`, the browser was still animating these
spinners even when they weren't visible. You can see that in the Chrome
devtools by selecting a `.repo::before` pseudo-element, and you'll see a
spinning outline of where the component is hidden.

One problem with using `display: none` (the new approach) is that the
gear icon is not loaded until someone clicks on 'Activate' or
'Deactivate'. That shows up as a small delay, but I'm not sure how to
fix it.