### PR TITLE
Point to new SCSS config location

### DIFF
--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -16,7 +16,7 @@ module ConfigurationHelper
   end
 
   def scss_config_url
-    "https://raw.githubusercontent.com/thoughtbot/hound/master/config/style_guides/scss.yml"
+    "https://raw.githubusercontent.com/thoughtbot/hound-scss/master/config/default.yml"
   end
 
   def haml_config_url


### PR DESCRIPTION
SCSS config now lives in the worker, so we should point there.