### PR TITLE
Exclude spec directory when checking for long methods

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -508,6 +508,8 @@ Metrics/MethodLength:
   Enabled: true
   CountComments: true
   Max: 10
+  Exclude:
+  - "spec/**/*"
 Metrics/ParameterLists:
   Description: Avoid long parameter lists.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#too-many-params


### PR DESCRIPTION
@gylaz, this should work, right?