### PR TITLE
Add how to exclude SCSS files in configuration page

### DIFF
--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -186,11 +186,11 @@
               config_file: .scss-style.yml
 
       %p
-        If you would like to ignore certain SCSS files, Add
+        If you would like to ignore certain SCSS files, add
         %em.code exclude:
         to your
         %em.code .scss-style.yml
-        to exclude scss files from being linted
+        to exclude scss files from being linted.
 
         %code.code-block
           :preserve

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -186,6 +186,19 @@
               config_file: .scss-style.yml
 
       %p
+        If you would like to ignore certain SCSS files, Add
+        %em.code exclude:
+        to your
+        %em.code .scss-style.yml
+        to exclude scss files from being linted
+
+        %code.code-block
+          :preserve
+            scss:
+              exclude:
+                - "app/assets/stylesheets/plugins/**"
+
+      %p
         Add the following code to your
         %em.code .hound.yml
         to disable SCSS style checking.


### PR DESCRIPTION
This Pull Request adds how to exclude SCSS files from being linted the SCSS config from Configuration page. New content highlighted with red box in below screenshot:

![screenshot_2015-05-10_11_52_42](https://cloud.githubusercontent.com/assets/1000669/7553014/25761b9c-f70b-11e4-8dcf-848f67da1107.png)

Follow up of https://github.com/thoughtbot/hound/issues/775.