### PR TITLE
Use ENV var instead of fixed value in repo_list_spec

### DIFF
--- a/spec/features/repo_list_spec.rb
+++ b/spec/features/repo_list_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "Repo list", js: true do
-  let(:username) { 'houndci' }
+  let(:username) { ENV.fetch("HOUND_GITHUB_USERNAME") }
 
   scenario "user views landing page" do
     user = create(:user)


### PR DESCRIPTION
Having this value hard coded led to hard to debug failures
when your local `HOUND_GITHUB_USERNAME` was not "houndci".
This was because the `WebMock` stubs were stubbing
with "houndci" and the app makes requests
based on the `ENV` var.