### PR TITLE
Introduce FileReview model

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -1,5 +1,6 @@
 class Build < ActiveRecord::Base
   belongs_to :repo
+  has_many :file_reviews, dependent: :destroy
   has_many :violations, dependent: :destroy
 
   before_create :generate_uuid

--- a/app/models/file_review.rb
+++ b/app/models/file_review.rb
@@ -1,0 +1,13 @@
+class FileReview < ActiveRecord::Base
+  belongs_to :build
+
+  validates :build, presence: :true
+
+  def completed?
+    completed_at?
+  end
+
+  def running?
+    !completed?
+  end
+end

--- a/db/migrate/20150425204143_create_file_reviews.rb
+++ b/db/migrate/20150425204143_create_file_reviews.rb
@@ -1,0 +1,10 @@
+class CreateFileReviews < ActiveRecord::Migration
+  def change
+    create_table :file_reviews do |t|
+      t.belongs_to :build, index: true, foreign_key: true, null: false
+      t.datetime :completed_at
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150306184045) do
+ActiveRecord::Schema.define(version: 20150425204143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,15 @@ ActiveRecord::Schema.define(version: 20150306184045) do
 
   add_index "builds", ["repo_id"], name: "index_builds_on_repo_id", using: :btree
   add_index "builds", ["uuid"], name: "index_builds_on_uuid", unique: true, using: :btree
+
+  create_table "file_reviews", force: :cascade do |t|
+    t.integer  "build_id",     null: false
+    t.datetime "completed_at"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
+  add_index "file_reviews", ["build_id"], name: "index_file_reviews_on_build_id", using: :btree
 
   create_table "memberships", force: :cascade do |t|
     t.integer  "user_id",    null: false
@@ -115,6 +124,7 @@ ActiveRecord::Schema.define(version: 20150306184045) do
 
   add_index "violations", ["build_id"], name: "index_violations_on_build_id", using: :btree
 
+  add_foreign_key "file_reviews", "builds"
   add_foreign_key "memberships", "repos"
   add_foreign_key "memberships", "users"
   add_foreign_key "repos", "owners"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -10,6 +10,14 @@ FactoryGirl.define do
     end
   end
 
+  factory :file_review do
+    build
+
+    trait :completed do
+      completed_at Time.zone.now
+    end
+  end
+
   factory :repo do
     trait(:active) { active true }
     trait(:inactive) { active false }

--- a/spec/models/build_spec.rb
+++ b/spec/models/build_spec.rb
@@ -1,9 +1,15 @@
 require "rails_helper"
 
 describe Build do
-  it { should belong_to :repo }
-  it { should validate_presence_of :repo }
-  it { should have_many(:violations).dependent(:destroy) }
+  describe "associations" do
+    it { should belong_to :repo }
+    it { should have_many(:file_reviews).dependent(:destroy) }
+    it { should have_many(:violations).dependent(:destroy) }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of :repo }
+  end
 end
 
 describe Build, '#status' do

--- a/spec/models/file_review_spec.rb
+++ b/spec/models/file_review_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe FileReview do
+  describe "associations" do
+    it { should belong_to :build }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of :build }
+  end
+
+  describe "#completed?" do
+    it "returns true when completed_at is set" do
+      file_review = FileReview.new(completed_at: Time.zone.now)
+
+      expect(file_review).to be_completed
+    end
+
+    it "returns false when completed_at is nil" do
+      file_review = FileReview.new
+
+      expect(file_review).not_to be_completed
+    end
+  end
+
+  describe "#running?" do
+    it "returns true when complete_at is set" do
+      file_review = FileReview.new(completed_at: Time.zone.now)
+
+      expect(file_review).not_to be_running
+    end
+
+    it "returns false when completed_at is nil" do
+      file_review = FileReview.new(completed_at: nil)
+
+      expect(file_review).to be_running
+    end
+  end
+end


### PR DESCRIPTION
This model will represent the progress of a file review, particularly those done by an external system, e.g. IronWorker.

This is another extraction of a small chunk of functionality from #727. It went under the name `BuildWorker` in that PR.