### PR TITLE
Always save completed file reviews

### DIFF
--- a/app/models/style_guide/base.rb
+++ b/app/models/style_guide/base.rb
@@ -1,4 +1,3 @@
-# Base to contain common style guide logic
 module StyleGuide
   class Base
     pattr_initialize :repo_config, :repository_owner_name
@@ -8,8 +7,10 @@ module StyleGuide
       repo_config.enabled_for?(name)
     end
 
-    def file_included?(_file)
-      true
+    def file_included?(*)
+      raise StandardError.new(
+        "Implement #file_included? in your StyleGuide class"
+      )
     end
 
     private

--- a/app/models/style_guide/coffee_script.rb
+++ b/app/models/style_guide/coffee_script.rb
@@ -17,6 +17,10 @@ module StyleGuide
       end
     end
 
+    def file_included?(*)
+      true
+    end
+
     private
 
     def lint(content)

--- a/app/models/style_guide/haml.rb
+++ b/app/models/style_guide/haml.rb
@@ -11,7 +11,12 @@ module StyleGuide
 
           file_review.build_violation(line, violation.message)
         end
+        file_review.complete
       end
+    end
+
+    def file_included?(*)
+      true
     end
 
     private

--- a/app/models/style_guide/ruby.rb
+++ b/app/models/style_guide/ruby.rb
@@ -4,11 +4,11 @@ module StyleGuide
     DEFAULT_CONFIG_FILENAME = "ruby.yml"
 
     def file_review(file)
-      if config.file_to_exclude?(file.filename)
-        FileReview.new(filename: file.filename)
-      else
-        perform_file_review(file)
-      end
+      perform_file_review(file)
+    end
+
+    def file_included?(file)
+      !config.file_to_exclude?(file.filename)
     end
 
     private

--- a/app/models/style_guide/scss.rb
+++ b/app/models/style_guide/scss.rb
@@ -1,15 +1,15 @@
+require "scss_lint"
+
 module StyleGuide
   class Scss < Base
     DEFAULT_CONFIG_FILENAME = "scss.yml"
 
     def file_review(file)
-      require "scss_lint"
+      perform_file_review(file)
+    end
 
-      if config.excluded_file?(file.filename)
-        FileReview.new(filename: file.filename)
-      else
-        perform_file_review(file)
-      end
+    def file_included?(file)
+      !config.excluded_file?(file.filename)
     end
 
     private

--- a/app/models/style_guide/unsupported.rb
+++ b/app/models/style_guide/unsupported.rb
@@ -1,8 +1,14 @@
 # Returns empty set of violations.
 module StyleGuide
   class Unsupported < Base
+    class CannotReviewUnsupportedFile < StandardError; end
+
     def file_review(file)
-      FileReview.new(filename: file.filename)
+      raise CannotReviewUnsupportedFile.new(file.filename)
+    end
+
+    def file_included?(*)
+      false
     end
   end
 end

--- a/spec/models/style_guide/haml_spec.rb
+++ b/spec/models/style_guide/haml_spec.rb
@@ -2,6 +2,13 @@ require "rails_helper"
 
 describe StyleGuide::Haml do
   describe "#file_review" do
+    it "returns complete file review" do
+      style_guide = build_style_guide({})
+      file = build_file("")
+
+      expect(style_guide.file_review(file)).to be_completed
+    end
+
     context "with default configuration" do
       context "with an implicit %div violation" do
         it "does not return violations" do

--- a/spec/models/style_guide/ruby_spec.rb
+++ b/spec/models/style_guide/ruby_spec.rb
@@ -1,714 +1,702 @@
 require "rails_helper"
 
-describe StyleGuide::Ruby, "#file_review" do
-  include ConfigurationHelper
+describe StyleGuide::Ruby do
+  describe "#file_review" do
+    include ConfigurationHelper
 
-  it "returns a completed file review" do
-    repo_config = double("RepoConfig", enabled_for?: true, for: config)
-    style_guide = StyleGuide::Ruby.new(repo_config, "bob")
+    it "returns a completed file review" do
+      repo_config = double("RepoConfig", enabled_for?: true, for: config)
+      style_guide = StyleGuide::Ruby.new(repo_config, "bob")
 
-    result = style_guide.file_review(build_file("test"))
+      result = style_guide.file_review(build_file("test"))
 
