### PR TITLE
Prevent hound builld_workers call with a secret token 

### DIFF
--- a/app/controllers/build_workers_controller.rb
+++ b/app/controllers/build_workers_controller.rb
@@ -2,6 +2,7 @@ class BuildWorkersController < ApplicationController
   skip_before_action :authenticate
   skip_before_action :capture_campaign_params
   skip_before_action :verify_authenticity_token
+  before_action :authenticate_with_token
 
   def update
     build_worker = find_build_worker
@@ -29,5 +30,11 @@ class BuildWorkersController < ApplicationController
 
   def find_build_worker
     @find_build_worker ||= BuildWorker.find(params[:id])
+  end
+
+  def authenticate_with_token
+    authenticate_or_request_with_http_token do |token, _|
+      token == ENV.fetch("BUILD_WORKERS_TOKEN")
+    end
   end
 end

--- a/app/workers/language_worker/scss.rb
+++ b/app/workers/language_worker/scss.rb
@@ -1,7 +1,10 @@
 module LanguageWorker
   class Scss < Base
     def run
-      connection.post("/", body: worker_payload.to_json)
+      Faraday.post do |request|
+        request.url = ENV.fetch("SCSS_WORKER_URL")
+        request.body = worker_payload.to_json
+      end
     end
 
     private
@@ -13,6 +16,7 @@ module LanguageWorker
         config: config,
         file: file,
         hound_url: ENV.fetch("BUILD_WORKERS_URL"),
+        token: ENV.fetch("BUILD_WORKERS_TOKEN")
       }
     end
 
@@ -40,10 +44,6 @@ module LanguageWorker
         default_config_file,
         pull_request.repository_owner_name
       ).content
-    end
-
-    def connection
-      @connection ||= Faraday.new(url: ENV.fetch("SCSS_WORKER_URL"))
     end
 
     def default_config_file

--- a/app/workers/language_worker/style_guide_worker.rb
+++ b/app/workers/language_worker/style_guide_worker.rb
@@ -1,7 +1,11 @@
 module LanguageWorker
   class StyleGuideWorker < Base
     def run
-      hound_connection.post("/", body: hound_payload.to_json)
+      Faraday.post do |request|
+        request.url = ENV.fetch("BUILD_WORKERS_URL")
+        request.token_auth(ENV.fetch("BUILD_WORKERS_TOKEN"))
+        request.body = hound_payload.to_json
+      end
     end
 
     attr_implement :style_guide_name
@@ -28,10 +32,6 @@ module LanguageWorker
           messages: violation.messages
         }
       end
-    end
-
-    def hound_connection
-      @hound_connection ||= Faraday.new(url: ENV.fetch("BUILD_WORKERS_URL"))
     end
 
     def violations_from_guide

--- a/spec/controllers/build_workers_controller_spec.rb
+++ b/spec/controllers/build_workers_controller_spec.rb
@@ -2,6 +2,14 @@ require "rails_helper"
 
 describe BuildWorkersController do
   describe "#update" do
+    context "auth" do
+      it "unauthorized access without token" do
+        put :update, id: 1, format: :json
+
+        expect(response.status).to eq(401)
+      end
+    end
+
     context "given an completed build" do
       it "does not complete the build" do
         build_worker = create(
@@ -9,6 +17,7 @@ describe BuildWorkersController do
           :completed,
           completed_at: 1.day.ago,
         )
+        authorized_headers_for_build_worker
 
         put :update, id: build_worker.id, format: :json
 
@@ -25,6 +34,7 @@ describe BuildWorkersController do
       file = double("File")
       violations_attrs = double("ViolationsAttrs")
       build_worker = create(:build_worker)
