### PR TITLE
Add missing EXEMPT_ORGS env variable

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,5 +1,6 @@
 CHANGED_FILES_THRESHOLD=300
 ENABLE_HTTPS=no
+EXEMPT_ORGS=organisation_name,user_name
 GITHUB_CLIENT_ID=github_client_id
 GITHUB_CLIENT_SECRET=github_client_secret
 HOST=your-initials-hound.ngrok.com


### PR DESCRIPTION
Adds missing EXEMPT_ORGS variable responsible for exempting users or organisations from paying for repo reviews.