### PR TITLE
Fix add hound to repo specs: when services team exist, add user to team cases

### DIFF
--- a/spec/services/add_hound_to_repo_spec.rb
+++ b/spec/services/add_hound_to_repo_spec.rb
@@ -58,26 +58,48 @@ describe AddHoundToRepo do
 
         context "when Services team exists" do
           it "adds user to existing Services team" do
-            github_team_id = 1001
-            github = build_github(github_team_id: github_team_id)
+            services_team = double(
+              "GithubTeam",
+              id: 222,
+              name: "Services",
+              permission: "push"
+            )
+            github = build_github(github_team_id: services_team.id)
+            allow(github).to receive(:repo_teams).and_return([])
+            allow(github).to receive(:org_teams).and_return([services_team])
+            allow(github).to receive(:add_repo_to_team)
             allow(github).to receive(:add_user_to_team)
+            repo_name = "foo/bar"
 
-            AddHoundToRepo.run("foo/bar", github)
+            AddHoundToRepo.run(repo_name, github)
 
+            expect(github).to have_received(:add_repo_to_team).
+              with(services_team.id, repo_name)
             expect(github).to have_received(:add_user_to_team).
-              with(github_team_id, hound_github_username)
+              with(services_team.id, hound_github_username)
           end
 
           context "when team name is lowercase" do
             it "adds user to the team" do
-              github_team_id = 1001
-              github = build_github(github_team_id: github_team_id)
+              services_team = double(
+                "GithubTeam",
+                id: 222,
+                name: "services",
+                permission: "push"
+              )
+              github = build_github(github_team_id: services_team.id)
+              allow(github).to receive(:repo_teams).and_return([])
+              allow(github).to receive(:org_teams).and_return([services_team])
+              allow(github).to receive(:add_repo_to_team)
               allow(github).to receive(:add_user_to_team)
+              repo_name = "foo/bar"
 
-              AddHoundToRepo.run("foo/bar", github)
+              AddHoundToRepo.run(repo_name, github)
 
+              expect(github).to have_received(:add_repo_to_team).
+                with(services_team.id, repo_name)
               expect(github).to have_received(:add_user_to_team).
-                with(github_team_id, hound_github_username)
+                with(services_team.id, hound_github_username)
             end
           end
         end


### PR DESCRIPTION
Fix the case when services team exists, should add user to existing Services Team.
The fix is to make `team_with_admin_access` be falsy so we can test the logic in
`add_user_and_repo_to_services_team` method.

See relevant code and two inline comments below for why:

```ruby
class AddHoundToRepo < ManageHound
  def run
    if repo.organization
      add_user_to_org
    else
      add_collaborator_to_repo
    end
  end

  def add_user_to_org
    if team_with_admin_access # <= Before this commit, was testing the logic here.
      github.add_user_to_team(team_with_admin_access.id, github_username)
    else
      add_user_and_repo_to_services_team # <= After this commit, test the logic here.
    end
  end

  def add_user_and_repo_to_services_team
    if team = decorated_services_team
      team.add_repo(repo_name)
    else
      team = GithubTeam.new(create_team, github)
    end

    team.add_user(github_username)
  end
end

class ManageHound
  def decorated_services_team
    if find_services_team
      GithubTeam.new(find_services_team, github)
    end
  end
  
  def find_services_team
    @services_team ||= github.org_teams(org_name).detect do |team|
      team.name.downcase == GITHUB_TEAM_NAME.downcase
    end
  end
end  
```