### PR TITLE
Use absolute file paths to fix excluding

### DIFF
--- a/app/models/style_guide/ruby.rb
+++ b/app/models/style_guide/ruby.rb
@@ -28,7 +28,8 @@ module StyleGuide
     end
 
     def parsed_source(file)
-      RuboCop::ProcessedSource.new(file.content, file.filename)
+      absolute_filepath = File.expand_path(file.filename)
+      RuboCop::ProcessedSource.new(file.content, absolute_filepath)
     end
 
     def config

--- a/spec/models/style_guide/ruby_spec.rb
+++ b/spec/models/style_guide/ruby_spec.rb
@@ -442,11 +442,11 @@ end
       end
     end
 
-    context "with excluded files" do
-      it "has no violations" do
+    context "with Exclude option" do
+      it "excludes the file" do
         config = {
           "AllCops" => {
-            "Exclude" => ["lib/a.rb"]
+            "Exclude" => ["app/models/user.rb"]
           }
         }
 
@@ -461,7 +461,7 @@ end
             "EnforcedStyle" => "single_quotes"
           },
           "HashSyntax" => {
-            "Exclude" => ["lib/**/*"]
+            "Exclude" => ["app/models/*"]
           }
         }
 
@@ -471,6 +471,28 @@ end
           "Prefer single-quoted strings when you don't need string "\
           "interpolation or special symbols."
         ]
+      end
+
+      it "ignores rules for excluded directories" do
+        code = <<-TEXT
+          def test_method
+            [1, 2, 3, nil, 3, 1].
+              uniq.
+              compact
+          end
+        TEXT
+
+        config = {
+          "Metrics/MethodLength" => {
+            "Enabled" => true,
+            "Max" => 2,
+            "Exclude" => ["app/**/*"],
+          },
+        }
+
+        violations = violations_in(code, config: config)
+
+        expect(violations).to eq []
       end
     end
 
@@ -612,7 +634,7 @@ hoge
 
   def build_file(content)
     line = double("Line", content: "blah", number: 1, patch_position: 2)
-    filename = Rails.root.join("lib/a.rb")
+    filename = "app/models/user.rb"
     double("CommitFile", content: content, line_at: line, filename: filename)
   end
 


### PR DESCRIPTION
We call `make_excludes_absolute` on the configuration
to satisfy RuboCop's `file_to_exclude?` since it calls `File.expand_path`
on the filename that we pass it.
Thus, all of our `Exclude` paths for individual cops get expanded to absolute as
well. We need to call `File.expand_path` on the filename in order for the two
paths to match.

This is kind of silly, since GitHub does not give us absolute paths, so we
should be fine with just the relative paths (relative to project root),
because they would match what the user puts in their config.

Basically, all of this (plus `make_excludes_absolute`) is because of
`file_to_exclude?`.