### PR TITLE
Lint `coffee.erb`

### DIFF
--- a/app/models/style_checker.rb
+++ b/app/models/style_checker.rb
@@ -40,7 +40,7 @@ class StyleChecker
     case filename
     when /.+\.rb\z/
       StyleGuide::Ruby
-    when /.+\.coffee(\.js)?\z/
+    when /.+\.coffee(\.js)?(\.erb)?\z/
       StyleGuide::CoffeeScript
     when /.+\.js\z/
       StyleGuide::JavaScript

--- a/app/models/style_guide/coffee_script.rb
+++ b/app/models/style_guide/coffee_script.rb
@@ -2,9 +2,11 @@
 module StyleGuide
   class CoffeeScript < Base
     DEFAULT_CONFIG_FILENAME = "coffeescript.json"
+    ERB_TAGS = /<%.*%>/
 
     def violations_in_file(file)
-      Coffeelint.lint(file.content, config).map do |violation|
+      content = content_for_file(file)
+      lint(content).map do |violation|
         line = file.line_at(violation["lineNumber"])
 
         Violation.new(
@@ -18,6 +20,22 @@ module StyleGuide
     end
 
     private
+
+    def lint(content)
+      Coffeelint.lint(content, config)
+    end
+
+    def content_for_file(file)
+      if erb? file
+        file.content.gsub(ERB_TAGS, "123")
+      else
+        file.content
+      end
+    end
+
+    def erb?(file)
+      file.filename.ends_with? ".erb"
+    end
 
     def config
       default_config.merge(repo_config.for(name))

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -68,6 +68,18 @@ describe StyleChecker, "#violations" do
       expect(messages).to eq ["Empty function"]
     end
 
+    it "is processed with a coffee.erb extension" do
+      file = stub_commit_file("test.coffee.erb", "class strange_ClassNAME")
+      pull_request = stub_pull_request(pull_request_files: [file])
+      style_checker = StyleChecker.new(pull_request)
+      allow(RepoConfig).to receive(:new).and_return(stub_repo_config)
+
+      violations = style_checker.violations
+      messages = violations.flat_map(&:messages)
+
+      expect(messages).to eq ["Class names should be camel cased"]
+    end
+
     context "with style violations" do
       it "returns violations" do
         file = stub_commit_file("test.coffee", "foo: ->")

--- a/spec/models/style_guide/coffee_script_spec.rb
+++ b/spec/models/style_guide/coffee_script_spec.rb
@@ -130,6 +130,47 @@ describe StyleGuide::CoffeeScript do
       end
     end
 
+    context "given a `coffee.erb` file" do
+      it "lints the file" do
+        repo_config = double("RepoConfig", enabled_for?: true, for: {})
+        style_guide = StyleGuide::CoffeeScript.new(repo_config, "Ralph")
+        line = double("Line", content: "blah", number: 1, patch_position: 2)
+        file = double(
+          "File",
+          content: "class strange_ClassNAME",
+          filename: "test.coffee.erb",
+          line_at: line
+        )
+
+        violations = style_guide.violations_in_file(file)
+        violation = violations.first
+
+        expect(violations.size).to eq 1
+        expect(violation.filename).to eq "test.coffee.erb"
+        expect(violation.patch_position).to eq line.patch_position
+        expect(violation.line_number).to eq 1
+        expect(violation.messages).to match_array(
+          ["Class names should be camel cased"]
+        )
+      end
+
+      it "removes the ERB tags from the file" do
+        repo_config = double("RepoConfig", enabled_for?: true, for: {})
+        style_guide = StyleGuide::CoffeeScript.new(repo_config, "Ralph")
+        line = double("Line", content: "blah", number: 1, patch_position: 2)
+        file = double(
+          "File",
+          content: "leonidasLastWords = <%= raise 'hell' %>",
+          filename: "test.coffee.erb",
+          line_at: line,
+        )
+
+        violations = style_guide.violations_in_file(file)
+
+        expect(violations).to be_empty
+      end
+    end
+
     private
 
     def violations_in(content, repository_owner_name: "ralph")


### PR DESCRIPTION
To avoid eval-ing `erb` tags, due to security reasons, we could instead
replace it the tag with a dummy value. I picked an emtpy string since
that seemed the easier way of solving it.

Thoughts?