+      authorized_headers_for_build_worker
 
       put(
         :update,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ ENV["STRIPE_PUBLISHABLE_KEY"] = "pk_test_123"
 ENV["EXEMPT_ORGS"] = "thoughtbot,billybob"
 ENV["SCSS_WORKER_URL"] = "foo.iron.io"
 ENV["BUILD_WORKERS_URL"] = "localhost"
+ENV["BUILD_WORKERS_TOKEN"] = "long-token"
 
 RSpec.configure do |config|
   config.order = "random"

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -2,6 +2,12 @@ module ApiHelper
   def json_body
     JSON.parse(response.body)
   end
+
+  def authorized_headers_for_build_worker
+    header_token = ActionController::HttpAuthentication::Token.
+      encode_credentials(ENV["BUILD_WORKERS_TOKEN"])
+    @request.headers["HTTP_AUTHORIZATION"] = header_token
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/shared/language_not_moved_to_iron_worker.rb
+++ b/spec/support/shared/language_not_moved_to_iron_worker.rb
@@ -2,26 +2,22 @@ shared_examples "Language not moved to IronWorker" do
   describe "#run" do
     it "sends violations to hound" do
       build_worker = create(:build_worker)
-      repo_config = double("RepoConfig")
-      allow(repo_config).to receive(:for).with(language).and_return({})
       pull_request = double("PullRequest", repository_owner_name: "foo")
-      build_worker_url = ENV["BUILD_WORKERS_URL"]
-      connection = double("Connection", post: true)
-      allow(Faraday).to receive(:new).with(url: build_worker_url).
-        and_return(connection)
+      faraday_request = stub_faraday
       worker = described_class.new(
         build_worker,
         pull_request_file,
-        repo_config,
+        stub_repo_config,
         pull_request
       )
 
       worker.run
 
-      expect(Faraday).to have_received(:new).with(url: build_worker_url)
-      expect(connection).to have_received(:post).with(
-        "/",
-        body: {
+      expect(Faraday).to have_received(:post)
+      expect(faraday_request).to have_received(:url=).with(ENV["BUILD_WORKERS_URL"])
+      expect(faraday_request).to have_received(:token_auth).with(ENV.fetch("BUILD_WORKERS_TOKEN"))
+      expect(faraday_request).to have_received(:body=).with(
+        {
           build_worker_id: build_worker.id,
           build_id: build_worker.build_id,
           violations: violations,
@@ -46,5 +42,22 @@ shared_examples "Language not moved to IronWorker" do
         messages: messages,
       }
     ]
+  end
+
+  def stub_faraday
+    faraday_request = double("FaradayRequest")
+    allow(faraday_request).to receive(:url=)
+    allow(faraday_request).to receive(:token_auth)
+    allow(faraday_request).to receive(:body=)
+    allow(Faraday).to receive(:post).and_yield(faraday_request)
+
+    faraday_request
+  end
+
+  def stub_repo_config
+    repo_config = double("RepoConfig")
+    allow(repo_config).to receive(:for).with(language).and_return({})
+
+    repo_config
   end
 end

--- a/spec/support/shared/language_not_moved_to_iron_worker.rb
+++ b/spec/support/shared/language_not_moved_to_iron_worker.rb
@@ -14,8 +14,10 @@ shared_examples "Language not moved to IronWorker" do
       worker.run
 
       expect(Faraday).to have_received(:post)
-      expect(faraday_request).to have_received(:url=).with(ENV["BUILD_WORKERS_URL"])
-      expect(faraday_request).to have_received(:token_auth).with(ENV.fetch("BUILD_WORKERS_TOKEN"))
+      expect(faraday_request).
+        to have_received(:url=).with(ENV["BUILD_WORKERS_URL"])
+      expect(faraday_request).
+        to have_received(:token_auth).with(ENV.fetch("BUILD_WORKERS_TOKEN"))
       expect(faraday_request).to have_received(:body=).with(
         {
           build_worker_id: build_worker.id,

--- a/spec/workers/language_worker/scss_spec.rb
+++ b/spec/workers/language_worker/scss_spec.rb
@@ -17,7 +17,8 @@ module LanguageWorker
         worker.run
 
         expect(Faraday).to have_received(:post)
-        expect(faraday_request).to have_received(:url=).with(ENV["SCSS_WORKER_URL"])
+        expect(faraday_request).
+          to have_received(:url=).with(ENV["SCSS_WORKER_URL"])
         expect(faraday_request).to have_received(:body=).with(
           {
             build_worker_id: build_worker.id,


### PR DESCRIPTION
We are going to send a token with payload to workers and workers will be sending back that token in headers so we can verify calls.