### PR TITLE
Add ability to exclude SCSS files

### DIFF
--- a/app/models/style_guide/scss.rb
+++ b/app/models/style_guide/scss.rb
@@ -1,4 +1,5 @@
 require "scss_lint"
+require "lib/ext/scss-lint/config"
 
 module StyleGuide
   class Scss < Base

--- a/lib/ext/scss-lint/config.rb
+++ b/lib/ext/scss-lint/config.rb
@@ -1,0 +1,15 @@
+# Patch SCSSLint::Config to expand file_path
+# to the same directory as the config file,
+# which is a Tempfile itself.
+module SCSSLint
+  class Config
+    def excluded_file?(file_path)
+      config_file_tmp_dir = Dir.tmpdir
+      abs_path = File.expand_path(file_path, config_file_tmp_dir)
+
+      @options.fetch("exclude", []).any? do |exclusion_glob|
+        File.fnmatch(exclusion_glob, abs_path)
+      end
+    end
+  end
+end

--- a/spec/models/style_guide/scss_spec.rb
+++ b/spec/models/style_guide/scss_spec.rb
@@ -72,23 +72,6 @@ describe StyleGuide::Scss do
           expect(violations_in(content, config)).to eq []
         end
       end
-
-      context "when exclude is provided as string" do
-        it "does not error" do
-          pending
-
-          content = ".a { margin: .5em; }\n"
-          config = {
-            "linters" => {
-              "LeadingZero" => {
-                "exclude" => "lib/**",
-              }
-            }
-          }
-
-          expect(violations_in(content, config)).to be_empty
-        end
-      end
     end
 
     context "over multiple runs" do
@@ -108,11 +91,7 @@ describe StyleGuide::Scss do
   describe "#file_included?" do
     context "when file is excluded" do
       it "returns false" do
-        pending
-
-        config = {
-          "exclude" => "lib/**"
-        }
+        config = { "exclude" => "lib/**" }
         repo_config = double("RepoConfig", for: config)
         style_guide = StyleGuide::Scss.new(repo_config, "ralph")
         file = double("CommitFile", filename: "lib/exclude.scss")


### PR DESCRIPTION
Monkey patch the SCSSLint gem to expand the file path
to the same directory as the config file.
Since the config file is a Tempfile,
that directory can be acquired by creating another Tempfile

This only makes the top level `exclude:` option work
in the SCSSLint configuration file.

`exclude` at each individual SCSS linters level will not work
because we are passing SCSSLint string (file content),
and thus file path is not available when SCSSLint needs it.