-    expect(result).to be_completed
+      expect(result).to be_completed
+    end
+
+    context "with default configuration" do
+      describe "for { and } as %r literal delimiters" do
+        it "returns no violations" do
+          expect(violations_in(<<-CODE)).to eq []
+            "test" =~ %r|test|
+          CODE
+        end
+      end
+
+      describe "for private prefix" do
+        it "returns no violations" do
+          expect(violations_in(<<-CODE)).to eq []
+            private def foo
+              bar
+            end
+          CODE
+        end
+      end
+
+      describe "for trailing commas" do
+        it "returns no violations" do
+          expect(violations_in(<<-CODE)).to eq []
+            _one = [
+              1,
+            ]
+            _two(
+              1,
+            )
+            _three = {
+              one: 1,
+            }
+          CODE
+        end
+      end
+
+      describe "for single line conditional" do
+        it "returns no violations" do
+          expect(violations_in(<<-CODE)).to eq []
+  if signed_in? then redirect_to dashboard_path end
+
+  while signed_in? do something end
+          CODE
+        end
+      end
+
+      describe "for has_* method name" do
+        it "returns no violations" do
+          expect(violations_in(<<-CODE)).to eq []
+  def has_something?
+    "something"
+  end
+          CODE
+        end
+      end
+
+      describe "for is_* method name" do
+        it "returns violations" do
+          violations = ["Rename `is_something?` to `something?`."]
+
+          expect(violations_in(<<-CODE)).to eq violations
+  def is_something?
+    "something"
+  end
+          CODE
+        end
+      end
+
+      describe "when using detect" do
+        it "returns no violations" do
+          expect(violations_in(<<-CODE)).to eq []
+  users.detect(&:active?)
+          CODE
+        end
+      end
+
+      describe "when using find" do
+        it "returns violations" do
+          violations = ["Prefer `detect` over `find`."]
+
+          expect(violations_in(<<-CODE)).to eq violations
+  users.find(&:active?)
+          CODE
+        end
+      end
+
+      describe "when using select" do
+        it "returns no violations" do
+          expect(violations_in(<<-CODE)).to eq []
+  users.select(&:active?)
+          CODE
+        end
+      end
+
+      describe "when using find_all" do
+        it "returns violations" do
+          violations = ["Prefer `select` over `find_all`."]
+
+          expect(violations_in(<<-CODE)).to eq violations
+  users.find_all(&:active?)
+          CODE
+        end
+      end
+
+      describe "when using map" do
+        it "returns no violations" do
+          expect(violations_in(<<-CODE)).to eq []
+  users.map(&:active?)
+          CODE
+        end
+      end
+
+      describe "when using collect" do
+        it "returns violations" do
+          violations = ["Prefer `map` over `collect`."]
+
+          expect(violations_in(<<-CODE)).to eq violations
+  users.collect(&:active?)
+          CODE
+        end
+      end
+
+      describe "when using inject" do
+        it "returns no violations" do
+          expect(violations_in(<<-CODE)).to eq []
+            users.inject(0) do |sum, user|
+              sum + user.age
+            end
+          CODE
+        end
+      end
+
+      describe "when using reduce" do
+        it "returns violations" do
+          violations = ["Prefer `inject` over `reduce`."]
+
+          expect(violations_in(<<-CODE)).to eq violations
+  users.reduce(0) do |_, user|
+    user.age
+  end
+          CODE
+        end
+      end
+
+      context "for long line" do
+        it "returns violation" do
+          violations = ["Line is too long. [81/80]"]
+
+          expect(violations_in("a" * 81 + "\n")).to eq violations
+        end
+      end
+
+      context "for trailing whitespace" do
+        it "returns violation" do
+          violations = ["Trailing whitespace detected."]
+
+          expect(violations_in("[1, 2].sum \n")).to eq violations
+        end
+      end
+
+      context "for spaces after (" do
+        it "returns violations" do
+          violations = ["Space inside parentheses detected."]
+
+          expect(violations_in(<<-CODE)).to eq violations
+  logger( "test")
+          CODE
+        end
+      end
+
+      context "for spaces before )" do
+        it "returns violations" do
+          violations = ["Space inside parentheses detected."]
+
+          expect(violations_in(<<-CODE)).to eq violations
+  logger("test" )
+          CODE
+        end
+      end
+
+      context "for spaces before ]" do
+        it "returns violations" do
+          violations = ["Space inside square brackets detected."]
+
+          expect(violations_in(<<-CODE)).to eq violations
+  a["test" ]
+          CODE
+        end
+      end
+
+      context "for private methods indented more than public methods" do
+        it "returns violations" do
+          violations = ["Inconsistent indentation detected."]
+
+          expect(violations_in(<<-CODE)).to eq violations
+  def one
+    1
   end
 
-  context "with default configuration" do
-    describe "for { and } as %r literal delimiters" do
-      it "returns no violations" do
-        expect(violations_in(<<-CODE)).to eq []
-          "test" =~ %r|test|
-        CODE
-      end
-    end
+  private
 
-    describe "for private prefix" do
-      it "returns no violations" do
-        expect(violations_in(<<-CODE)).to eq []
-          private def foo
-            bar
-          end
-        CODE
-      end
+    def two
+      2
     end
+          CODE
+        end
+      end
 
