### PR TITLE
Don't comment until the build is finished

### DIFF
--- a/app/services/build_report.rb
+++ b/app/services/build_report.rb
@@ -10,9 +10,8 @@ class BuildReport
   pattr_initialize :pull_request, :build
 
   def run
-    commenter.comment_on_violations(priority_violations)
-
     if build.completed?
+      commenter.comment_on_violations(priority_violations)
       create_success_status
       track_subscribed_build_completed
     end


### PR DESCRIPTION
This will allow us to respect the MAX_COMMENTS environment variable
across the whole build and should help alleviate some abuse warnings.

As-is, if an external worker fails for whatever reason, the build will
not be marked as complete and comments will never go out. I *think*
we'll want to get that working by having the workers be retryable and we
can mark the build as complete if it fails too many times. Maybe this is
good enough for now, though?