### PR TITLE
Only return current pull request files

### DIFF
--- a/app/models/commit_file.rb
+++ b/app/models/commit_file.rb
@@ -6,15 +6,7 @@ class CommitFile
   end
 
   def content
-    @content ||= begin
-      unless removed?
-        commit.file_content(filename)
-      end
-    end
-  end
-
-  def removed?
-    file.status == "removed"
+    @content ||= commit.file_content(filename)
   end
 
   def line_at(line_number)

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -1,14 +1,14 @@
 class PullRequest
   pattr_initialize :payload, :token
 
+  FILE_REMOVED_STATUS = "removed"
+
   def comments
     @comments ||= user_github.pull_request_comments(full_repo_name, number)
   end
 
   def pull_request_files
-    @pull_request_files ||= user_github.
-      pull_request_files(full_repo_name, number).
-      map { |file| build_commit_file(file) }
+    @pull_request_files ||= changed_pull_request_files
   end
 
   def comment_on_violation(violation)
@@ -41,6 +41,13 @@ class PullRequest
 
   def build_commit_file(file)
     CommitFile.new(file, head_commit)
+  end
+
+  def changed_pull_request_files
+    user_github.
+      pull_request_files(full_repo_name, number).
+      reject { |file| file.status == FILE_REMOVED_STATUS }.
+      map { |file| build_commit_file(file) }
   end
 
   def user_github

--- a/app/models/style_checker.rb
+++ b/app/models/style_checker.rb
@@ -22,7 +22,7 @@ class StyleChecker
   end
 
   def files_to_check
-    pull_request.pull_request_files.reject(&:removed?).select do |file|
+    pull_request.pull_request_files.select do |file|
       file_style_guide = style_guide(file.filename)
       file_style_guide.enabled? && file_style_guide.file_included?(file)
     end

--- a/spec/models/commit_file_spec.rb
+++ b/spec/models/commit_file_spec.rb
@@ -6,24 +6,6 @@ require "app/models/patch"
 require "app/models/unchanged_line"
 
 describe CommitFile do
-  describe "#removed?" do
-    context "when status is removed" do
-      it "returns true" do
-        commit_file = commit_file(status: "removed")
-
-        expect(commit_file).to be_removed
-      end
-    end
-
-    context "when status is added" do
-      it "returns false" do
-        commit_file = commit_file(status: "added")
-
-        expect(commit_file).not_to be_removed
-      end
-    end
-  end
-
   describe "#line_at" do
     context "with a changed line" do
       it "returns a line at the given line number" do
@@ -47,20 +29,10 @@ describe CommitFile do
   end
 
   describe "#content" do
-    context "when file is removed" do
-      it "returns nil" do
-        commit_file = commit_file(status: "removed")
+    it "returns content string" do
+      commit_file = commit_file(status: "modified")
 
-        expect(commit_file.content).to eq nil
-      end
-    end
-
-    context "when file is modified" do
-      it "returns content string" do
-        commit_file = commit_file(status: "modified")
-
-        expect(commit_file.content).to eq "some content"
-      end
+      expect(commit_file.content).to eq "some content"
     end
   end
 

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 require "app/models/pull_request"
 require "app/models/commit"
 require "lib/github_api"
@@ -76,6 +76,24 @@ describe PullRequest do
         comment: violation.messages.first,
         filename: violation.filename,
         patch_position: violation.patch_position,
+      )
+    end
+  end
+
+  describe "#pull_request_files" do
+    it "does not include removed files" do
+      added_file = double(filename: "foo.rb", status: "added")
+      modified_file = double(filename: "baz.rb", status: "modified")
+      removed_file = double(filename: "bar.rb", status: "removed")
+      all_pull_request_files = [added_file, removed_file, modified_file]
+      github = double(:github, pull_request_files: all_pull_request_files)
+      pull_request = pull_request_stub(github)
+
+      files = pull_request.pull_request_files
+      file_names = files.map(&:filename)
+
+      expect(file_names).to match_array(
+        [added_file.filename, modified_file.filename]
       )
     end
   end

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -198,18 +198,6 @@ describe StyleChecker, "#violations" do
     end
   end
 
-  context "a removed file" do
-    it "does not return a violation for the file" do
-      file = stub_commit_file("ruby.rb", "puts 123    ", removed: true)
-      pull_request = stub_pull_request(pull_request_files: [file])
-
-      violations = StyleChecker.new(pull_request).violations
-      messages = violations.flat_map(&:messages)
-
-      expect(messages).to eq []
-    end
-  end
-
   private
 
   def stub_pull_request(options = {})
@@ -224,14 +212,13 @@ describe StyleChecker, "#violations" do
     double("PullRequest", defaults.merge(options))
   end
 
-  def stub_commit_file(filename, contents, line = nil, removed: false)
+  def stub_commit_file(filename, contents, line = nil)
     line ||= Line.new(content: "foo", number: 1, patch_position: 2)
     formatted_contents = "#{contents}\n"
     double(
       filename.split(".").first,
       filename: filename,
       content: formatted_contents,
-      removed?: removed,
       line_at: line,
     )
   end


### PR DESCRIPTION
`PullRequest#pull_request_files` now only returns the *current* files of a pull request. Previously it would return files that had been removed, and left the responsibility of not operating on them up to other parts of the application.

This is the first step in an attempt to split up #727 into smaller chunks that can be reviewed more thoroughly. I started with this small change so I could get people's thoughts on this approach to try to determine if splitting it up is worth pursuing.