### PR TITLE
Save subscription metadata as string

### DIFF
--- a/app/models/payment_gateway_customer.rb
+++ b/app/models/payment_gateway_customer.rb
@@ -26,7 +26,7 @@ class PaymentGatewayCustomer
 
   def find_or_create_subscription(plan:, repo_id:)
     subscriptions.detect { |subscription| subscription.plan == plan } ||
-      create_subscription(plan: plan, metadata: { repo_ids: [repo_id] })
+      create_subscription(plan: plan, metadata: { repo_ids: repo_id })
   end
 
   def subscriptions

--- a/app/models/payment_gateway_subscription.rb
+++ b/app/models/payment_gateway_subscription.rb
@@ -45,7 +45,11 @@ class PaymentGatewaySubscription
   private
 
   def current_repo_ids
-    Array(metadata["repo_ids"] || metadata["repo_id"])
+    if metadata["repo_ids"]
+      metadata["repo_ids"].split(",")
+    else
+      Array(metadata["repo_id"])
+    end
   end
 
   def append_repo_id_to_metadata(repo_id)
@@ -55,12 +59,16 @@ class PaymentGatewaySubscription
       metadata["repo_id"] = nil
     end
 
-    metadata["repo_ids"] = repo_ids.map(&:to_s)
+    metadata["repo_ids"] = repo_ids.join(",")
   end
 
   def remove_repo_id_from_metadata(repo_id)
-    metadata["repo_ids"] = current_repo_ids.reject do |id|
-      id.to_s == repo_id.to_s
+    repo_ids = current_repo_ids.reject { |id| id.to_s == repo_id.to_s }
+
+    if repo_ids.empty?
+      metadata["repo_ids"] = nil
+    else
+      metadata["repo_ids"] = repo_ids.join(",")
     end
   end
 end

--- a/app/services/update_stripe_metadata.rb
+++ b/app/services/update_stripe_metadata.rb
@@ -11,7 +11,7 @@ class UpdateStripeMetadata
       )
 
       if stripe_subscription
-        stripe_subscription.metadata = { repo_ids: [repo.id.to_s] }
+        stripe_subscription.metadata = { repo_ids: repo.id }
         stripe_subscription.save
       end
     end

--- a/spec/models/payment_gateway_subscription_spec.rb
+++ b/spec/models/payment_gateway_subscription_spec.rb
@@ -7,11 +7,11 @@ describe PaymentGatewaySubscription do
         stripe_subscription = MockStripeSubscription.new(repo_ids: [1])
         subscription = PaymentGatewaySubscription.new(stripe_subscription)
 
-        expect(stripe_subscription.metadata["repo_ids"]).to eq ["1"]
+        expect(stripe_subscription.metadata["repo_ids"]).to eq "1"
 
         subscription.subscribe(2)
 
-        expect(stripe_subscription.metadata["repo_ids"]).to eq ["1", "2"]
+        expect(stripe_subscription.metadata["repo_ids"]).to eq "1,2"
       end
 
       it "converts legacy format to new format" do
@@ -23,7 +23,7 @@ describe PaymentGatewaySubscription do
         subscription.subscribe(2)
 
         expect(legacy_subscription.metadata["repo_id"]).to be_nil
-        expect(legacy_subscription.metadata["repo_ids"]).to eq ["1", "2"]
+        expect(legacy_subscription.metadata["repo_ids"]).to eq "1,2"
       end
     end
   end
@@ -37,7 +37,7 @@ describe PaymentGatewaySubscription do
 
       subscription.unsubscribe(2)
 
-      expect(stripe_subscription.metadata["repo_ids"]).to eq ["1"]
+      expect(stripe_subscription.metadata["repo_ids"]).to eq "1"
       expect(stripe_subscription).not_to have_received(:delete)
       expect(stripe_subscription).to have_received(:save)
     end
@@ -60,7 +60,7 @@ describe PaymentGatewaySubscription do
 
     def initialize(repo_ids:)
       @quantity = repo_ids.count
-      @metadata = { "repo_ids" => repo_ids.map(&:to_s) }
+      @metadata = { "repo_ids" => repo_ids.join(",") }
     end
 
     def save; end

