### PR TITLE
Remove unreachable repo from user's repos

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -33,10 +33,6 @@ FactoryGirl.define do
 
   factory :user do
     github_username { generate(:github_name) }
-
-    ignore do
-      repos []
-    end
   end
 
   factory :membership do

--- a/spec/services/repo_subscriber_spec.rb
+++ b/spec/services/repo_subscriber_spec.rb
@@ -56,7 +56,7 @@ describe RepoSubscriber do
 
       it "reports raised exceptions to Sentry" do
         repo = build_stubbed(:repo)
-        user = create(:user, repos: [repo])
+        user = create(:user)
         stub_customer_create_request(user)
         stub_failed_subscription_create_request(repo.plan_type)
         allow(Raven).to receive(:capture_exception)


### PR DESCRIPTION
When a repo cannot be reached with a user's token,
causing a 404 Not Found error,
that means that user has been barred access to it.

By removing the repo from user's associated repos,
the job will be retried with a different user's token,
or fallback to Hound's.

This should fix numerous 404 errors that are causing jobs to fail.