### PR TITLE
Include violation count in GitHub status message

### DIFF
--- a/app/models/violation.rb
+++ b/app/models/violation.rb
@@ -9,6 +9,8 @@ class Violation < ActiveRecord::Base
 
   attr_writer :line
 
+  delegate :count, to: :messages, prefix: true
+
   def add_messages(new_messages)
     self[:messages].concat(new_messages)
   end

--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -89,7 +89,7 @@ class BuildRunner
     github.create_success_status(
       payload.full_repo_name,
       payload.head_sha,
-      I18n.t(:success_status)
+      I18n.t(:success_status, count: violation_count)
     )
   end
 
@@ -117,5 +117,9 @@ class BuildRunner
 
   def configuration_url
     Rails.application.routes.url_helpers.configuration_url(host: ENV["HOST"])
+  end
+
+  def violation_count
+    violations.sum(&:messages_count)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,10 @@ en:
   active_repos: "Active repos"
   search_placeholder: "Search by repo"
   pending_status: "Hound is busy reviewing changes..."
-  success_status: "Hound has reviewed all the changes!"
+  success_status:
+    zero: "No violations found. Woof!"
+    one: "1 violation found."
+    other: "%{count} violations found."
   config_error_status:
     "Error parsing your config file. Click \"details\" for
     assistance."

--- a/spec/models/violation_spec.rb
+++ b/spec/models/violation_spec.rb
@@ -41,4 +41,12 @@ describe Violation do
       expect(changed).to eq false
     end
   end
+
+  describe "#messages_count" do
+    it "returns the number of violation messages" do
+      violation = build(:violation, messages: ["foo", "bar"])
+
+      expect(violation.messages_count).to eq 2
+    end
+  end
 end

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -96,7 +96,11 @@ describe BuildRunner, '#run' do
       )
       build_runner = BuildRunner.new(payload)
       stubbed_pull_request
-      stubbed_style_checker_with_violations
+      violations = [
+        build(:violation),
+        build(:violation, messages: ["wrong", "bad"]),
+      ]
+      stubbed_style_checker(violations: violations)
       stubbed_commenter
       github_api = stubbed_github_api
 
@@ -110,7 +114,7 @@ describe BuildRunner, '#run' do
       expect(github_api).to have_received(:create_success_status).with(
         "test/repo",
         "headsha",
-        "Hound has reviewed all the changes!"
+        "3 violations found."
       )
     end
 

--- a/spec/support/helpers/github_api_helper.rb
+++ b/spec/support/helpers/github_api_helper.rb
@@ -431,7 +431,7 @@ module GithubApiHelper
       repo_name,
       sha,
       "success",
-      "Hound has reviewed all the changes!"
+      anything
     )
   end
 


### PR DESCRIPTION
* Treats multiple messages on a line as separate violations.
* The status message will be overwritten when new commits are pushed to
  the PR.
* Updates feature spec stubbing to not care what message is passed.

https://trello.com/c/oCqXJB1V

![yep_by_thorncp_ _pull_request__22_ _thornco_dumb-ruby](https://cloud.githubusercontent.com/assets/72176/6955345/01634722-d891-11e4-81c4-75dc0b136a3d.png)
<hr>
![yep_by_thorncp_ _pull_request__22_ _thornco_dumb-ruby](https://cloud.githubusercontent.com/assets/72176/6955351/1e523b7c-d891-11e4-9e01-92de002ea789.png)
<hr>
![yep_by_thorncp_ _pull_request__23_ _thornco_dumb-ruby](https://cloud.githubusercontent.com/assets/72176/6968727/b8c992ae-d91d-11e4-8b1e-690f7192a588.png)

