### PR TITLE
Extract PR status setting to CommitStatus class

### DIFF
--- a/app/jobs/completed_file_review_job.rb
+++ b/app/jobs/completed_file_review_job.rb
@@ -35,7 +35,11 @@ class CompletedFileReviewJob
     payload = Payload.new(build.payload)
     pull_request = PullRequest.new(payload, ENV.fetch("HOUND_GITHUB_TOKEN"))
 
-    BuildReport.run(pull_request, build)
+    BuildReport.run(
+      pull_request: pull_request,
+      build: build,
+      token: build.user_token,
+    )
   rescue ActiveRecord::RecordNotFound, Resque::TermException
     Resque.enqueue(self, attributes)
   end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -1,5 +1,6 @@
 class Build < ActiveRecord::Base
   belongs_to :repo
+  belongs_to :user
   has_many :file_reviews, dependent: :destroy
   has_many :violations, through: :file_reviews
 
@@ -7,8 +8,18 @@ class Build < ActiveRecord::Base
 
   validates :repo, presence: true
 
+  delegate :name, to: :repo, prefix: true
+
   def completed?
     file_reviews.where(completed_at: nil).empty?
+  end
+
+  def violation_count
+    violations.map(&:messages_count).sum
+  end
+
+  def user_token
+    (user && user.token) || Hound::GITHUB_TOKEN
   end
 
   private

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -1,0 +1,33 @@
+class CommitStatus
+  def initialize(repo_name:, sha:, token:)
+    @repo_name = repo_name
+    @sha = sha
+    @token = token
+  end
+
+  def set_pending
+    github.create_pending_status(repo_name, sha, I18n.t(:pending_status))
+  end
+
+  def set_success(violation_count)
+    message = I18n.t(:success_status, count: violation_count)
+    github.create_success_status(repo_name, sha, message)
+  end
+
+  def set_failure
+    message = I18n.t(:config_error_status)
+    github.create_error_status(repo_name, sha, message, configuration_url)
+  end
+
+  private
+
+  attr_reader :repo_name, :sha, :token
+
+  def configuration_url
+    Rails.application.routes.url_helpers.configuration_url(host: ENV["HOST"])
+  end
+
+  def github
+    @github ||= GithubApi.new(token)
+  end
+end

--- a/app/services/build_report.rb
+++ b/app/services/build_report.rb
@@ -1,54 +1,30 @@
-require "attr_extras"
-
 class BuildReport
   MAX_COMMENTS = ENV.fetch("MAX_COMMENTS").to_i
 
-  def self.run(pull_request, build)
-    new(pull_request, build).run
+  def self.run(pull_request:, build:, token:)
+    new(pull_request: pull_request, build: build, token: token).run
   end
 
-  pattr_initialize :pull_request, :build
+  def initialize(pull_request:, build:, token:)
+    @build = build
+    @pull_request = pull_request
+    @token = token
+  end
 
   def run
     if build.completed?
-      commenter.comment_on_violations(priority_violations)
-      create_success_status
+      Commenter.new(pull_request).comment_on_violations(priority_violations)
+      commit_status.set_success(build.violation_count)
       track_subscribed_build_completed
     end
   end
 
   private
 
-  def commenter
-    Commenter.new(pull_request)
-  end
-
-  def token
-    ENV.fetch("HOUND_GITHUB_TOKEN")
-  end
-
-  def violations
-    build.violations
-  end
+  attr_reader :build, :token, :pull_request
 
   def priority_violations
-    violations.take(MAX_COMMENTS)
-  end
-
-  def create_success_status
-    github.create_success_status(
-      pull_request.head_commit.repo_name,
-      pull_request.head_commit.sha,
-      I18n.t(:success_status, count: violation_count),
-    )
-  end
-
-  def violation_count
-    violations.map(&:messages_count).sum
-  end
-
-  def github
-    @github ||= GithubApi.new(token)
+    build.violations.take(MAX_COMMENTS)
   end
 
   def track_subscribed_build_completed
@@ -57,5 +33,13 @@ class BuildReport
       analytics = Analytics.new(user)
       analytics.track_build_completed(build.repo)
     end
+  end
+
+  def commit_status
+    CommitStatus.new(
+      repo_name: build.repo_name,
+      sha: build.commit_sha,
+      token: token,
+    )
   end
 end

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,0 +1,3 @@
+module Hound
+  GITHUB_TOKEN = ENV.fetch("HOUND_GITHUB_TOKEN")
+end

