### PR TITLE
Listen for link clicks correctly

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,6 +1,6 @@
 module AnalyticsHelper
   def analytics?
-    ENV['ANALYTICS']
+    ENV["SEGMENT_KEY"]
   end
 
   def identify_hash(user = current_user)

--- a/app/views/application/_analytics.haml
+++ b/app/views/application/_analytics.haml
@@ -13,6 +13,17 @@
       #{raw identify_hash.to_json},
       #{raw intercom_hash.to_json}
     );
+- else
+  :javascript
+    var links = document.getElementsByClassName("auth");
+
+    for (var i = 0; i < links.length; i++) {
+      window.analytics.trackLink(
+        links[i],
+        "Clicked Sign In",
+        { variation: "#{ab_test("auth_button")}" }
+      );
+    }
 
 - if flash[:signed_up]
   :javascript

--- a/app/views/application/_auth_button.haml
+++ b/app/views/application/_auth_button.haml
@@ -1,12 +1,3 @@
 = link_to "/auth/github", class: "auth" do
   %i.fa.fa-github
   %span= ab_test("auth_button")
-
-- content_for :analytics do
-  :javascript
-    var link = document.getElementsByClassName("auth")[0];
-    window.analytics.trackLink(
-      link,
-      "Clicked Sign In",
-      { variation: "#{ab_test("auth_button")}" }
-    );

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
-describe AnalyticsHelper, '#analytics?' do
-  it "is true when ENV['ANALYTICS'] is present" do
-    ENV['ANALYTICS'] = 'anything'
+describe AnalyticsHelper, "#analytics?" do
+  it 'is true when ENV["SEGMENT_KEY"] is present' do
+    ENV["SEGMENT_KEY"] = "anything"
 
     expect(analytics?).to be_truthy
 
-    ENV['ANALYTICS'] = nil
+    ENV["SEGMENT_KEY"] = nil
   end
 
-  it "is false when ENV['ANALYTICS'] is not present" do
-    ENV['ANALYTICS'] = nil
+  it 'is false when ENV["SEGMENT_KEY"] is not present' do
+    ENV["SEGMENT_KEY"] = nil
 
     expect(analytics?).to be_falsy
   end


### PR DESCRIPTION
* Listen for link clinks on all `auth` elements on the page,
  not just the first one in the header.
* Don't add `trackClick` listener for each
  `_auth_button` partial render.

Refactoring:

* Remove unnecessary `ANALYTICS` environment variable.
  This is in line with our other apps.