### PR TITLE
Fix bundler caching on Travis to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: ruby
 sudo: false
-cache: bundler
 rvm: 2.2.2
+
+bundler_args: --path vendor/bundle --jobs=3 --retry=3
+cache:
+  directories:
+    - vendor/bundle
 
 addons:
   postgresql: "9.3"


### PR DESCRIPTION
Trying technique noted on:

https://github.com/thoughtbot/suspenders/pull/567#issuecomment-109330176