### PR TITLE
Refactor display_onboarding? query

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,9 @@ module ApplicationHelper
   end
 
   def display_onboarding?
-    current_user.repos.select { |repo| repo.builds.any? }.empty?
+    Build.
+      joins(repo: :memberships).
+      where(memberships: { user_id: current_user.id }).
+      empty?
   end
 end


### PR DESCRIPTION
There was an N+1 query firing whern we checked if a `user` has had a previous
`build` (used to determine if we should display onboarding copy).

This change refactors the check to a single query. It may make sense later to
move this query elsewhere entirely.

Fixes
https://trello.com/c/axeF15jZ/566-investigate-n-1-query-on-builds-in-web-process