--- a/db/migrate/20150710220040_associate_user_to_build.rb
+++ b/db/migrate/20150710220040_associate_user_to_build.rb
@@ -1,0 +1,5 @@
+class AssociateUserToBuild < ActiveRecord::Migration
+  def change
+    add_column :builds, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150619222741) do
+ActiveRecord::Schema.define(version: 20150710220040) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 20150619222741) do
     t.integer  "pull_request_number"
     t.string   "commit_sha",          limit: 255
     t.text     "payload"
+    t.integer  "user_id"
   end
 
   add_index "builds", ["repo_id"], name: "index_builds_on_repo_id", using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
   sequence(:github_name) { |n| "github_name#{n}" }
 
   factory :build do
+    commit_sha "somesha"
     repo
   end
 

--- a/spec/jobs/completed_file_review_job_spec.rb
+++ b/spec/jobs/completed_file_review_job_spec.rb
@@ -24,7 +24,11 @@ describe CompletedFileReviewJob do
 
       CompletedFileReviewJob.perform(attributes)
 
-      expect(BuildReport).to have_received(:run).with(pull_request, build)
+      expect(BuildReport).to have_received(:run).with(
+        pull_request: pull_request,
+        build: build,
+        token: Hound::GITHUB_TOKEN,
+      )
       expect(Payload).to have_received(:new).with(build.payload)
       expect(PullRequest).to(
         have_received(:new).with(payload, ENV.fetch("HOUND_GITHUB_TOKEN"))
@@ -78,8 +82,9 @@ describe CompletedFileReviewJob do
         CompletedFileReviewJob.perform(attributes)
 
         expect(BuildReport).to have_received(:run).with(
-          pull_request,
-          correct_build
+          pull_request: pull_request,
+          build: correct_build,
+          token: Hound::GITHUB_TOKEN,
         )
       end
     end

--- a/spec/models/build_spec.rb
+++ b/spec/models/build_spec.rb
@@ -10,12 +10,46 @@ describe Build do
   describe "validations" do
     it { should validate_presence_of :repo }
   end
-end
 
-describe Build, 'on create' do
-  it 'generates a UUID' do
-    build = create(:build)
+  context "on create" do
+    it "generates a UUID" do
+      build = create(:build)
 
-    expect(build.uuid).to be_present
+      expect(build.uuid).to be_present
+    end
+  end
+
+  describe "#violation_count" do
+    it "returns count of violation messages in the build" do
+      build = build(:build)
+      violation1 = build(:violation, messages: ["one", "two"])
+      violation2 = build(:violation, messages: ["three", "four"])
+      create(
+        :file_review,
+        violations: [violation1, violation2],
+        build: build,
+      )
+
+      expect(build.violation_count).to eq 4
+    end
+  end
+
+  describe "#user_token" do
+    context "when user is associated with a build" do
+      it "returns the user's token" do
+        user = build(:user, token: "sometoken")
+        build = build(:build, user: user)
+
+        expect(build.user_token).to eq user.token
+      end
+    end
+
+    context "when user is not associated" do
+      it "returns the houndci's token" do
+        build = build(:build)
+
+        expect(build.user_token).to eq Hound::GITHUB_TOKEN
+      end
+    end
   end
 end

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -37,7 +37,11 @@ describe BuildRunner, '#run' do
 
       build_runner.run
 
-      expect(BuildReport).to have_received(:run).with(pull_request, Build.last)
+      expect(BuildReport).to have_received(:run).with(
+        build: Build.last,
+        pull_request: pull_request,
+        token: Hound::GITHUB_TOKEN,
+      )
     end
 
     it 'initializes StyleChecker with modified files and config' do
@@ -90,7 +94,12 @@ describe BuildRunner, '#run' do
       expect(github_api).to have_received(:create_pending_status).with(
         "test/repo",
         "headsha",
-        "Hound is busy reviewing changes..."
+        I18n.t(:pending_status),
+      )
+      expect(github_api).to have_received(:create_success_status).with(
+        "test/repo",
+        "headsha",
+        I18n.t(:success_status, count: 3),
       )
     end
 
@@ -259,7 +268,7 @@ describe BuildRunner, '#run' do
   end
 
   def stubbed_style_checker(violations:)
-    file_review = build(:file_review, violations: violations)
+    file_review = build(:file_review, :completed, violations: violations)
     style_checker = double("StyleChecker", file_reviews: [file_review])
     allow(StyleChecker).to receive(:new).and_return(style_checker)
 


### PR DESCRIPTION
This solves the issue where the app was always setting
the final success status with `houndci`'s token,
instead of user's token (if available).

This also gets all that code out of `BuildRunner`
and into its own `CommitStatus` class.