### PR TITLE
Extract build finalization to job

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
-    attr_extras (3.1.0)
+    attr_extras (4.4.0)
     bourbon (4.1.0)
       sass (~> 3.3)
       thor

--- a/app/services/build_report.rb
+++ b/app/services/build_report.rb
@@ -1,0 +1,59 @@
+require "attr_extras"
+
+class BuildReport
+  MAX_COMMENTS = ENV.fetch("MAX_COMMENTS").to_i
+
+  def self.run(pull_request, build)
+    new(pull_request, build).run
+  end
+
+  pattr_initialize :pull_request, :build
+
+  def run
+    commenter.comment_on_violations(priority_violations)
+    create_success_status
+    track_subscribed_build_completed
+  end
+
+  private
+
+  def commenter
+    Commenter.new(pull_request)
+  end
+
+  def token
+    ENV.fetch("HOUND_GITHUB_TOKEN")
+  end
+
+  def violations
+    build.violations
+  end
+
+  def priority_violations
+    violations.take(MAX_COMMENTS)
+  end
+
+  def create_success_status
+    github.create_success_status(
+      pull_request.head_commit.repo_name,
+      pull_request.head_commit.sha,
+      I18n.t(:success_status, count: violation_count),
+    )
+  end
+
+  def violation_count
+    violations.map(&:messages_count).sum
+  end
+
+  def github
+    @github ||= GithubApi.new(token)
+  end
+
+  def track_subscribed_build_completed
+    if build.repo.subscription
+      user = build.repo.subscription.user
+      analytics = Analytics.new(user)
+      analytics.track_build_completed(build.repo)
+    end
+  end
+end

--- a/spec/services/build_report_spec.rb
+++ b/spec/services/build_report_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+describe BuildReport do
+  describe ".run" do
+    context "when build has violations" do
+      it "comments a maximum number of times" do
+        stub_const("::BuildReport::MAX_COMMENTS", 1)
+        commenter = stubbed_commenter(comment_on_violations: true)
+        build = create(:build, violations: build_list(:violation, 2))
+        stubbed_github_api
+        pull_request = stubbed_pull_request
+
+        BuildReport.run(pull_request, build)
+
+        expect(commenter).to have_received(:comment_on_violations).
+          with(build.violations.take(BuildReport::MAX_COMMENTS))
+      end
+
+      it "creates GitHub statuses" do
+        repo = create(:repo, full_github_name: "test/repo")
+        build = create(
+          :build,
+          commit_sha: "headsha",
+          repo: repo,
+          violations: [
+            build(:violation, messages: ["wrong", "bad"]),
+          ],
+        )
+        stubbed_commenter
+        github_api = stubbed_github_api
+        pull_request = stubbed_pull_request
+
+        BuildReport.run(pull_request, build)
+
+        expect(github_api).to have_received(:create_success_status).with(
+          "test/repo",
+          "headsha",
+          "2 violations found."
+        )
+      end
+    end
+
+    context "with subscribed private repo and opened pull request" do
+      it "tracks build events" do
+        repo = create(:repo, :active, github_id: 123, private: true)
+        build = create(:build, repo: repo)
+        create(:subscription, repo: repo)
+        stubbed_commenter
+        stubbed_github_api
+        pull_request = stubbed_pull_request
+
+        BuildReport.run(pull_request, build)
+
+        expect(analytics).to have_tracked("Build Completed").
+          for_user(repo.subscription.user).
+          with(properties: { name: repo.full_github_name, private: true })
+      end
+    end
+
+    def stubbed_commenter(options = {})
+      commenter = double(:commenter, options).as_null_object
+      allow(Commenter).to receive(:new).and_return(commenter)
+
+      commenter
+    end
+
+    def stubbed_pull_request
+      head_commit = double(
+        "HeadCommit",
+        sha: "headsha",
+        repo_name: "test/repo",
+      )
+      pull_request = double(
+        :pull_request,
+        pull_request_files: [double(:file)],
+        config: double(:config),
+        opened?: true,
+        head_commit: head_commit,
+      )
+      allow(PullRequest).to receive(:new).and_return(pull_request)
+
+      pull_request
+    end
+
+    def stubbed_github_api
+      github_api = double(
+        "GithubApi",
+        create_pending_status: nil,
+        create_success_status: nil,
+        create_error_status: nil
+      )
+      allow(GithubApi).to receive(:new).and_return(github_api)
+
+      github_api
+    end
+  end
+end


### PR DESCRIPTION
`BuildReportJob` should stand in place of the GitHub interactions in
`Review` in #727 with the plan of using it in the build workers
controller. Also change `Commenter` to accept a `Payload` and create its
own `PullRequest` instance.

Up next will be implementing the `BuildWorkers` controller
that will check for build completion, persist violations, and enqueue
this job.

https://trello.com/c/CdExHIVN