### PR TITLE
Don't hard-fail on repo update during sync

### DIFF
--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -144,6 +144,24 @@ describe Repo do
         expect(repo.reload).to be_present
       end
     end
+
+    context "when one repo has taken the github name and another taken id" do
+      it "repors update failure" do
+        github_name = "foo/bar"
+        github_id = 40023
+        _repo_with_id = create(:repo, github_id: github_id)
+        _repo_with_name = create(:repo, full_github_name: github_name)
+        new_attributes = { github_id: github_id, full_github_name: github_name }
+        allow(Raven).to receive(:capture_exception)
+
+        Repo.find_or_create_with(new_attributes)
+
+        expect(Raven).to have_received(:capture_exception).with(
+          instance_of(ActiveRecord::RecordInvalid),
+          extra: { github_id: github_id, full_github_name: github_name }
+        )
+      end
+    end
   end
 
   describe ".find_and_update" do


### PR DESCRIPTION
There are situations when both github_id and github_name are taken
by other repos. We don't want to fail the sync in that case,
but we do want to get notified, and address those repos manually.