### PR TITLE
Wrap repo sync inserts in a transaction

### DIFF
--- a/app/services/repo_synchronization.rb
+++ b/app/services/repo_synchronization.rb
@@ -4,10 +4,13 @@ class RepoSynchronization
 
   def start
     user.repos.clear
+    repos = api.repos
 
-    api.repos.each do |resource|
-      attributes = repo_attributes(resource.to_hash)
-      user.repos << Repo.find_or_create_with(attributes)
+    Repo.transaction do
+      repos.each do |resource|
+        attributes = repo_attributes(resource.to_hash)
+        user.repos << Repo.find_or_create_with(attributes)
+      end
     end
   end
 


### PR DESCRIPTION
This wraps the loop in `RepoSynchronization#start` in a transaction. This way
all the `INSERT`s will happen together or not at all, which should lead to more
consistent repo syncs.