### PR TITLE
Convert inherit_from value to array

### DIFF
--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -77,7 +77,7 @@ class RepoConfig
 
   def load_config(config_file_path, file_type)
     main_config = load_file(config_file_path, file_type)
-    inherit_from = main_config.fetch("inherit_from", [])
+    inherit_from = Array(main_config.fetch("inherit_from", []))
 
     inherited_config = inherit_from.reduce({}) do |config, ancestor_file_path|
       ancestor_config = load_file(ancestor_file_path, file_type)

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -155,49 +155,83 @@ describe RepoConfig do
         )
       end
 
-      it "supports inherit_from" do
-        hound_config = <<-EOS.strip_heredoc
-          ruby:
-            enabled: true
-            config_file: .rubocop.yml
-        EOS
+      context "with a list of inherit_from files" do
+        it "returns violations" do
+          hound_config = <<-EOS.strip_heredoc
+            ruby:
+              enabled: true
+              config_file: .rubocop.yml
+          EOS
 
-        rubocop = <<-EOS.strip_heredoc
-          inherit_from:
-            - config/base.yml
-            - config/overrides.yml
-          Style/Encoding:
-            Enabled: true
-        EOS
+          rubocop = <<-EOS.strip_heredoc
+            inherit_from:
+              - config/base.yml
+              - config/overrides.yml
+            Style/Encoding:
+              Enabled: true
+          EOS
 
-        base = <<-EOS.strip_heredoc
-          LineLength:
-            Max: 40
-        EOS
+          base = <<-EOS.strip_heredoc
+            LineLength:
+              Max: 40
+          EOS
 
-        overrides = <<-EOS.strip_heredoc
-          Style/HashSyntax:
-            EnforcedStyle: hash_rockets
-          Style/Encoding:
-            Enabled: false
-        EOS
+          overrides = <<-EOS.strip_heredoc
+            Style/HashSyntax:
+              EnforcedStyle: hash_rockets
+            Style/Encoding:
+              Enabled: false
+          EOS
 
-        commit = stub_commit(
-          hound_config: hound_config,
-          ".rubocop.yml" => rubocop,
-          "config/base.yml" => base,
-          "config/overrides.yml" => overrides
-        )
+          commit = stub_commit(
+            hound_config: hound_config,
+            ".rubocop.yml" => rubocop,
+            "config/base.yml" => base,
+            "config/overrides.yml" => overrides
+          )
 
-        config = RepoConfig.new(commit)
+          config = RepoConfig.new(commit)
 
-        result = config.for("ruby")
+          result = config.for("ruby")
 
-        expect(result).to eq(
-          "Style/HashSyntax" => { "EnforcedStyle" => "hash_rockets" },
-          "LineLength" => { "Max" => 40 },
-          "Style/Encoding" => { "Enabled" => true }
-        )
+          expect(result).to eq(
+            "Style/HashSyntax" => { "EnforcedStyle" => "hash_rockets" },
+            "LineLength" => { "Max" => 40 },
+            "Style/Encoding" => { "Enabled" => true }
+          )
+        end
+      end
+
+      context "with a single inherit_from entry" do
+        it "returns violations" do
+          hound_config = <<-EOS.strip_heredoc
+            ruby:
+              config_file: .rubocop.yml
+          EOS
+          rubocop = <<-EOS.strip_heredoc
+            inherit_from: config/base.yml
+
+            Style/Encoding:
+              Enabled: true
+          EOS
+          base = <<-EOS.strip_heredoc
+            LineLength:
+              Max: 40
+          EOS
+          commit = stub_commit(
+            hound_config: hound_config,
+            ".rubocop.yml" => rubocop,
+            "config/base.yml" => base,
+          )
+          config = RepoConfig.new(commit)
+
+          result = config.for("ruby")
+
+          expect(result).to eq(
+            "LineLength" => { "Max" => 40 },
+            "Style/Encoding" => { "Enabled" => true },
+          )
+        end
       end
 
       context "with unsafe yaml" do


### PR DESCRIPTION
The value can be a single entry:

    inherit_from: .rubocop_todo.yml

which will be parsed as just a string.

This change ensures we are always dealing with an array.