### PR TITLE
Update SCSSLint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem "resque-scheduler"
 gem "resque-sentry"
 gem "rubocop", "0.29.1"
 gem "sass-rails"
-gem "scss-lint", "0.34.0", require: false
+gem "scss-lint", "0.37.0", require: false
 gem "sentry-raven"
 gem "split", require: "split/dashboard"
 gem "stripe"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,7 @@ GEM
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
-    scss-lint (0.34.0)
+    scss-lint (0.37.0)
       rainbow (~> 2.0)
       sass (~> 3.4.1)
     sentry-raven (0.9.4)
@@ -382,7 +382,7 @@ DEPENDENCIES
   rspec-rails (>= 3.2)
   rubocop (= 0.29.1)
   sass-rails
-  scss-lint (= 0.34.0)
+  scss-lint (= 0.37.0)
   sentry-raven
   shoulda-matchers
   split

--- a/app/models/style_guide/scss.rb
+++ b/app/models/style_guide/scss.rb
@@ -4,12 +4,13 @@ module StyleGuide
 
     def violations_in_file(file)
       require "scss_lint"
+      tempfile = create_tempfile(file)
 
       if config.excluded_file?(file.filename)
         []
       else
         runner = build_runner
-        runner.run([file.content])
+        runner.run([tempfile.path])
 
         runner.lints.map do |violation|
           line = file.line_at(violation.location.line)
@@ -23,12 +24,21 @@ module StyleGuide
           )
         end
       end
+    ensure
+      tempfile.close
     end
 
     private
 
     def build_runner
       SCSSLint::Runner.new(config)
+    end
+
+    def create_tempfile(file)
+      Tempfile.create("").tap do |tempfile|
+        tempfile.write(file.content)
+        tempfile.rewind
+      end
     end
 
     def config

--- a/config/style_guides/scss.yml
+++ b/config/style_guides/scss.yml
@@ -72,6 +72,19 @@ linters:
     enabled: true
     include_nested: false
     max_properties: 10
+  PropertyUnits:
+    enabled: true
+    global: [
+      'ch', 'em', 'ex', 'rem',                 # Font-relative lengths
+      'cm', 'in', 'mm', 'pc', 'pt', 'px', 'q', # Absolute lengths
+      'vh', 'vw', 'vmin', 'vmax',              # Viewport-percentage lengths
+      'deg', 'grad', 'rad', 'turn',            # Angle
+      'ms', 's',                               # Duration
+      'Hz', 'kHz',                             # Frequency
+      'dpi', 'dpcm', 'dppx',                   # Resolution
+      '%',                                     # Other
+    ]
+    properties: {}
   PropertySortOrder:
     enabled: true
     ignore_unspecified: false
@@ -96,6 +109,7 @@ linters:
   Shorthand:
     enabled: true
     severity: warning
+    allowed_shorthands: [1, 2, 3]
   SingleLinePerProperty:
     enabled: true
     allow_single_line_rule_sets: true
@@ -133,13 +147,15 @@ linters:
   VariableForProperty:
     enabled: false
     properties: []
-  VendorPrefixes:
+  VendorPrefix:
     enabled: true
     identifier_list: bourbon
     include: []
     exclude: []
+    additional_identifiers: []
+    excluded_identifiers: []
   ZeroUnit:
     enabled: true
     severity: warning
-  Compass::PropertyWithMixin:
+  Compass::*:
     enabled: false

--- a/config/style_guides/thoughtbot/scss.yml
+++ b/config/style_guides/thoughtbot/scss.yml
@@ -69,7 +69,7 @@ linters:
   PlaceholderInExtend:
     enabled: false
   PropertyCount:
-    enabled: true
+    enabled: false
     include_nested: false
     max_properties: 10
   PropertyUnits:

--- a/config/style_guides/thoughtbot/scss.yml
+++ b/config/style_guides/thoughtbot/scss.yml
@@ -69,7 +69,22 @@ linters:
   PlaceholderInExtend:
     enabled: false
   PropertyCount:
-    enabled: false
+    enabled: true
+    include_nested: false
+    max_properties: 10
+  PropertyUnits:
+    enabled: true
+    global: [
+      'ch', 'em', 'ex', 'rem',                 # Font-relative lengths
+      'cm', 'in', 'mm', 'pc', 'pt', 'px', 'q', # Absolute lengths
+      'vh', 'vw', 'vmin', 'vmax',              # Viewport-percentage lengths
+      'deg', 'grad', 'rad', 'turn',            # Angle
+      'ms', 's',                               # Duration
+      'Hz', 'kHz',                             # Frequency
+      'dpi', 'dpcm', 'dppx',                   # Resolution
+      '%',                                     # Other
+    ]
+    properties: {}
   PropertySortOrder:
     enabled: true
     ignore_unspecified: false
@@ -94,6 +109,7 @@ linters:
   Shorthand:
     enabled: true
     severity: warning
+    allowed_shorthands: [1, 2, 3]
   SingleLinePerProperty:
     enabled: true
     allow_single_line_rule_sets: true
@@ -131,13 +147,15 @@ linters:
   VariableForProperty:
     enabled: false
     properties: []
-  VendorPrefixes:
+  VendorPrefix:
     enabled: true
     identifier_list: bourbon
     include: []
     exclude: []
+    additional_identifiers: []
+    excluded_identifiers: []
   ZeroUnit:
     enabled: true
     severity: warning
-  Compass::PropertyWithMixin:
+  Compass::*:
     enabled: false


### PR DESCRIPTION
- Update SCSS config
- Due to a change in `0.35.0`, we have to support create an actual file
  for each file we want to lint. This is being handled by creating a
  tempfile and then unlinking it after each run