### PR TITLE
Fix load path of the scss-lint patch

### DIFF
--- a/app/models/style_guide/scss.rb
+++ b/app/models/style_guide/scss.rb
@@ -1,5 +1,5 @@
 require "scss_lint"
-require "lib/ext/scss-lint/config"
+require "ext/scss-lint/config"
 
 module StyleGuide
   class Scss < Base


### PR DESCRIPTION
Since `lib/` is being auto-loaded, we don't need to specify it.