### PR TITLE
Adjust the max SelectorDepth in scss lint to 4

### DIFF
--- a/config/style_guides/thoughtbot/scss.yml
+++ b/config/style_guides/thoughtbot/scss.yml
@@ -86,7 +86,7 @@ linters:
     severity: warning
   SelectorDepth:
     enabled: true
-    max_depth: 2
+    max_depth: 4
     severity: warning
   SelectorFormat:
     enabled: true


### PR DESCRIPTION
Our style guide currently includes [the following with regard to selector depth][]:

> Avoid nesting more than 4 selectors deep.
> Don't nest more than 6 selectors deep.

SCSSlint has two seemingly applicable settings, [NestingDepth][] and [SelectorDepth][]. The former is set to 4 in our hound configuration, but the latter is set to 2. My thinking is that this setting (`SelectorDepth`) should also be 4. This is well out of my area of expertise, but I have run into it enough on PRs and would rather not just ignore.

/cc @thoughtbot/design 

[the following with regard to selector depth]: https://github.com/thoughtbot/guides/tree/c3394adfa486ce37bf205a85e8dc1c5dffd6c6da/style/sass#selectors
[NestingDepth]: https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#nestingdepth
[SelectorDepth]: https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#selectordepth