### PR TITLE
Return an existing subscription during activation

### DIFF
--- a/app/services/repo_subscriber.rb
+++ b/app/services/repo_subscriber.rb
@@ -10,26 +10,7 @@ class RepoSubscriber
   end
 
   def subscribe
-    customer = if user.stripe_customer_id.present?
-      payment_gateway_customer
-    else
-      create_stripe_customer
-    end
-
-    stripe_subscription = customer.subscriptions.create(
-      plan: repo.plan_type,
-      metadata: { repo_id: repo.id }
-    )
-
-    repo.create_subscription!(
-      user_id: user.id,
-      stripe_subscription_id: stripe_subscription.id,
-      price: repo.plan_price
-    )
-  rescue => error
-    report_exception(error)
-    stripe_subscription.try(:delete)
-    nil
+    repo.subscription || create_subscription
   end
 
   def unsubscribe
@@ -46,11 +27,32 @@ class RepoSubscriber
 
   private
 
+  def create_subscription
+    stripe_subscription = stripe_customer.subscriptions.create(
+      plan: repo.plan_type,
+      metadata: { repo_id: repo.id }
+    )
+
+    create_subscription_record(stripe_subscription.id)
+  rescue => error
+    report_exception(error)
+    stripe_subscription.try(:delete)
+    nil
+  end
+
   def report_exception(error)
     Raven.capture_exception(
       error,
       extra: { user_id: user.id, repo_id: repo.id }
     )
+  end
+
+  def stripe_customer
+    if user.stripe_customer_id.present?
+      payment_gateway_customer
+    else
+      create_stripe_customer
+    end
   end
 
   def payment_gateway_customer
@@ -67,5 +69,13 @@ class RepoSubscriber
     user.update(stripe_customer_id: stripe_customer.id)
 
     stripe_customer
+  end
+
+  def create_subscription_record(stripe_subscription_id)
+    repo.create_subscription!(
+      user_id: user.id,
+      stripe_subscription_id: stripe_subscription_id,
+      price: repo.plan_price
+    )
   end
 end

--- a/spec/services/repo_subscriber_spec.rb
+++ b/spec/services/repo_subscriber_spec.rb
@@ -82,6 +82,22 @@ describe RepoSubscriber do
         expect(stripe_delete_request).to have_been_requested
       end
     end
+
+    context "when repo already has a subscription" do
+      context "and it is not marked as deleted" do
+        it "returns the existing subscription" do
+          subscription = create(:subscription)
+
+          result = RepoSubscriber.subscribe(
+            subscription.repo,
+            subscription.user,
+            "cardtoken"
+          )
+
+          expect(result).to eq subscription
+        end
+      end
+    end
   end
 
   describe ".unsubscribe" do


### PR DESCRIPTION
We've recently encountered a situation where we believe the customer had
a subscription, but was attempting to activate again -- this can also be
caused by duplicate, simultaneous requests for the same user.

There is not reason to not return the existing subscription, if it
exists and avoid charging the user again via Stripe.