### PR TITLE
Require Bundler >= 1.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 ruby "2.2.2"
 
+gem "bundler", "~> 1.10"
+
 gem "active_model_serializers", "0.8.3"
 gem "analytics-ruby", "~> 2.0.0", require: "segment/analytics"
 gem "angularjs-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,6 +348,7 @@ DEPENDENCIES
   angularjs-rails
   attr_extras
   bourbon
+  bundler (~> 1.10)
   byebug
   capybara (~> 2.4.0)
   capybara-webkit (~> 1.5.1)
@@ -390,3 +391,6 @@ DEPENDENCIES
   uglifier (>= 1.0.3)
   unicorn
   webmock
+
+BUNDLED WITH
+   1.10.2


### PR DESCRIPTION
As of Bundler 1.10, Bundler now includes an additional section in
Gemfile.lock, "BUNDLED WITH", that tells it which version was used to
run `bundle install`:

<bundler/bundler@a264e6b>

Unfortunately, on versions prior to 1.10, this section is missing, so
Gemfile.lock will change every time you run `bundle` until you upgrade
to Bundler 1.10.

For this reason, bump the dependency on Bundler to force people to
upgrade.