### PR TITLE
Set StyleGuide::CoffeeScript#name

### DIFF
--- a/app/models/style_guide/coffee_script.rb
+++ b/app/models/style_guide/coffee_script.rb
@@ -34,5 +34,9 @@ module StyleGuide
         repository_owner_name
       ).path
     end
+
+    def name
+      "coffeescript"
+    end
   end
 end

--- a/spec/models/style_guide/coffee_script_spec.rb
+++ b/spec/models/style_guide/coffee_script_spec.rb
@@ -3,6 +3,34 @@ require "rails_helper"
 describe StyleGuide::CoffeeScript do
   include ConfigurationHelper
 
+  describe "enabled?" do
+    context "with legacy coffee_script key" do
+      it "is not enabled" do
+        commit = double("Commit", file_content: <<-EOS.strip_heredoc)
+          coffee_script:
+            enabled: false
+        EOS
+        repo_config = RepoConfig.new(commit)
+        style_guide = StyleGuide::CoffeeScript.new(repo_config, "RalphJoe")
+
+        expect(style_guide).not_to be_enabled
+      end
+    end
+
+    context "with coffeescript key" do
+      it "is not enabled" do
+        commit = double("Commit", file_content: <<-EOS.strip_heredoc)
+          coffeescript:
+            enabled: false
+        EOS
+        repo_config = RepoConfig.new(commit)
+        style_guide = StyleGuide::CoffeeScript.new(repo_config, "RalphJoe")
+
+        expect(style_guide).not_to be_enabled
+      end
+    end
+  end
+
   describe "#violations_in_file" do
     context "with default configuration" do
       context "for long line" do


### PR DESCRIPTION
This PR is a follow up to
https://github.com/thoughtbot/hound/commit/6cec20ad0cb47ce807e631ede531efd3f39ba067
and fixes an issue where the new `coffeescript` would not be picked up.