### PR TITLE
Refactor CommitFile

### DIFF
--- a/app/jobs/completed_file_review_job.rb
+++ b/app/jobs/completed_file_review_job.rb
@@ -4,22 +4,25 @@ class CompletedFileReviewJob
   def self.perform(attributes)
     # filename
     # commit_sha
+    # pull_request_number
     # patch
     # violations
     #   [{ line: 123, message: "WAT" }]
 
-    build = Build.find_by!(commit_sha: attributes.fetch("commit_sha"))
+    build = Build.find_by!(
+      pull_request_number: attributes.fetch("pull_request_number"),
+      commit_sha: attributes.fetch("commit_sha")
+    )
     file_review = build.file_reviews.find_by(
       filename: attributes.fetch("filename")
     )
-
-    file = OpenStruct.new(
+    commit_file = CommitFile.new(
       filename: file_review.filename,
-      patch: attributes.fetch("patch")
+      content: "",
+      patch: attributes.fetch("patch"),
+      pull_request_number: attributes.fetch("pull_request_number"),
+      sha: build.commit_sha
     )
-
-    commit = Commit.new(build.repo.full_github_name, build.commit_sha, nil)
-    commit_file = commit_file = CommitFile.new(file, commit)
 
     attributes.fetch("violations").each do |violation|
       line = commit_file.line_at(violation.fetch("line"))

--- a/app/models/commit_file.rb
+++ b/app/models/commit_file.rb
@@ -1,12 +1,12 @@
 class CommitFile
-  pattr_initialize :file, :commit
+  attr_reader :filename, :content, :patch, :pull_request_number, :sha
 
-  def filename
-    file.filename
-  end
-
-  def content
-    @content ||= commit.file_content(filename)
+  def initialize(filename:, content:, patch:, pull_request_number:, sha:)
+    @filename = filename
+    @content = content
+    @patch = patch
+    @pull_request_number = pull_request_number
+    @sha = sha
   end
 
   def line_at(line_number)
@@ -14,21 +14,9 @@ class CommitFile
       UnchangedLine.new
   end
 
-  def sha
-    commit.sha
-  end
-
-  def patch_body
-    file.patch
-  end
-
   private
 
   def changed_lines
-    @changed_lines ||= patch.changed_lines
-  end
-
-  def patch
-    Patch.new(file.patch)
+    @changed_lines ||= Patch.new(patch).changed_lines
   end
 end

--- a/app/models/style_checker.rb
+++ b/app/models/style_checker.rb
@@ -8,8 +8,8 @@ class StyleChecker
   end
 
   def file_reviews
-    files_to_check.map do |file|
-      style_guide(file.filename).file_review(file)
+    commit_files_to_check.map do |commit_file|
+      style_guide(commit_file.filename).file_review(commit_file)
     end
   end
 
@@ -17,8 +17,8 @@ class StyleChecker
 
   attr_reader :pull_request, :style_guides
 
-  def files_to_check
-    pull_request.pull_request_files.select do |file|
+  def commit_files_to_check
+    pull_request.commit_files.select do |file|
       file_style_guide = style_guide(file.filename)
       file_style_guide.enabled? && file_style_guide.file_included?(file)
     end

--- a/app/models/style_guide/coffee_script.rb
+++ b/app/models/style_guide/coffee_script.rb
@@ -4,12 +4,12 @@ module StyleGuide
     DEFAULT_CONFIG_FILENAME = "coffeescript.json"
     ERB_TAGS = /<%.*%>/
 
-    def file_review(file)
-      FileReview.new(filename: file.filename) do |file_review|
-        content = content_for_file(file)
+    def file_review(commit_file)
+      FileReview.new(filename: commit_file.filename) do |file_review|
+        content = content_for_file(commit_file)
 
         lint(content).each do |violation|
-          line = file.line_at(violation["lineNumber"])
+          line = commit_file.line_at(violation["lineNumber"])
           file_review.build_violation(line, violation["message"])
         end
 

--- a/app/models/style_guide/haml.rb
+++ b/app/models/style_guide/haml.rb
@@ -2,12 +2,12 @@ module StyleGuide
   class Haml < Base
     DEFAULT_CONFIG_FILENAME = "haml.yml"
 
-    def file_review(file)
-      @file = file
+    def file_review(commit_file)
+      @commit_file = commit_file
 
-      FileReview.new(filename: file.filename) do |file_review|
+      FileReview.new(filename: commit_file.filename) do |file_review|
         run_linters.map do |violation|
-          line = file.line_at(violation.line)
+          line = commit_file.line_at(violation.line)
 
           file_review.build_violation(line, violation.message)
         end
@@ -21,10 +21,10 @@ module StyleGuide
 
     private
 
-    attr_reader :file
+    attr_reader :commit_file
 
     def parser
-      @parser ||= HamlLint::Parser.new(file.content, {})
+      @parser ||= HamlLint::Parser.new(commit_file.content, {})
     end
 
     def run_linters

--- a/app/models/style_guide/java_script.rb
+++ b/app/models/style_guide/java_script.rb
@@ -2,18 +2,20 @@ module StyleGuide
   class JavaScript < Base
     DEFAULT_CONFIG_FILENAME = "javascript.json"
 
-    def file_review(file)
-      FileReview.new(filename: file.filename) do |file_review|
-        Jshintrb.lint(file.content, config).compact.each do |violation|
-          line = file.line_at(violation["line"])
+    def file_review(commit_file)
+      FileReview.new(filename: commit_file.filename) do |file_review|
+        Jshintrb.lint(commit_file.content, config).compact.each do |violation|
+          line = commit_file.line_at(violation["line"])
           file_review.build_violation(line, violation["reason"])
         end
         file_review.complete
       end
     end
 
-    def file_included?(file)
-      !excluded_files.any? { |pattern| File.fnmatch?(pattern, file.filename) }
+    def file_included?(commit_file)
+      !excluded_files.any? do |pattern|
+        File.fnmatch?(pattern, commit_file.filename)
+      end
     end
 
     private

--- a/app/models/style_guide/ruby.rb
+++ b/app/models/style_guide/ruby.rb
@@ -3,20 +3,20 @@ module StyleGuide
   class Ruby < Base
     DEFAULT_CONFIG_FILENAME = "ruby.yml"
 
-    def file_review(file)
-      perform_file_review(file)
+    def file_review(commit_file)
+      perform_file_review(commit_file)
     end
 
-    def file_included?(file)
-      !config.file_to_exclude?(file.filename)
+    def file_included?(commit_file)
+      !config.file_to_exclude?(commit_file.filename)
     end
 
     private
 
-    def perform_file_review(file)
-      FileReview.new(filename: file.filename) do |file_review|
-        team.inspect_file(parsed_source(file)).each do |violation|
-          line = file.line_at(violation.line)
+    def perform_file_review(commit_file)
+      FileReview.new(filename: commit_file.filename) do |file_review|
+        team.inspect_file(parsed_source(commit_file)).each do |violation|
+          line = commit_file.line_at(violation.line)
           file_review.build_violation(line, violation.message)
         end
         file_review.complete
@@ -27,9 +27,9 @@ module StyleGuide
       RuboCop::Cop::Team.new(RuboCop::Cop::Cop.all, config, rubocop_options)
     end
 
-    def parsed_source(file)
-      absolute_filepath = File.expand_path(file.filename)
-      RuboCop::ProcessedSource.new(file.content, absolute_filepath)
+    def parsed_source(commit_file)
+      absolute_filepath = File.expand_path(commit_file.filename)
+      RuboCop::ProcessedSource.new(commit_file.content, absolute_filepath)
     end
 
     def config

--- a/app/models/style_guide/scss.rb
+++ b/app/models/style_guide/scss.rb
@@ -2,17 +2,18 @@ module StyleGuide
   class Scss < Base
     LANGUAGE = "scss"
 
-    def file_review(file)
+    def file_review(commit_file)
       Resque.enqueue(
         ScssReviewJob,
-        filename: file.filename,
-        commit_sha: file.sha,
-        patch: file.patch_body,
-        content: file.content,
+        filename: commit_file.filename,
+        commit_sha: commit_file.sha,
+        pull_request_number: commit_file.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
         config: repo_config.raw_for(LANGUAGE)
       )
 
-      FileReview.new(filename: file.filename)
+      FileReview.new(filename: commit_file.filename)
     end
 
     def file_included?(_)

--- a/app/models/style_guide/unsupported.rb
+++ b/app/models/style_guide/unsupported.rb
@@ -3,8 +3,8 @@ module StyleGuide
   class Unsupported < Base
     class CannotReviewUnsupportedFile < StandardError; end
 
-    def file_review(file)
-      raise CannotReviewUnsupportedFile.new(file.filename)
+    def file_review(commit_file)
+      raise CannotReviewUnsupportedFile.new(commit_file.filename)
     end
 
     def file_included?(*)

--- a/spec/models/commit_file_spec.rb
+++ b/spec/models/commit_file_spec.rb
@@ -28,22 +28,43 @@ describe CommitFile do
     end
   end
 
-  describe "#content" do
-    it "returns content string" do
-      commit_file = commit_file(status: "modified")
+  describe "#filename" do
+    it "returns filename" do
+      expect(commit_file.filename).to eq "test.rb"
+    end
+  end
 
-      expect(commit_file.content).to eq "some content"
+  describe "#content" do
+    it "returns content" do
+      expect(commit_file.content).to eq "content"
+    end
+  end
+
+  describe "#patch" do
+    it "returns patch" do
+      expect(commit_file.patch).to eq "patch"
+    end
+  end
+
+  describe "#pull_request_number" do
+    it "returns pull request number" do
+      expect(commit_file.pull_request_number).to eq 123
+    end
+  end
+
+  describe "#sha" do
+    it "returns sha" do
+      expect(commit_file.sha).to eq "abc123"
     end
   end
 
   def commit_file(options = {})
-    file = double(:file, options.reverse_merge(patch: "", filename: "test.rb"))
-    commit = double(
-      :commit,
-      repo_name: "test/test",
-      sha: "abc",
-      file_content: "some content"
+    CommitFile.new(
+      filename: "test.rb",
+      content: "content",
+      patch: "patch",
+      pull_request_number: 123,
+      sha: "abc123"
     )
-    CommitFile.new(file, commit)
   end
 end

--- a/spec/models/patch_spec.rb
+++ b/spec/models/patch_spec.rb
@@ -5,8 +5,8 @@ require 'app/models/line'
 describe Patch do
   describe "#changed_lines" do
     it 'returns lines that were modified' do
-      patch_body = File.read('spec/support/fixtures/patch.diff')
-      patch = Patch.new(patch_body)
+      patch_text = File.read('spec/support/fixtures/patch.diff')
+      patch = Patch.new(patch_text)
 
       expect(patch.changed_lines.size).to eq(3)
       expect(patch.changed_lines.map(&:number)).to eq [14, 22, 54]

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -80,20 +80,36 @@ describe PullRequest do
     end
   end
 
-  describe "#pull_request_files" do
+  describe "#commit_files" do
     it "does not include removed files" do
-      added_file = double(filename: "foo.rb", status: "added")
-      modified_file = double(filename: "baz.rb", status: "modified")
-      removed_file = double(filename: "bar.rb", status: "removed")
-      all_pull_request_files = [added_file, removed_file, modified_file]
-      github = double(:github, pull_request_files: all_pull_request_files)
+      added_github_file = double(
+        filename: "foo.rb",
+        status: "added",
+        patch: "patch"
+      )
+      modified_github_file = double(
+        filename: "baz.rb",
+        status: "modified",
+        patch: "patch"
+      )
+      removed_github_file = double(
+        filename: "bar.rb",
+        status: "removed"
+      )
+      all_github_files = [
+        added_github_file,
+        removed_github_file,
+        modified_github_file
+      ]
+      github = double(:github, pull_request_files: all_github_files)
       pull_request = pull_request_stub(github)
+      commit = double("Commit", file_content: "content", sha: "abc123")
+      allow(Commit).to receive(:new).and_return(commit)
 
-      files = pull_request.pull_request_files
-      file_names = files.map(&:filename)
+      commit_files = pull_request.commit_files
 
-      expect(file_names).to match_array(
-        [added_file.filename, modified_file.filename]
+      expect(commit_files.map(&:filename)).to match_array(
+        [added_github_file.filename, modified_github_file.filename]
       )
     end
   end

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -2,10 +2,11 @@ require "rails_helper"
 
 describe StyleChecker, "#file_reviews" do
   it "returns a collection of file reviews with violations" do
-    stylish_file = stub_commit_file("good.rb", "def good; end")
-    violated_file = stub_commit_file("bad.rb", "def bad( a ); a; end  ")
-    pull_request =
-      stub_pull_request(pull_request_files: [stylish_file, violated_file])
+    stylish_commit_file = stub_commit_file("good.rb", "def good; end")
+    violated_commit_file = stub_commit_file("bad.rb", "def bad( a ); a; end  ")
+    pull_request = stub_pull_request(
+      commit_files: [stylish_commit_file, violated_commit_file]
+    )
     expected_violations = [
       "Unnecessary spacing detected.",
       "Space inside parentheses detected.",
@@ -20,8 +21,8 @@ describe StyleChecker, "#file_reviews" do
   context "for a Ruby file" do
     context "with style violations" do
       it "returns violations" do
-        file = stub_commit_file("ruby.rb", "puts 123    ")
-        pull_request = stub_pull_request(pull_request_files: [file])
+        commit_file = stub_commit_file("ruby.rb", "puts 123    ")
+        pull_request = stub_pull_request(commit_files: [commit_file])
         expected_violations = [
           "Unnecessary spacing detected.",
           "Trailing whitespace detected.",
@@ -35,8 +36,12 @@ describe StyleChecker, "#file_reviews" do
 
     context "with style violation on unchanged line" do
       it "returns no violations" do
-        file = stub_commit_file("foo.rb", "'wrong quotes'", UnchangedLine.new)
-        pull_request = stub_pull_request(pull_request_files: [file])
+        commit_file = stub_commit_file(
+          "foo.rb",
+          "'wrong quotes'",
+          UnchangedLine.new
+        )
+        pull_request = stub_pull_request(commit_files: [commit_file])
 
         violation_messages = pull_request_violations(pull_request)
 
@@ -46,8 +51,8 @@ describe StyleChecker, "#file_reviews" do
 
     context "without style violations" do
       it "returns no violations" do
-        file = stub_commit_file("ruby.rb", "puts 123")
-        pull_request = stub_pull_request(pull_request_files: [file])
+        commit_file = stub_commit_file("ruby.rb", "puts 123")
+        pull_request = stub_pull_request(commit_files: [commit_file])
 
         violation_messages = pull_request_violations(pull_request)
 
@@ -58,8 +63,8 @@ describe StyleChecker, "#file_reviews" do
 
   context "for a CoffeeScript file" do
     it "is processed with a coffee.js extension" do
-      file = stub_commit_file("test.coffee.js", "foo ->")
-      pull_request = stub_pull_request(pull_request_files: [file])
+      commit_file = stub_commit_file("test.coffee.js", "foo ->")
+      pull_request = stub_pull_request(commit_files: [commit_file])
       allow(RepoConfig).to receive(:new).and_return(stub_repo_config)
 
       violation_messages = pull_request_violations(pull_request)
@@ -68,8 +73,11 @@ describe StyleChecker, "#file_reviews" do
     end
 
     it "is processed with a coffee.erb extension" do
-      file = stub_commit_file("test.coffee.erb", "class strange_ClassNAME")
-      pull_request = stub_pull_request(pull_request_files: [file])
+      commit_file = stub_commit_file(
+        "test.coffee.erb",
+        "class strange_ClassNAME"
+      )
+      pull_request = stub_pull_request(commit_files: [commit_file])
       allow(RepoConfig).to receive(:new).and_return(stub_repo_config)
 
       violation_messages = pull_request_violations(pull_request)
@@ -79,8 +87,8 @@ describe StyleChecker, "#file_reviews" do
 
     context "with style violations" do
       it "returns violations" do
-        file = stub_commit_file("test.coffee", "foo: ->")
-        pull_request = stub_pull_request(pull_request_files: [file])
+        commit_file = stub_commit_file("test.coffee", "foo: ->")
+        pull_request = stub_pull_request(commit_files: [commit_file])
 
         violation_messages = pull_request_violations(pull_request)
 
@@ -90,8 +98,8 @@ describe StyleChecker, "#file_reviews" do
 
     context "without style violations" do
       it "returns no violations" do
-        file = stub_commit_file("test.coffee", "alert('Hello World')")
-        pull_request = stub_pull_request(pull_request_files: [file])
+        commit_file = stub_commit_file("test.coffee", "alert('Hello World')")
+        pull_request = stub_pull_request(commit_files: [commit_file])
 
         violation_messages = pull_request_violations(pull_request)
 
@@ -103,8 +111,8 @@ describe StyleChecker, "#file_reviews" do
   context "for a JavaScript file" do
     context "with style violations" do
       it "returns violations" do
-        file = stub_commit_file("test.js", "var test = 'test'")
-        pull_request = stub_pull_request(pull_request_files: [file])
+        commit_file = stub_commit_file("test.js", "var test = 'test'")
+        pull_request = stub_pull_request(commit_files: [commit_file])
 
         violation_messages = pull_request_violations(pull_request)
 
@@ -114,8 +122,8 @@ describe StyleChecker, "#file_reviews" do
 
     context "without style violations" do
       it "returns no violations" do
-        file = stub_commit_file("test.js", "var test = 'test';")
-        pull_request = stub_pull_request(pull_request_files: [file])
+        commit_file = stub_commit_file("test.js", "var test = 'test';")
+        pull_request = stub_pull_request(commit_files: [commit_file])
 
         violation_messages = pull_request_violations(pull_request)
 
@@ -135,10 +143,10 @@ describe StyleChecker, "#file_reviews" do
           ".jshintignore" => "test.js"
         )
 
-        file = stub_commit_file("test.js", "var test = 'test'")
+        commit_file = stub_commit_file("test.js", "var test = 'test'")
         pull_request = stub_pull_request(
           head_commit: head_commit,
-          pull_request_files: [file]
+          commit_files: [commit_file]
         )
 
         violation_messages = pull_request_violations(pull_request)
@@ -150,8 +158,8 @@ describe StyleChecker, "#file_reviews" do
 
   context "for a SCSS file" do
     it "does not immediately return violations" do
-      file = stub_commit_file("test.scss", "* { color: red; }")
-      pull_request = stub_pull_request(pull_request_files: [file])
+      commit_file = stub_commit_file("test.scss", "* { color: red; }")
+      pull_request = stub_pull_request(commit_files: [commit_file])
 
       violation_messages = pull_request_violations(pull_request)
 
@@ -162,8 +170,8 @@ describe StyleChecker, "#file_reviews" do
   context "for a Haml file" do
     context "with style violations" do
       it "returns no violations" do
-        file = stub_commit_file("test.haml", "%div.message 123")
-        pull_request = stub_pull_request(pull_request_files: [file])
+        commit_file = stub_commit_file("test.haml", "%div.message 123")
+        pull_request = stub_pull_request(commit_files: [commit_file])
 
         violation_messages = pull_request_violations(pull_request)
 
@@ -173,8 +181,8 @@ describe StyleChecker, "#file_reviews" do
 
     context "without style violations" do
       it "returns no violations" do
-        file = stub_commit_file("test.haml", ".message 123")
-        pull_request = stub_pull_request(pull_request_files: [file])
+        commit_file = stub_commit_file("test.haml", ".message 123")
+        pull_request = stub_pull_request(commit_files: [commit_file])
 
         violation_messages = pull_request_violations(pull_request)
 
@@ -187,8 +195,11 @@ describe StyleChecker, "#file_reviews" do
 
   context "with unsupported file type" do
     it "uses unsupported style guide" do
-      file = stub_commit_file("fortran.f", %{PRINT *, "Hello World!"\nEND})
-      pull_request = stub_pull_request(pull_request_files: [file])
+      commit_file = stub_commit_file(
+        "fortran.f",
+        %{PRINT *, "Hello World!"\nEND}
+      )
+      pull_request = stub_pull_request(commit_files: [commit_file])
 
       violation_messages = pull_request_violations(pull_request)
 
@@ -207,7 +218,7 @@ describe StyleChecker, "#file_reviews" do
     defaults = {
       file_content: "",
       head_commit: head_commit,
-      pull_request_files: [],
+      commit_files: [],
       repository_owner_name: "some_org"
     }
 
@@ -223,7 +234,8 @@ describe StyleChecker, "#file_reviews" do
       content: formatted_contents,
       line_at: line,
       sha: "abc123",
-      patch_body: "patchbody"
+      patch: "patch",
+      pull_request_number: 123
     )
   end
 

--- a/spec/models/style_guide/java_script_spec.rb
+++ b/spec/models/style_guide/java_script_spec.rb
@@ -7,9 +7,9 @@ describe StyleGuide::JavaScript do
     it "returns a completed file review" do
       repo_config = double("RepoConfig", enabled_for?: true, for: {})
       style_guide = StyleGuide::JavaScript.new(repo_config, "bob")
-      file = build_file
+      commit_file = build_commit_file
 
-      result = style_guide.file_review(file)
+      result = style_guide.file_review(commit_file)
 
       expect(result).to be_completed
     end
@@ -18,12 +18,15 @@ describe StyleGuide::JavaScript do
       context "when semicolon is missing" do
         it "returns a collection of violation objects" do
           repo_config = double("RepoConfig", for: {})
-          file = build_file("var foo = 'bar'")
+          commit_file = build_commit_file("var foo = 'bar'")
 
-          violations = violations_in(file, repo_config)
+          violations = violations_in(
+            commit_file: commit_file,
+            repo_config: repo_config
+          )
 
           violation = violations.first
-          expect(violation.filename).to eq file.filename
+          expect(violation.filename).to eq commit_file.filename
           expect(violation.line_number).to eq 1
           expect(violation.messages).to match_array([
             "Missing semicolon.",
@@ -37,9 +40,12 @@ describe StyleGuide::JavaScript do
       context "when semicolon is missing" do
         it "returns no violation" do
           repo_config = double("RepoConfig", for: { "asi" => true })
-          file = build_file("parseFloat('1')")
+          commit_file = build_commit_file("parseFloat('1')")
 
-          violations = violations_in(file, repo_config)
+          violations = violations_in(
+            commit_file: commit_file,
+            repo_config: repo_config
+          )
 
           expect(violations).to be_empty
         end
@@ -49,10 +55,13 @@ describe StyleGuide::JavaScript do
     context "when jshintrb returns nil violation" do
       it "returns no violations" do
         repo_config = double("RepoConfig", for: {})
-        file = double(:file).as_null_object
+        commit_file = double("CommitFile").as_null_object
         allow(Jshintrb).to receive_messages(lint: [nil])
 
-        violations = violations_in(file, repo_config)
+        violations = violations_in(
+          commit_file: commit_file,
+          repo_config: repo_config
+        )
 
         expect(violations).to be_empty
       end
@@ -61,9 +70,12 @@ describe StyleGuide::JavaScript do
     context "when a global variable is ignored" do
       it "returns no violations" do
         repo_config = double("RepoConfig", for: { "predef" => ["myGlobal"] })
-        file = build_file("$(myGlobal).hide();")
+        commit_file = build_commit_file("$(myGlobal).hide();")
 
-        violations = violations_in(file, repo_config)
+        violations = violations_in(
+          commit_file: commit_file,
+          repo_config: repo_config
+        )
 
         expect(violations).to be_empty
       end
@@ -77,11 +89,11 @@ describe StyleGuide::JavaScript do
           StyleGuide::JavaScript
         )
         repo_config = double("RepoConfig", for: {})
-        file = build_file("$(myGlobal).hide();")
+        commit_file = build_commit_file("$(myGlobal).hide();")
 
         violations_in(
-          file,
-          repo_config,
+          commit_file: commit_file,
+          repo_config: repo_config,
           repository_owner_name: "not_thoughtbot"
         )
 
@@ -95,13 +107,17 @@ describe StyleGuide::JavaScript do
       it "uses the thoughtbot hound configuration" do
         spy_on_file_read
         spy_on_jshintrb
-        file = build_file("$(myGlobal).hide();")
+        commit_file = build_commit_file("$(myGlobal).hide();")
         configuration_file_path = thoughtbot_configuration_file(
           StyleGuide::JavaScript
         )
         repo_config = double("RepoConfig", for: {})
 
-        violations_in(file, repo_config, repository_owner_name: "thoughtbot")
+        violations_in(
+          commit_file: commit_file,
+          repo_config: repo_config,
+          repository_owner_name: "thoughtbot"
+        )
 
         expect(File).to have_received(:read).with(configuration_file_path)
         expect(Jshintrb).to have_received(:lint).
@@ -112,9 +128,12 @@ describe StyleGuide::JavaScript do
     context "with ES6 support enabled" do
       it "respects ES6" do
         repo_config = double("RepoConfig", for: { esnext: true })
-        file = build_file("import Ember from 'ember'")
+        commit_file = build_commit_file("import Ember from 'ember'")
 
-        violations = violations_in(file, repo_config)
+        violations = violations_in(
+          commit_file: commit_file,
+          repo_config: repo_config
+        )
 
         violation = violations.first
         expect(violation.messages).to match_array([
@@ -130,9 +149,9 @@ describe StyleGuide::JavaScript do
       it "returns false" do
         repo_config = double("RepoConfig", ignored_javascript_files: ["foo.js"])
         style_guide = StyleGuide::JavaScript.new(repo_config, "ralph")
-        file = double(:file, filename: "foo.js")
+        commit_file = double("CommitFile", filename: "foo.js")
 
-        included = style_guide.file_included?(file)
+        included = style_guide.file_included?(commit_file)
 
         expect(included).to be false
       end
@@ -142,9 +161,9 @@ describe StyleGuide::JavaScript do
       it "returns true" do
         repo_config = double("RepoConfig", ignored_javascript_files: ["foo.js"])
         style_guide = StyleGuide::JavaScript.new(repo_config, "ralph")
-        file = double(:file, filename: "bar.js")
+        commit_file = double("CommitFile", filename: "bar.js")
 
-        included = style_guide.file_included?(file)
+        included = style_guide.file_included?(commit_file)
 
         expect(included).to be true
       end
@@ -159,26 +178,36 @@ describe StyleGuide::JavaScript do
         ]
       )
       style_guide = StyleGuide::JavaScript.new(repo_config, "ralph")
-      file1 = double(:file, filename: "app/assets/javascripts/bar.js")
-      file2 = double(:file, filename: "vendor/assets/javascripts/foo.js")
+      commit_file1 = double(
+        "CommitFile",
+        filename: "app/assets/javascripts/bar.js"
+      )
+      commit_file2 = double(
+        "CommitFile",
+        filename: "vendor/assets/javascripts/foo.js"
+      )
 
-      expect(style_guide.file_included?(file1)).to be false
-      expect(style_guide.file_included?(file2)).to be false
+      expect(style_guide.file_included?(commit_file1)).to be false
+      expect(style_guide.file_included?(commit_file2)).to be false
     end
   end
 
-  def build_file(content = "foo")
+  def build_commit_file(content = "foo")
     filename = "some-file.js"
     line = double("Line", number: 1, patch_position: 1, changed?: true)
-    double("File", filename: filename, line_at: line, content: content)
+    double("CommitFile", filename: filename, line_at: line, content: content)
   end
 
-  def violations_in(file, repo_config, repository_owner_name: "not_thoughtbot")
+  def violations_in(
+    commit_file:,
+    repo_config:,
+    repository_owner_name: "not_thoughtbot"
+  )
     style_guide = StyleGuide::JavaScript.new(
       repo_config,
       repository_owner_name
     )
-    style_guide.file_review(file).violations
+    style_guide.file_review(commit_file).violations
   end
 
   def default_configuration

--- a/spec/models/style_guide/scss_spec.rb
+++ b/spec/models/style_guide/scss_spec.rb
@@ -4,9 +4,9 @@ describe StyleGuide::Scss do
   describe "#file_review" do
     it "returns an incompleted file review" do
       style_guide = build_style_guide
-      file = build_file
+      commit_file = build_commit_file
 
-      result = style_guide.file_review(file)
+      result = style_guide.file_review(commit_file)
 
       expect(result).not_to be_completed
     end
@@ -14,16 +14,17 @@ describe StyleGuide::Scss do
     it "schedules a review job" do
       allow(Resque).to receive(:enqueue)
       style_guide = build_style_guide("config")
-      file = build_file
+      commit_file = build_commit_file
 
-      style_guide.file_review(file)
+      style_guide.file_review(commit_file)
 
       expect(Resque).to have_received(:enqueue).with(
         ScssReviewJob,
-        filename: file.filename,
-        commit_sha: file.sha,
-        patch: file.patch_body,
-        content: file.content,
+        filename: commit_file.filename,
+        commit_sha: commit_file.sha,
+        pull_request_number: commit_file.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
         config: "config"
       )
     end
@@ -44,7 +45,7 @@ describe StyleGuide::Scss do
     StyleGuide::Scss.new(repo_config, "ralph")
   end
 
-  def build_file
+  def build_commit_file
     line = double(
       "Line",
       changed?: true,
@@ -58,7 +59,8 @@ describe StyleGuide::Scss do
       filename: "lib/a.scss",
       line_at: line,
       sha: "abc123",
-      patch_body: "patchbody"
+      patch: "patch",
+      pull_request_number: 123
     )
   end
 end

--- a/spec/services/build_report_spec.rb
+++ b/spec/services/build_report_spec.rb
@@ -90,7 +90,7 @@ describe BuildReport do
       )
       pull_request = double(
         :pull_request,
-        pull_request_files: [double(:file)],
+        commit_files: [double("CommitFile")],
         config: double(:config),
         opened?: true,
         head_commit: head_commit,

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -281,7 +281,7 @@ describe BuildRunner, '#run' do
     )
     pull_request = double(
       :pull_request,
-      pull_request_files: [double(:file)],
+      commit_files: [double("CommitFile")],
       config: double(:config),
       opened?: true,
       head_commit: head_commit,
@@ -292,11 +292,11 @@ describe BuildRunner, '#run' do
   end
 
   def stubbed_pull_request_with_file(filename, file_content)
-    file = double_file(filename, file_content)
-    double_pull_request_with_files([file])
+    commit_file = commit_file_double(filename, file_content)
+    double_pull_request_with_files([commit_file])
   end
 
-  def double_file(filename, file_content)
+  def commit_file_double(filename, file_content)
     double(
       "CommitFile",
       filename: filename,
@@ -305,10 +305,10 @@ describe BuildRunner, '#run' do
     )
   end
 
-  def double_pull_request_with_files(files)
+  def double_pull_request_with_files(commit_files)
     double(
       "PullRequest",
-      pull_request_files: files,
+      commit_files: commit_files,
       opened?: true,
       repository_owner_name: "test"
     )


### PR DESCRIPTION
* Fixes an issue where multiple builds could be created with the same `commit_sha` and the correct one might not be found in `CompletedFileReview`.
* Makes it easier to use `CommitFile`, it lets you initialize `CommitFile` without having to create `file` and `commit` objects
* Gets rid of an `OpenStruct` in `CompletedFileReview`
* Makes it clear what type of "file" object we are dealing with. `CommitFile` was often confused with what returned by `GithubApi` and `Octokit` when fetching pull request files
* Avoids confusing `patch_body` and `patch`