--- a/spec/services/repo_subscriber_spec.rb
+++ b/spec/services/repo_subscriber_spec.rb
@@ -15,7 +15,7 @@ describe RepoSubscriber do
           update_request = stub_customer_update_request
           subscription_request = stub_subscription_create_request(
             plan: repo.plan_type,
-            repo_ids: [repo.id],
+            repo_ids: repo.id,
           )
 
           RepoSubscriber.subscribe(repo, user, "cardtoken")
@@ -37,14 +37,13 @@ describe RepoSubscriber do
             repos: [repo],
           )
           stub_customer_find_request_with_subscriptions
-          repo_ids = [repo.id]
           subscription_update_request = stub_subscription_update_request(
             quantity: 2,
-            repo_ids: repo_ids,
+            repo_ids: repo.id,
           )
           subscription_create_request = stub_subscription_create_request(
             plan: repo.plan_type,
-            repo_ids: repo_ids,
+            repo_ids: repo.id,
           )
 
           RepoSubscriber.subscribe(repo, user, "cardtoken")
@@ -63,10 +62,9 @@ describe RepoSubscriber do
         repo = create(:repo)
         user = create(:user, repos: [repo], stripe_customer_id: "",)
         customer_request = stub_customer_create_request(user)
-        subscription_request =
-          stub_subscription_create_request(
-            plan: repo.plan_type,
-            repo_ids: [repo.id],
+        subscription_request = stub_subscription_create_request(
+          plan: repo.plan_type,
+          repo_ids: repo.id,
         )
 
         RepoSubscriber.subscribe(repo, user, "cardtoken")
@@ -111,7 +109,7 @@ describe RepoSubscriber do
         stub_customer_create_request(user)
         stub_subscription_create_request(
           plan: repo.plan_type,
-          repo_ids: [repo.id],
+          repo_ids: repo.id,
         )
         stripe_delete_request = stub_subscription_delete_request
         allow(repo).to receive(:create_subscription!).and_raise(StandardError)
@@ -172,7 +170,7 @@ describe RepoSubscriber do
         stub_subscription_find_request(subscription, quantity: 2)
         stripe_delete_request = stub_subscription_delete_request
         subscription_update_request = stub_subscription_update_request(
-          quantity: 1
+          quantity: 1,
         )
 
         RepoSubscriber.unsubscribe(subscription.repo, subscription.user)

--- a/spec/support/helpers/stripe_api_helper.rb
+++ b/spec/support/helpers/stripe_api_helper.rb
@@ -77,10 +77,10 @@ module StripeApiHelper
     )
   end
 
-  def stub_subscription_create_request(plan: "free", repo_ids: [])
+  def stub_subscription_create_request(plan: "free", repo_ids: "")
     body = {
       "plan" => plan,
-      "metadata" => { "repo_ids" => repo_ids.map(&:to_s) }
+      "metadata" => { "repo_ids" => repo_ids.to_s }
     }
     stub_request(
       :post,
@@ -95,11 +95,12 @@ module StripeApiHelper
   end
 
   def stub_subscription_update_request(quantity: 1, repo_ids: nil)
-    body = { "quantity" => quantity.to_s }
-
-    if repo_ids.present?
-      body["metadata"] = { repo_ids: repo_ids.map(&:to_s) }
-    end
+    body = {
+      quantity: quantity.to_s,
+      metadata: {
+        repo_ids: repo_ids.to_s,
+      },
+    }
 
     stub_request(
       :post,
@@ -146,7 +147,7 @@ module StripeApiHelper
       "#{stripe_base_url}/#{stripe_customer_id}/"\
         "subscriptions/#{stripe_subscription_id}"
     ).with(
-      body: "metadata[repo_ids][]=#{subscription.repo_id}",
+      body: { metadata: { repo_ids: subscription.repo_id.to_s } },
       headers: { "Authorization" => "Bearer #{ENV["STRIPE_API_KEY"]}" }
     ).to_return(
       status: 200,


### PR DESCRIPTION
Stripe metadata does not support arrays.
The metadata must be a string.

Fixes these errors from Stripe:

    {
      error:
      {
        type: "invalid_request_error"
        message: "Invalid val: ["161936", "326736"] must be a string under 500 characters"
        param: "metadata"
      }
    }