### PR TITLE
Include .env in the repo

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
+# Don't modify this file. Create `.env.local` and put your overrides in there.
 CHANGED_FILES_THRESHOLD=300
 ENABLE_HTTPS=no
 EXEMPT_ORGS=organisation_name,user_name
@@ -5,7 +6,7 @@ GITHUB_CLIENT_ID=github_client_id
 GITHUB_CLIENT_SECRET=github_client_secret
 HOST=your-initials-hound.ngrok.com
 HOUND_GITHUB_TOKEN=your_github_token
-HOUND_GITHUB_USERNAME=houndci
+HOUND_GITHUB_USERNAME=your_github_username
 MAX_COMMENTS=10
 QUEUE=high,medium,low
 REDIS_URL=redis://localhost:6379

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-.env
-.env.test
+.env.local
 .foreman
 /.bundle
 /db/*.sqlite3

--- a/bin/setup
+++ b/bin/setup
@@ -6,12 +6,6 @@ bundle install
 # Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
 mkdir -p .git/safe
 
-# Set up development environment config
-if [ ! -f .env ]; then
-  cp .sample.env .env
-  cp .sample.env .env.test
-fi
-
 # Set up database
 bundle exec rake db:setup
 
@@ -28,10 +22,9 @@ if ! grep -qs 'port' .foreman; then
 fi
 
 # Stripe credentials
-if ! grep -qs 'STRIPE' .env; then
-  heroku config --app hound-staging | grep "STRIPE" > .env
-  sed -i '' 's/\:/=/' .env
-  sed -i '' 's/ //g' .env
+if ! grep -qs 'STRIPE' .env.local; then
+  heroku config:get STRIPE_API_KEY --remote staging --shell >> .env.local
+  heroku config:get STRIPE_PUBLISHABLE_KEY --remote staging --shell >> .env.local
 fi
 
 # GitHub

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,3 @@
 test:
-  pre:
-    - cp .sample.env .env
   override:
     - bundle exec rake


### PR DESCRIPTION
Moves .sample.env to .env. This file has all the config necessary to get
running in development and `cp .sample.env .env` was in `bin/setup`. If
this file just exists as `.env` in the repo, then the setup step is not
needed and things should Just Work™ out of the box. The dotenv [docs][1]
even recommend doing this to ease new developers onto the project.

Additionally, our heavy use of `ENV.fetch` is now causing the test suite
to [fail][2] on CircleCI, because the database is being setup before the
`pre` hook fires. With `.env` the test suite will work fine without this
setup.

Local customizations can be added to `.env.local`, which is ignored.

[1]: https://github.com/bkeepers/dotenv#should-i-commit-my-env-file
[2]: https://circleci.com/gh/thoughtbot/hound/202