### PR TITLE
Handle single (non-array) SCSS excludes

### DIFF
--- a/spec/models/style_guide/scss_spec.rb
+++ b/spec/models/style_guide/scss_spec.rb
@@ -35,7 +35,7 @@ describe StyleGuide::Scss do
     end
 
     context "with custom configuration" do
-      describe "for single quotes" do
+      context "for single quotes" do
         it "returns no violation" do
           content = ".a { display: 'none'; }\n"
           config = {
@@ -50,7 +50,7 @@ describe StyleGuide::Scss do
         end
       end
 
-      describe "for no leading zeros" do
+      context "for no leading zeros" do
         it "returns no violation" do
           content = ".a { margin: .5em; }\n"
           config = {
@@ -62,6 +62,23 @@ describe StyleGuide::Scss do
           }
 
           expect(violations_in(content, config)).to eq []
+        end
+      end
+
+      context "when exclude is provided as string" do
+        it "does not error" do
+          content = ".a { margin: .5em; }\n"
+          config = {
+            "linters" => {
+              "LeadingZero" => {
+                "exclude" => "lib/**",
+              }
+            }
+          }
+
+          expect(violations_in(content, config)).to eq [
+            "`.5` should be written with a leading zero as `0.5`"
+          ]
         end
       end
     end


### PR DESCRIPTION
Users can provide excludes for SCSS linters as an array:

    exclude:
      - lib/**
      - spec/assets/**

or as a string:

    exclude: spec/assets/**

We need to run the config hash through SCSSLint's methods to normalize
all of the options. In order to do that, we need to write to a file and
provide a path to that file.

Related error: https://app.getsentry.com/hound-1/production/group/63380345/