### PR TITLE
Update capybara-webkit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ end
 
 group :test do
   gem "capybara", "~> 2.4.0"
-  gem "capybara-webkit"
+  gem "capybara-webkit", "~> 1.5.1"
   gem "database_cleaner"
   gem "factory_girl_rails"
   gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,8 +61,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.3.0)
-      capybara (>= 2.0.2, < 2.5.0)
+    capybara-webkit (1.5.1)
+      capybara (>= 2.3.0, < 2.5.0)
       json
     cliver (0.3.2)
     coffee-rails (4.0.1)
@@ -345,7 +345,7 @@ DEPENDENCIES
   bourbon
   byebug
   capybara (~> 2.4.0)
-  capybara-webkit
+  capybara-webkit (~> 1.5.1)
   coffee-rails
   coffeelint
   database_cleaner

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,10 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
+  config.before(:each, js: true) do
+    page.driver.block_unknown_urls
+  end
+
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
   config.include AnalyticsHelper


### PR DESCRIPTION
In some situations, JavaScript tests were displaying native alert
dialogs and crashing. This is now fixed in capybara-webkit.

Also blocks remote URLs to prevent warnings and slow tests.

Fixes #403.