### PR TITLE
Exclude predicate matcher rule for RSpec specs

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -310,6 +310,8 @@ Style/PredicateName:
   - have_
   NamePrefixBlacklist:
   - is_
+  Exclude:
+  - spec/**/*
 Style/RaiseArgs:
   Description: Checks the arguments passed to raise/fail.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#exception-class-messages

--- a/config/style_guides/thoughtbot/ruby.yml
+++ b/config/style_guides/thoughtbot/ruby.yml
@@ -171,6 +171,8 @@ PerlBackrefs:
 PredicateName:
   NamePrefixBlacklist:
     - is_
+  Exclude:
+    - spec/**/*
 
 Proc:
   Enabled: false


### PR DESCRIPTION
Using [Predicate matchers][predicates] is a common convention
within the RSpec community.

[Related blog post][blog-post].

[predicates]: https://www.relishapp.com/rspec/rspec-expectations/v/3-2/docs/built-in-matchers/predicate-matchers
[blog-post]: http://www.elabs.se/blog/51-simple-tricks-to-clean-up-your-capybara-tests