### PR TITLE
Add API endpoint for updating account

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,11 +1,39 @@
 class AccountsController < ApplicationController
   def show
-    @account_page = AccountPage.new(find_subscribed_repos)
+    @account_page = AccountPage.new(
+      repos: find_subscribed_repos,
+      billable_email: current_user.billable_email
+    )
+  end
+
+  def update
+    customer = PaymentGatewayCustomer.new(current_user)
+
+    respond_to do |format|
+      format.json do
+        if customer.update_email(new_billable_email)
+          render json: updated_account_page
+        else
+          head :bad_gateway
+        end
+      end
+    end
   end
 
   private
 
+  def new_billable_email
+    params.require(:billable_email)
+  end
+
   def find_subscribed_repos
     current_user.subscribed_repos.order(:full_github_name)
+  end
+
+  def updated_account_page
+    AccountPage.new(
+      repos: find_subscribed_repos,
+      billable_email: new_billable_email
+    )
   end
 end

--- a/app/models/payment_gateway_customer.rb
+++ b/app/models/payment_gateway_customer.rb
@@ -24,6 +24,14 @@ class PaymentGatewayCustomer
     customer.save
   end
 
+  def update_email(email)
+    customer.email = email
+    customer.save
+  rescue Stripe::APIError => e
+    Raven.capture_exception(e)
+    false
+  end
+
   private
 
   def default_card

--- a/app/presenters/account_page.rb
+++ b/app/presenters/account_page.rb
@@ -1,9 +1,10 @@
 class AccountPage
   include ActionView::Helpers::NumberHelper
 
-  attr_reader :repos
+  attr_reader :billable_email, :repos
 
-  def initialize(repos)
+  def initialize(repos:, billable_email:)
+    @billable_email = billable_email
     @repos = repos
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Houndapp::Application.routes.draw do
   get "/configuration", to: "pages#configuration"
   get "/faq", to: "pages#show", id: "faq"
 
-  resource :account, only: [:show]
+  resource :account, only: [:show, :update]
   resources :builds, only: [:create]
 
   resources :repos, only: [:index] do

--- a/spec/controllers/accounts_spec.rb
+++ b/spec/controllers/accounts_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+describe AccountsController do
+  context "updating billable email" do
+    context "when email is not provided" do
+      it "raises" do
+        user = create(:user, stripe_customer_id: "customer-id")
+        stub_sign_in(user)
+
+        expect do
+          patch :update, billable_email: "", format: :json
+        end.to raise_error(ActionController::ParameterMissing)
+      end
+    end
+
+    context "when email is provided" do
+      context "on success" do
+        it "returns updated account" do
+          new_email = "new-email@example.com"
+          customer_id = "customer-id"
+          user = create(:user, stripe_customer_id: customer_id)
+          stub_sign_in(user)
+          stub_customer_find_request(customer_id)
+          stub_customer_update_request(email: new_email)
+
+          patch :update, billable_email: new_email, format: :json
+
+          response_body = JSON.parse(response.body)
+          expect(response_body["billable_email"]).to eq new_email
+        end
+      end
+    end
+
+    context "on failure" do
+      it "returns 502 Bad Gateway" do
+        new_email = "new-email@example.com"
+        customer_id = "customer-id"
+        user = create(:user, stripe_customer_id: customer_id)
+        stub_sign_in(user)
+        stub_customer_find_request(customer_id)
+        stub_failed_customer_update_request(email: new_email)
+
+        patch :update, billable_email: new_email, format: :json
+
+        expect(response).to have_http_status(:bad_gateway)
+      end
+    end
+  end
+end

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -11,7 +11,9 @@ feature "Account" do
   end
 
   scenario "user with Stripe Customer ID" do
-    user = create(:user, stripe_customer_id: "123")
+    stripe_customer_id = "123"
+    user = create(:user, stripe_customer_id: stripe_customer_id)
+    stub_customer_find_request(stripe_customer_id)
 
     sign_in_as(user)
     visit account_path

--- a/spec/models/payment_gateway_customer_spec.rb
+++ b/spec/models/payment_gateway_customer_spec.rb
@@ -7,11 +7,39 @@ describe PaymentGatewayCustomer do
       user = build(:user, stripe_customer_id: stripe_customer_id)
       customer = PaymentGatewayCustomer.new(user)
       stub_customer_find_request
-      update_request = stub_customer_update_request(new_card_token)
+      update_request = stub_customer_update_request(card: new_card_token)
 
       customer.update_card(new_card_token)
 
       expect(update_request).to have_been_requested
+    end
+  end
+
+  describe "#update_email" do
+    it "updates customer email" do
+      new_email = "new-email@example.com"
+      user = build(:user, stripe_customer_id: stripe_customer_id)
+      customer = PaymentGatewayCustomer.new(user)
+      stub_customer_find_request
+      update_request = stub_customer_update_request(email: new_email)
+
+      customer.update_email(new_email)
+
+      expect(update_request).to have_been_requested
+    end
+
+    context "when update request fails" do
+      it "returns false" do
+        new_email = "new-email@example.com"
+        user = build(:user, stripe_customer_id: stripe_customer_id)
+        customer = PaymentGatewayCustomer.new(user)
+        stub_customer_find_request
+        stub_failed_customer_update_request(email: new_email)
+
+        customer = customer.update_email(new_email)
+
+        expect(customer).to eq false
+      end
     end
   end
 

--- a/spec/support/helpers/stripe_api_helper.rb
+++ b/spec/support/helpers/stripe_api_helper.rb
@@ -23,10 +23,10 @@ module StripeApiHelper
     )
   end
 
-  def stub_customer_find_request
+  def stub_customer_find_request(customer_id = stripe_customer_id)
     stub_request(
       :get,
-      "#{stripe_base_url}/#{stripe_customer_id}"
+      "#{stripe_base_url}/#{customer_id}"
     ).with(
       headers: { "Authorization" => "Bearer #{ENV["STRIPE_API_KEY"]}" }
     ).to_return(
@@ -35,16 +35,34 @@ module StripeApiHelper
     )
   end
 
-  def stub_customer_update_request(card_token = "cardtoken")
+  def stub_customer_update_request(attrs = { card: "card-token" })
     stub_request(
       :post,
       "#{stripe_base_url}/#{stripe_customer_id}"
     ).with(
-      body: { "card" => card_token },
+      body: attrs,
       headers: { "Authorization" => "Bearer #{ENV["STRIPE_API_KEY"]}" }
     ).to_return(
       status: 200,
       body: File.read("spec/support/fixtures/stripe_customer_update.json"),
+    )
+  end
+
+  def stub_failed_customer_update_request(attrs = { email: "email@foo.com" })
+    stub_request(
+      :post,
+      "#{stripe_base_url}/#{stripe_customer_id}"
+    ).with(
+      body: attrs,
+      headers: { "Authorization" => "Bearer #{ENV['STRIPE_API_KEY']}" }
+    ).to_return(
+      status: 500,
+      body: {
+        error: {
+          message: "Something went wrong",
+          type: "api_error"
+        }
+      }.to_json
     )
   end
 


### PR DESCRIPTION
* Support updating an account's billable email address
* Introduce `PATCH /account` endpoint
* Add `PaymentGatewayCustomer#update_email`
* Add `AccountPage#billable_email` and returns billable email in `GET
  /account` response