### PR TITLE
Handle Resque::TermException in CompletedReviewJob

### DIFF
--- a/app/jobs/completed_file_review_job.rb
+++ b/app/jobs/completed_file_review_job.rb
@@ -33,7 +33,7 @@ class CompletedFileReviewJob
     pull_request = PullRequest.new(payload, ENV.fetch("HOUND_GITHUB_TOKEN"))
 
     BuildReport.run(pull_request, build)
-  rescue ActiveRecord::RecordNotFound
+  rescue ActiveRecord::RecordNotFound, Resque::TermException
     Resque.enqueue(self, attributes)
   end
 end

--- a/spec/jobs/completed_file_review_job_spec.rb
+++ b/spec/jobs/completed_file_review_job_spec.rb
@@ -42,6 +42,21 @@ describe CompletedFileReviewJob do
         )
       end
     end
+
+    context "when Resque process is killed" do
+      it "enqueues job" do
+        allow(Build).to(
+          receive(:find_by!).and_raise(Resque::TermException.new(1))
+        )
+        allow(Resque).to receive(:enqueue)
+
+        CompletedFileReviewJob.perform(attributes)
+
+        expect(Resque).to(
+          have_received(:enqueue).with(CompletedFileReviewJob, attributes)
+        )
+      end
+    end
   end
 
   def attributes


### PR DESCRIPTION
This is recommended by Heroku and is necessary since we aren't extending `ApplicationJob`. We aren't extending `ApplicationJob` because the style review services serialize jobs using the job class, not `ActiveJob`s wrapper class.