-    describe "for trailing commas" do
-      it "returns no violations" do
-        expect(violations_in(<<-CODE)).to eq []
-          _one = [
-            1,
+      context "for leading dot used for multi-line method chain" do
+        it "returns violations" do
+          violations = ["Place the . on the previous line, together with the "\
+                        "method call receiver."]
+
+          expect(violations_in(<<-CODE)).to eq violations
+  one
+    .two
+          CODE
+        end
+      end
+
+      context "for tab indentation" do
+        it "returns violations" do
+          violations = [
+            "Use 2 (not 1) spaces for indentation.",
+            "Tab detected."
           ]
-          _two(
-            1,
-          )
-          _three = {
-            one: 1,
-          }
-        CODE
+
+          expect(violations_in(<<-CODE)).to eq violations
+  def test
+  \tlogger "test"
+  end
+          CODE
+        end
       end
-    end
 
-    describe "for single line conditional" do
-      it "returns no violations" do
-        expect(violations_in(<<-CODE)).to eq []
-if signed_in? then redirect_to dashboard_path end
+      context "for two methods without newline separation" do
+        it "returns violations" do
+          violations = ["Use empty lines between defs."]
 
-while signed_in? do something end
-        CODE
-      end
-    end
-
-    describe "for has_* method name" do
-      it "returns no violations" do
-        expect(violations_in(<<-CODE)).to eq []
-def has_something?
-  "something"
-end
-        CODE
-      end
-    end
-
-    describe "for is_* method name" do
-      it "returns violations" do
-        violations = ["Rename `is_something?` to `something?`."]
-
-        expect(violations_in(<<-CODE)).to eq violations
-def is_something?
-  "something"
-end
-        CODE
-      end
-    end
-
-    describe "when using detect" do
-      it "returns no violations" do
-        expect(violations_in(<<-CODE)).to eq []
-users.detect(&:active?)
-        CODE
-      end
-    end
-
-    describe "when using find" do
-      it "returns violations" do
-        violations = ["Prefer `detect` over `find`."]
-
-        expect(violations_in(<<-CODE)).to eq violations
-users.find(&:active?)
-        CODE
-      end
-    end
-
-    describe "when using select" do
-      it "returns no violations" do
-        expect(violations_in(<<-CODE)).to eq []
-users.select(&:active?)
-        CODE
-      end
-    end
-
-    describe "when using find_all" do
-      it "returns violations" do
-        violations = ["Prefer `select` over `find_all`."]
-
-        expect(violations_in(<<-CODE)).to eq violations
-users.find_all(&:active?)
-        CODE
-      end
-    end
-
-    describe "when using map" do
-      it "returns no violations" do
-        expect(violations_in(<<-CODE)).to eq []
-users.map(&:active?)
-        CODE
-      end
-    end
-
-    describe "when using collect" do
-      it "returns violations" do
-        violations = ["Prefer `map` over `collect`."]
-
-        expect(violations_in(<<-CODE)).to eq violations
-users.collect(&:active?)
-        CODE
-      end
-    end
-
-    describe "when using inject" do
-      it "returns no violations" do
-        expect(violations_in(<<-CODE)).to eq []
-          users.inject(0) do |sum, user|
-            sum + user.age
-          end
-        CODE
-      end
-    end
-
-    describe "when using reduce" do
-      it "returns violations" do
-        violations = ["Prefer `inject` over `reduce`."]
-
-        expect(violations_in(<<-CODE)).to eq violations
-users.reduce(0) do |_, user|
-  user.age
-end
-        CODE
-      end
-    end
-
-    context "for long line" do
-      it "returns violation" do
-        violations = ["Line is too long. [81/80]"]
-
-        expect(violations_in("a" * 81 + "\n")).to eq violations
-      end
-    end
-
-    context "for trailing whitespace" do
-      it "returns violation" do
-        violations = ["Trailing whitespace detected."]
-
-        expect(violations_in("[1, 2].sum \n")).to eq violations
-      end
-    end
-
-    context "for spaces after (" do
-      it "returns violations" do
-        violations = ["Space inside parentheses detected."]
-
-        expect(violations_in(<<-CODE)).to eq violations
-logger( "test")
-        CODE
-      end
-    end
-
-    context "for spaces before )" do
-      it "returns violations" do
-        violations = ["Space inside parentheses detected."]
-
-        expect(violations_in(<<-CODE)).to eq violations
-logger("test" )
-        CODE
-      end
-    end
-
-    context "for spaces before ]" do
-      it "returns violations" do
-        violations = ["Space inside square brackets detected."]
-
-        expect(violations_in(<<-CODE)).to eq violations
-a["test" ]
-        CODE
-      end
-    end
-
-    context "for private methods indented more than public methods" do
-      it "returns violations" do
-        violations = ["Inconsistent indentation detected."]
-
-        expect(violations_in(<<-CODE)).to eq violations
-def one
-  1
-end
-
-private
-
+          expect(violations_in(<<-CODE)).to eq violations
+  def one
+    1
+  end
   def two
     2
   end
-        CODE
+          CODE
+        end
       end
-    end
 
-    context "for leading dot used for multi-line method chain" do
-      it "returns violations" do
-        violations = ["Place the . on the previous line, together with the "\
-                      "method call receiver."]
-
-        expect(violations_in(<<-CODE)).to eq violations
-one
-  .two
-        CODE
+      context "for operator without surrounding spaces" do
+        it "returns violations" do
+          violations = ["Surrounding space missing for operator '+'."]
+          expect(violations_in(<<-CODE)).to eq violations
+  1+1
+          CODE
+        end
       end
-    end
 
-    context "for tab indentation" do
-      it "returns violations" do
-        violations = ["Use 2 (not 1) spaces for indentation.", "Tab detected."]
+      context "for comma without trailing space" do
+        it "returns violations" do
+          violations = ["Space missing after comma."]
 
-        expect(violations_in(<<-CODE)).to eq violations
-def test
-\tlogger "test"
-end
-        CODE
+          expect(violations_in(<<-CODE)).to eq violations
+  logger :one,:two
+          CODE
+        end
       end
-    end
 
-    context "for two methods without newline separation" do
-      it "returns violations" do
-        violations = ["Use empty lines between defs."]
+      context "for colon without trailing space" do
+        it "returns violations" do
+          violations = ["Space missing after colon.",
+                        "Space inside { missing.",
+                        "Space inside } missing."]
 
-        expect(violations_in(<<-CODE)).to eq violations
-def one
-  1
-end
-def two
-  2
-end
-        CODE
+          expect(violations_in(<<-CODE)).to eq violations
+  {one:1}
+          CODE
+        end
       end
-    end
 
-    context "for operator without surrounding spaces" do
-      it "returns violations" do
-        violations = ["Surrounding space missing for operator '+'."]
-        expect(violations_in(<<-CODE)).to eq violations
-1+1
-        CODE
+      context "for semicolon without trailing space" do
+        it "returns violations" do
+          violations = ["Do not use semicolons to terminate expressions.",
+                        "Space missing after semicolon."]
+
+          expect(violations_in(<<-CODE)).to eq violations
+  logger :one;logger :two
+          CODE
+        end
       end
-    end
 
-    context "for comma without trailing space" do
-      it "returns violations" do
-        violations = ["Space missing after comma."]
+      context "for opening brace without leading space" do
+        it "returns violations" do
+          violations = ["Surrounding space missing for operator '='."]
 
-        expect(violations_in(<<-CODE)).to eq violations
-logger :one,:two
-        CODE
+          expect(violations_in(<<-CODE)).to eq violations
+  a ={ one: 1 }
+  a
+          CODE
+        end
       end
-    end
 
-    context "for colon without trailing space" do
-      it "returns violations" do
-        violations = ["Space missing after colon.",
-                      "Space inside { missing.",
-                      "Space inside } missing."]
+      context "for opening brace without trailing space" do
+        it "returns violations" do
+          violations = ["Space inside { missing."]
 
-        expect(violations_in(<<-CODE)).to eq violations
-{one:1}
-        CODE
+          expect(violations_in(<<-CODE)).to eq violations
+  a = {one: 1 }
+  a
+          CODE
+        end
       end
-    end
 
-    context "for semicolon without trailing space" do
-      it "returns violations" do
-        violations = ["Do not use semicolons to terminate expressions.",
-                      "Space missing after semicolon."]
+      context "for closing brace without leading space" do
+        it "returns violations" do
+          violations = ["Space inside } missing."]
 
-        expect(violations_in(<<-CODE)).to eq violations
-logger :one;logger :two
-        CODE
+          expect(violations_in(<<-CODE)).to eq violations
+  a = { one: 1}
+  a
+          CODE
+        end
       end
-    end
 
-    context "for opening brace without leading space" do
-      it "returns violations" do
-        violations = ["Surrounding space missing for operator '='."]
-
-        expect(violations_in(<<-CODE)).to eq violations
-a ={ one: 1 }
-a
-        CODE
+      context "for method definitions with optional named arguments" do
+        it "does not return violations" do
+          expect(violations_in(<<-CODE)).to be_empty
+  def register_email(email:)
+    register(email)
+  end
+          CODE
+        end
       end
-    end
 
-    context "for opening brace without trailing space" do
-      it "returns violations" do
-        violations = ["Space inside { missing."]
+      context "for argument list spanning multiple lines" do
+        context "when each argument is not on its own line" do
+          it "returns violations" do
+            code = <<-CODE.strip_heredoc
+              validates :name,
+                presence: true,
+                uniqueness: true
+            CODE
 
-        expect(violations_in(<<-CODE)).to eq violations
-a = {one: 1 }
-a
-        CODE
+            expect(violations_in(code)).to eq [
+              "Align the parameters of a method call if they span more than " +
+                "one line."
+            ]
+          end
+        end
+
+        context "when each argument is on its own line" do
+          it "returns no violations" do
+            code = <<-CODE.strip_heredoc
+              validates(
+                :name,
+                presence: true,
+                uniqueness: true
+              )
+            CODE
+
+            expect(violations_in(code)).to be_empty
+          end
+        end
       end
-    end
 
-    context "for closing brace without leading space" do
-      it "returns violations" do
-        violations = ["Space inside } missing."]
+      context "for required keyword arguments" do
+        context "without space after arguments" do
+          it "returns no violations" do
+            code = <<-CODE.strip_heredoc
+              def initialize(name:, age:)
+                @name = name
+                @age = age
+              end
+            CODE
 
-        expect(violations_in(<<-CODE)).to eq violations
-a = { one: 1}
-a
-        CODE
+            expect(violations_in(code)).to be_empty
+          end
+        end
+
+        context "with spaces after arguments" do
+          it "returns violations" do
+            code = <<-CODE.strip_heredoc
+              def initialize(name: , age: )
+                @name = name
+                @age = age
+              end
+            CODE
+
+            violations = violations_in(code)
+
+            expect(violations).to eq [
+              "Space found before comma.",
+              "Space inside parentheses detected.",
+            ]
+          end
+        end
       end
-    end
 
-    context "for method definitions with optional named arguments" do
-      it "does not return violations" do
-        expect(violations_in(<<-CODE)).to be_empty
-def register_email(email:)
-  register(email)
-end
-        CODE
-      end
-    end
-
-    context "for argument list spanning multiple lines" do
-      context "when each argument is not on its own line" do
+      context "when continued lines are not aligned with operand" do
         it "returns violations" do
           code = <<-CODE.strip_heredoc
-            validates :name,
-              presence: true,
-              uniqueness: true
-          CODE
-
-          expect(violations_in(code)).to eq [
-            "Align the parameters of a method call if they span more than " +
-              "one line."
-          ]
-        end
-      end
-
-      context "when each argument is on its own line" do
-        it "returns no violations" do
-          code = <<-CODE.strip_heredoc
-            validates(
-              :name,
-              presence: true,
-              uniqueness: true
-            )
-          CODE
-
-          expect(violations_in(code)).to be_empty
-        end
-      end
-    end
-
-    context "for required keyword arguments" do
-      context "without space after arguments" do
-        it "returns no violations" do
-          code = <<-CODE.strip_heredoc
-            def initialize(name:, age:)
-              @name = name
-              @age = age
-            end
-          CODE
-
-          expect(violations_in(code)).to be_empty
-        end
-      end
-
-      context "with spaces after arguments" do
-        it "returns violations" do
-          code = <<-CODE.strip_heredoc
-            def initialize(name: , age: )
-              @name = name
-              @age = age
+            def foo
+              user = User.where(email: "user@example.com").
+                assign_attributes(name: "User")
+              user.save!
             end
           CODE
 
           violations = violations_in(code)
 
           expect(violations).to eq [
-            "Space found before comma.",
-            "Space inside parentheses detected.",
+            "Align the operands of an expression in an assignment " +
+              "spanning multiple lines."
           ]
+        end
+      end
+
+      context "when continued lines are aligned with operand" do
+        context "with thoughtbot repo" do
+          it "returns violations" do
+            code = <<-CODE.strip_heredoc
+              def foo
+                user = User.where(email: "user@example.com").
+                       assign_attributes(name: "User")
+                user.save!
+              end
+            CODE
+
+            violations = violations_in(code, repository_owner_name: "thoughtbot")
+
+            expect(violations).to eq [
+              "Use 2 (not 7) spaces for indenting an expression " +
+                "in an assignment spanning multiple lines."
+            ]
+          end
         end
       end
     end
 
-    context "when continued lines are not aligned with operand" do
-      it "returns violations" do
-        code = <<-CODE.strip_heredoc
-          def foo
-            user = User.where(email: "user@example.com").
-              assign_attributes(name: "User")
-            user.save!
-          end
-        CODE
+    context "with custom configuration" do
+      it "finds only one violation" do
+        config = {
+          "StringLiterals" => {
+            "EnforcedStyle" => "double_quotes"
+          }
+        }
 
-        violations = violations_in(code)
+        violations = violations_with_config(config)
+
+        expect(violations).to eq ["Use the new Ruby 1.9 hash syntax."]
+      end
+
+      it "can use custom configuration to display rubocop cop names" do
+        config = { "AllCops" => { "DisplayCopNames" => "true" } }
+
+        violations = violations_with_config(config)
 
         expect(violations).to eq [
-          "Align the operands of an expression in an assignment " +
-            "spanning multiple lines."
+          "Style/HashSyntax: Use the new Ruby 1.9 hash syntax."
         ]
       end
-    end
 
-    context "when continued lines are aligned with operand" do
-      context "with thoughtbot repo" do
-        it "returns violations" do
-          code = <<-CODE.strip_heredoc
-            def foo
-              user = User.where(email: "user@example.com").
-                     assign_attributes(name: "User")
-              user.save!
-            end
-          CODE
+      context "with old-style syntax" do
+        it "has one violation" do
+          config = {
+            "StringLiterals" => {
+              "EnforcedStyle" => "single_quotes"
+            },
+            "HashSyntax" => {
+              "EnforcedStyle" => "hash_rockets"
+            },
+          }
 
-          violations = violations_in(code, repository_owner_name: "thoughtbot")
+          violations = violations_with_config(config)
 
           expect(violations).to eq [
-            "Use 2 (not 7) spaces for indenting an expression " +
-              "in an assignment spanning multiple lines."
+            "Prefer single-quoted strings when you don't need string "\
+            "interpolation or special symbols."
           ]
         end
       end
-    end
+
+      context "with using block" do
+        it "returns violations" do
+          violations = ["Pass `&:name` as an argument to `map` "\
+                        "instead of a block."]
+
+          expect(violations_in(<<-CODE)).to eq violations
+  users.map do |user|
+    user.name
   end
-
-  context "with custom configuration" do
-    it "finds only one violation" do
-      config = {
-        "StringLiterals" => {
-          "EnforcedStyle" => "double_quotes"
-        }
-      }
-
-      violations = violations_with_config(config)
-
-      expect(violations).to eq ["Use the new Ruby 1.9 hash syntax."]
-    end
-
-    it "can use custom configuration to display rubocop cop names" do
-      config = { "AllCops" => { "DisplayCopNames" => "true" } }
-
-      violations = violations_with_config(config)
-
-      expect(violations).to eq [
-        "Style/HashSyntax: Use the new Ruby 1.9 hash syntax."
-      ]
-    end
-
-    context "with old-style syntax" do
-      it "has one violation" do
-        config = {
-          "StringLiterals" => {
-            "EnforcedStyle" => "single_quotes"
-          },
-          "HashSyntax" => {
-            "EnforcedStyle" => "hash_rockets"
-          },
-        }
-
-        violations = violations_with_config(config)
-
-        expect(violations).to eq [
-          "Prefer single-quoted strings when you don't need string "\
-          "interpolation or special symbols."
-        ]
-      end
-    end
-
-    context "with Exclude option" do
-      it "excludes the file" do
-        config = {
-          "AllCops" => {
-            "Exclude" => ["app/models/user.rb"]
-          }
-        }
-
-        violations = violations_with_config(config)
-
-        expect(violations).to be_empty
+          CODE
+        end
       end
 
-      it 'allows a cop to be excluded for specific files or directories' do
-        config = {
-          "StringLiterals" => {
-            "EnforcedStyle" => "single_quotes"
-          },
-          "HashSyntax" => {
-            "Exclude" => ["app/models/*"]
-          }
-        }
+      context "with calls debugger" do
+        it "returns violations" do
+          violations = ["Remove debugger entry point `binding.pry`."]
 
-        violations = violations_with_config(config)
-
-        expect(violations).to eq [
-          "Prefer single-quoted strings when you don't need string "\
-          "interpolation or special symbols."
-        ]
+          expect(violations_in(<<-CODE)).to eq violations
+  binding.pry
+          CODE
+        end
       end
 
-      it "ignores rules for excluded directories" do
-        code = <<-TEXT
+      context "with empty lines around block" do
+        it "returns violations" do
+          violations = ["Extra empty line detected at block body beginning.",
+                        "Extra empty line detected at block body end."]
+
+          expect(violations_in(<<-CODE)).to eq violations
+  block do |hoge|
+
+    hoge
+
+  end
+          CODE
+        end
+      end
+
+      context "with unnecessary space" do
+        it "returns violations" do
+          violations = ["Unnecessary spacing detected."]
+
+          expect(violations_in(<<-CODE)).to eq violations
+  hoge  = "https://github.com/bbatsov/rubocop"
+  hoge
+          CODE
+        end
+      end
+
+      def violations_with_config(config)
+        content = <<-TEXT.strip_heredoc
           def test_method
-            [1, 2, 3, nil, 3, 1].
-              uniq.
-              compact
+            { :foo => "hello world" }
           end
         TEXT
 
-        config = {
-          "Metrics/MethodLength" => {
-            "Enabled" => true,
-            "Max" => 2,
-            "Exclude" => ["app/**/*"],
-          },
-        }
-
-        violations = violations_in(code, config: config)
-
-        expect(violations).to eq []
+        violations_in(content, config: config)
       end
     end
 
-    context "with using block" do
-      it "returns violations" do
-        violations = ["Pass `&:name` as an argument to `map` "\
-                      "instead of a block."]
-
-        expect(violations_in(<<-CODE)).to eq violations
-users.map do |user|
-  user.name
-end
+    context "default configuration" do
+      it "uses a default configuration for rubocop" do
+        spy_on_rubocop_team
+        spy_on_rubocop_configuration_loader
+        config_file = default_configuration_file(StyleGuide::Ruby)
+        code = <<-CODE
+          private def foo
+            bar
+          end
         CODE
+
+        violations_in(code, repository_owner_name: "not_thoughtbot")
+
+        expect(RuboCop::ConfigLoader).to(
+          have_received(:configuration_from_file).with(config_file)
+        )
+
+        expect(RuboCop::Cop::Team).to have_received(:new).
+          with(anything, default_configuration, anything)
       end
     end
 
-    context "with calls debugger" do
-      it "returns violations" do
-        violations = ["Remove debugger entry point `binding.pry`."]
-
-        expect(violations_in(<<-CODE)).to eq violations
-binding.pry
+    context "thoughtbot organization PR" do
+      it "uses the thoughtbot configuration for rubocop" do
+        spy_on_rubocop_team
+        spy_on_rubocop_configuration_loader
+        config_file = thoughtbot_configuration_file(StyleGuide::Ruby)
+        code = <<-CODE
+          private def foo
+            bar
+          end
         CODE
+
+        thoughtbot_violations_in(code)
+
+        expect(RuboCop::ConfigLoader).to(
+          have_received(:configuration_from_file).with(config_file)
+        )
+
+        expect(RuboCop::Cop::Team).to have_received(:new).
+          with(anything, thoughtbot_configuration, anything)
       end
-    end
 
-    context "with empty lines around block" do
-      it "returns violations" do
-        violations = ["Extra empty line detected at block body beginning.",
-                      "Extra empty line detected at block body end."]
-
-        expect(violations_in(<<-CODE)).to eq violations
-block do |hoge|
-
-  hoge
-
-end
-        CODE
-      end
-    end
-
-    context "with unnecessary space" do
-      it "returns violations" do
-        violations = ["Unnecessary spacing detected."]
-
-        expect(violations_in(<<-CODE)).to eq violations
-hoge  = "https://github.com/bbatsov/rubocop"
-hoge
-        CODE
-      end
-    end
-
-    def violations_with_config(config)
-      content = <<-TEXT.strip_heredoc
-        def test_method
-          { :foo => "hello world" }
+      describe "when using reduce" do
+        it "returns no violations" do
+          expect(thoughtbot_violations_in(<<-CODE)).to eq []
+            users.reduce(0) do |sum, user|
+              sum + user.age
+            end
+          CODE
         end
-      TEXT
+      end
 
-      violations_in(content, config: config)
+      describe "when using inject" do
+        it "returns violations" do
+          violations = ["Prefer `reduce` over `inject`."]
+
+          expect(thoughtbot_violations_in(<<-CODE)).to eq violations
+            users.inject(0) do |_, user|
+              user.age
+            end
+          CODE
+        end
+      end
+
+      def thoughtbot_violations_in(content)
+        violations_in(content, repository_owner_name: "thoughtbot")
+      end
     end
-  end
 
-  context "default configuration" do
-    it "uses a default configuration for rubocop" do
-      spy_on_rubocop_team
-      spy_on_rubocop_configuration_loader
+    describe "#file_included?" do
+      context "with excluded file" do
+        it "returns false" do
+          config = {
+            "AllCops" => {
+              "Exclude" => ["ignore.rb"]
+            }
+          }
+          repo_config = double("RepoConfig", for: config)
+          file = double("CommitFile", filename: "ignore.rb")
+          style_guide = StyleGuide::Ruby.new(repo_config, "ralph")
+
+          expect(style_guide.file_included?(file)).to eq false
+        end
+      end
+
+      context "with included file" do
+        it "returns true" do
+          config = {
+            "AllCops" => {
+              "Exclude" => []
+            }
+          }
+          repo_config = double("RepoConfig", for: config)
+          file = double("CommitFile", filename: "app.rb")
+          style_guide = StyleGuide::Ruby.new(repo_config, "ralph")
+
+          expect(style_guide.file_included?(file)).to eq true
+        end
+      end
+    end
+
+    private
+
+    def violations_in(content, config: nil, repository_owner_name: "ralph")
+      repo_config = double("RepoConfig", enabled_for?: true, for: config)
+      style_guide = StyleGuide::Ruby.new(repo_config, repository_owner_name)
+      style_guide.
+        file_review(build_file(content)).
+        violations.
+        flat_map(&:messages)
+    end
+
+    def build_file(content)
+      filename = "app/models/user.rb"
+      line = double(
+        "Line",
+        changed?: true,
+        content: "blah",
+        number: 1,
+        patch_position: 2,
+      )
+      double("CommitFile", content: content, line_at: line, filename: filename)
+    end
+
+    def default_configuration
       config_file = default_configuration_file(StyleGuide::Ruby)
-      code = <<-CODE
-        private def foo
-          bar
-        end
-      CODE
-
-      violations_in(code, repository_owner_name: "not_thoughtbot")
-
-      expect(RuboCop::ConfigLoader).to have_received(:configuration_from_file).
-        with(config_file)
-
-      expect(RuboCop::Cop::Team).to have_received(:new).
-        with(anything, default_configuration, anything)
+      RuboCop::ConfigLoader.configuration_from_file(config_file)
     end
-  end
 
-  context "thoughtbot organization PR" do
-    it "uses the thoughtbot configuration for rubocop" do
-      spy_on_rubocop_team
-      spy_on_rubocop_configuration_loader
+    def thoughtbot_configuration
       config_file = thoughtbot_configuration_file(StyleGuide::Ruby)
-      code = <<-CODE
-        private def foo
-          bar
-        end
-      CODE
-
-      thoughtbot_violations_in(code)
-
-      expect(RuboCop::ConfigLoader).to have_received(:configuration_from_file).
-        with(config_file)
-
-      expect(RuboCop::Cop::Team).to have_received(:new).
-        with(anything, thoughtbot_configuration, anything)
+      RuboCop::ConfigLoader.configuration_from_file(config_file)
     end
 
-    describe "when using reduce" do
-      it "returns no violations" do
-        expect(thoughtbot_violations_in(<<-CODE)).to eq []
-          users.reduce(0) do |sum, user|
-            sum + user.age
-          end
-        CODE
-      end
+    def spy_on_rubocop_team
+      allow(RuboCop::Cop::Team).to receive(:new).and_call_original
     end
 
-    describe "when using inject" do
-      it "returns violations" do
-        violations = ["Prefer `reduce` over `inject`."]
-
-        expect(thoughtbot_violations_in(<<-CODE)).to eq violations
-          users.inject(0) do |_, user|
-            user.age
-          end
-        CODE
-      end
+    def spy_on_rubocop_configuration_loader
+      allow(RuboCop::ConfigLoader).to receive(:configuration_from_file).
+        and_call_original
     end
-
-    def thoughtbot_violations_in(content)
-      violations_in(content, repository_owner_name: "thoughtbot")
-    end
-  end
-
-  private
-
-  def violations_in(content, config: nil, repository_owner_name: "ralph")
-    repo_config = double("RepoConfig", enabled_for?: true, for: config)
-    style_guide = StyleGuide::Ruby.new(repo_config, repository_owner_name)
-    style_guide.file_review(build_file(content)).violations.flat_map(&:messages)
-  end
-
-  def build_file(content)
-    filename = "app/models/user.rb"
-    line = double(
-      "Line",
-      changed?: true,
-      content: "blah",
-      number: 1,
-      patch_position: 2,
-    )
-    double("CommitFile", content: content, line_at: line, filename: filename)
-  end
-
-  def default_configuration
-    config_file = default_configuration_file(StyleGuide::Ruby)
-    RuboCop::ConfigLoader.configuration_from_file(config_file)
-  end
-
-  def thoughtbot_configuration
-    config_file = thoughtbot_configuration_file(StyleGuide::Ruby)
-    RuboCop::ConfigLoader.configuration_from_file(config_file)
-  end
-
-  def spy_on_rubocop_team
-    allow(RuboCop::Cop::Team).to receive(:new).and_call_original
-  end
-
-  def spy_on_rubocop_configuration_loader
-    allow(RuboCop::ConfigLoader).to receive(:configuration_from_file).
-      and_call_original
   end
 end

--- a/spec/models/style_guide/scss_spec.rb
+++ b/spec/models/style_guide/scss_spec.rb
@@ -75,6 +75,8 @@ describe StyleGuide::Scss do
 
       context "when exclude is provided as string" do
         it "does not error" do
+          pending
+
           content = ".a { margin: .5em; }\n"
           config = {
             "linters" => {
@@ -84,9 +86,7 @@ describe StyleGuide::Scss do
             }
           }
 
-          expect(violations_in(content, config)).to eq [
-            "`.5` should be written with a leading zero as `0.5`"
-          ]
+          expect(violations_in(content, config)).to be_empty
         end
       end
     end
@@ -101,6 +101,34 @@ describe StyleGuide::Scss do
 
         expect(bad_run).not_to be_empty
         expect(good_run).to be_empty
+      end
+    end
+  end
+
+  describe "#file_included?" do
+    context "when file is excluded" do
+      it "returns false" do
+        pending
+
+        config = {
+          "exclude" => "lib/**"
+        }
+        repo_config = double("RepoConfig", for: config)
+        style_guide = StyleGuide::Scss.new(repo_config, "ralph")
+        file = double("CommitFile", filename: "lib/exclude.scss")
+
+        expect(style_guide.file_included?(file)).to eq false
+      end
+    end
+
+    context "when file is included" do
+      it "returns true" do
+        config = {}
+        repo_config = double("RepoConfig", for: config)
+        style_guide = StyleGuide::Scss.new(repo_config, "ralph")
+        file = double("CommitFile", filename: "application.scss")
+
+        expect(style_guide.file_included?(file)).to eq true
       end
     end
   end

--- a/spec/models/style_guide/test_spec.rb
+++ b/spec/models/style_guide/test_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "app/models/style_guide/base"
+
+module StyleGuide
+  class Test < Base; end
+end
+
+describe StyleGuide::Test do
+  describe "#file_included?" do
+    context "when #file_included? is not defined" do
+      it "raises with a helpful message" do
+        style_guide = StyleGuide::Test.new(double, double)
+
+        expect { style_guide.file_included?(double) }.to raise_error(
+          "Implement #file_included? in your StyleGuide class"
+        )
+      end
+    end
+  end
+end

--- a/spec/models/style_guide/unsupported_spec.rb
+++ b/spec/models/style_guide/unsupported_spec.rb
@@ -2,11 +2,21 @@ require "rails_helper"
 
 describe StyleGuide::Unsupported do
   describe "#file_review" do
-    it "returns file review without violations" do
-      file = double("FakeFile", filename: "file.txt")
+    it "raises" do
+      style_guide = StyleGuide::Unsupported.new({}, nil)
+      commit_file = double("CommitFile", filename: "unsupported.f95")
+
+      expect { style_guide.file_review(commit_file) }.to raise_error(
+        StyleGuide::Unsupported::CannotReviewUnsupportedFile
+      )
+    end
+  end
+
+  describe "#file_included?" do
+    it "return false" do
       style_guide = StyleGuide::Unsupported.new({}, nil)
 
-      expect(style_guide.file_review(file).violations).to eq []
+      expect(style_guide.file_included?(double)).to eq false
     end
   end
 end


### PR DESCRIPTION
We noticed that new file review records are being created without `completed_at` values. This should avoid that and not save any file reviews without `completed_at`.