### PR TITLE
Store utm_source on user

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,7 +26,8 @@ class SessionsController < ApplicationController
   def create_user
     user = User.create!(
       github_username: github_username,
-      email_address: github_email_address
+      email_address: github_email_address,
+      utm_source: session[:campaign_params].try(:[], :utm_source),
     )
     flash[:signed_up] = true
     user

--- a/db/migrate/20150612231322_add_utm_source_to_users.rb
+++ b/db/migrate/20150612231322_add_utm_source_to_users.rb
@@ -1,0 +1,5 @@
+class AddUtmSourceToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :utm_source, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150526214750) do
+ActiveRecord::Schema.define(version: 20150612231322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -109,6 +109,7 @@ ActiveRecord::Schema.define(version: 20150526214750) do
     t.string   "email_address",      limit: 255
     t.string   "stripe_customer_id", limit: 255
     t.string   "token"
+    t.string   "utm_source"
   end
 
   add_index "users", ["remember_token"], name: "index_users_on_remember_token", using: :btree


### PR DESCRIPTION
The goal of this change is to make it easier
to query the customer acquisition channel
where the user came from.