### PR TITLE
Reschedule job if build hasn't been created yet

### DIFF
--- a/app/jobs/completed_file_review_job.rb
+++ b/app/jobs/completed_file_review_job.rb
@@ -9,7 +9,7 @@ class CompletedFileReviewJob
     #   [{ line: 123, message: "WAT" }]
 
     build = Build.find_by!(commit_sha: attributes.fetch("commit_sha"))
-    file_review = build.file_reviews.find_by!(
+    file_review = build.file_reviews.find_by(
       filename: attributes.fetch("filename")
     )
 
@@ -33,5 +33,7 @@ class CompletedFileReviewJob
     pull_request = PullRequest.new(payload, ENV.fetch("HOUND_GITHUB_TOKEN"))
 
     BuildReport.run(pull_request, build)
+  rescue ActiveRecord::RecordNotFound
+    Resque.enqueue(self, attributes)
   end
 end

--- a/spec/jobs/completed_file_review_job_spec.rb
+++ b/spec/jobs/completed_file_review_job_spec.rb
@@ -30,6 +30,18 @@ describe CompletedFileReviewJob do
         have_received(:new).with(payload, ENV.fetch("HOUND_GITHUB_TOKEN"))
       )
     end
+
+    context "when build doesn't exist" do
+      it "enqueues job" do
+        allow(Resque).to receive(:enqueue)
+
+        CompletedFileReviewJob.perform(attributes)
+
+        expect(Resque).to(
+          have_received(:enqueue).with(CompletedFileReviewJob, attributes)
+        )
+      end
+    end
   end
 
   def attributes


### PR DESCRIPTION
I believe there are cases where a SCSS review can finish before the build is saved. This change handles that case by rescheduling the `CompletedFileReview` job when the build doesn't exist.