### PR TITLE
Add Go as a new language supported by Hound.

### DIFF
--- a/app/jobs/go_review_job.rb
+++ b/app/jobs/go_review_job.rb
@@ -1,0 +1,3 @@
+class GoReviewJob
+  @queue = :go_review
+end

--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -1,7 +1,8 @@
 # Load and parse config files from GitHub repo
 class RepoConfig
   HOUND_CONFIG = ".hound.yml"
-  LANGUAGES = %w(ruby coffeescript javascript scss haml)
+  BETA_LANGUAGES = %w(go)
+  LANGUAGES = %w(ruby coffeescript javascript scss haml go)
   FILE_TYPES = {
     "ruby" => "yaml",
     "javascript" => "json",
@@ -15,8 +16,7 @@ class RepoConfig
   pattr_initialize :commit
 
   def enabled_for?(language)
-    options = options_for(language)
-    options.nil? || !disabled?(language)
+    !disabled?(language)
   end
 
   def for(language)
@@ -55,8 +55,18 @@ class RepoConfig
 
   private
 
+  def beta?(language)
+    BETA_LANGUAGES.include?(language)
+  end
+
+  def defualt_options_for(language)
+    { "enabled" => !beta?(language) }
+  end
+
   def options_for(language)
-    hound_config[language] || hound_config[language_camelize(language)]
+    hound_config[language] ||
+      hound_config[language_camelize(language)] ||
+      defualt_options_for(language)
   end
 
   def disabled?(language)

--- a/app/models/style_checker.rb
+++ b/app/models/style_checker.rb
@@ -44,6 +44,8 @@ class StyleChecker
       StyleGuide::Haml
     when /.+\.scss\z/
       StyleGuide::Scss
+    when /.+\.go\z/
+      StyleGuide::Go
     else
       StyleGuide::Unsupported
     end

--- a/app/models/style_guide/go.rb
+++ b/app/models/style_guide/go.rb
@@ -1,0 +1,32 @@
+module StyleGuide
+  class Go < Base
+    LANGUAGE = "go"
+
+    def file_review(commit_file)
+      Resque.enqueue(
+        GoReviewJob,
+        filename: commit_file.filename,
+        commit_sha: commit_file.sha,
+        pull_request_number: commit_file.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
+        config: repo_config.raw_for(LANGUAGE),
+      )
+
+      FileReview.new(filename: commit_file.filename)
+    end
+
+    def file_included?(commit_file)
+      !vendored?(commit_file.filename)
+    end
+
+    private
+
+    def vendored?(filename)
+      path_components = Pathname(filename).each_filename
+
+      path_components.include?("vendor") ||
+        path_components.take(2) == ["Godeps", "_workspace"]
+    end
+  end
+end

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -15,6 +15,8 @@
         = link_to "SCSS config", "#scss"
       %li
         = link_to "Haml config", "#haml"
+      %li
+        = link_to "Go config", "#go"
 
   %section.doc-content
     %article
@@ -240,6 +242,19 @@
           :preserve
             haml:
               enabled: false
+
+    %article#go
+      %h3 Go
+
+      %p
+        Add the following code to your
+        %em.code .hound.yml
+        to enable Go style checking.
+
+        %code.code-block
+          :preserve
+            go:
+              enabled: true
 
     %article
       %h3 Didn't find what you where looking for?

--- a/doc/SECURITY.md
+++ b/doc/SECURITY.md
@@ -197,6 +197,7 @@ that we use to check the style of the code in each pull request notification:
 * CoffeeScript: [CoffeeLint](http://www.coffeelint.org/)
 * JavaScript: [JSHint](https://github.com/jshint/jshint/)
 * SCSS: [SCSS-Lint](https://github.com/brigade/scss-lint)
+* Go: [golint](https://github.com/golang/lint)
 
 Those libraries find style violations
 and pass them back up through `StyleGuide` and `BuildRunner`.

--- a/spec/models/style_guide/coffee_script_spec.rb
+++ b/spec/models/style_guide/coffee_script_spec.rb
@@ -174,14 +174,7 @@ describe StyleGuide::CoffeeScript do
     end
 
     def build_file(content, filename = "test.coffee")
-      line = double(
-        "Line",
-        changed?: true,
-        content: "blah",
-        number: 1,
-        patch_position: 2,
-      )
-      double("GithubFile", content: content, filename: filename, line_at: line)
+      build_commit_file(filename: filename, content: content)
     end
 
     def build_style_guide

--- a/spec/models/style_guide/go_spec.rb
+++ b/spec/models/style_guide/go_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+describe StyleGuide::Go do
+  describe "#file_review" do
+    it "returns an incompleted file review" do
+      style_guide = build_style_guide
+      commit_file = build_commit_file(filename: "a.go")
+
+      result = style_guide.file_review(commit_file)
+
+      expect(result).not_to be_completed
+    end
+
+    it "schedules a review job" do
+      allow(Resque).to receive(:enqueue)
+      style_guide = build_style_guide("config")
+      commit_file = build_commit_file(filename: "a.go")
+
+      style_guide.file_review(commit_file)
+
+      expect(Resque).to have_received(:enqueue).with(
+        GoReviewJob,
+        filename: commit_file.filename,
+        commit_sha: commit_file.sha,
+        pull_request_number: commit_file.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
+        config: "config",
+      )
+    end
+  end
+
+  describe "#file_included?" do
+    context "when file is in Godeps/_workspace" do
+      it "returns false" do
+        commit_file = build_commit_file(filename: "Godeps/_workspace/foo/a.go")
+        style_guide = build_style_guide
+
+        expect(style_guide.file_included?(commit_file)).to eq false
+      end
+    end
+
+    context "when file is rooted in a vendor/ directory" do
+      it "returns false" do
+        commit_file = build_commit_file(filename: "vendor/foo/a.go")
+        style_guide = build_style_guide
+
+        expect(style_guide.file_included?(commit_file)).to eq false
+      end
+    end
+
+    context "when file is in a vendor/ directory" do
+      it "returns false" do
+        commit_file = build_commit_file(filename: "foo/vendor/bar/a.go")
+        style_guide = build_style_guide
+
+        expect(style_guide.file_included?(commit_file)).to eq false
+      end
+    end
+
+    context "when file is not vendored" do
+      it "returns true" do
+        commit_file = build_commit_file(filename: "a.go")
+        style_guide = build_style_guide
+
+        expect(style_guide.file_included?(commit_file)).to eq true
+      end
+    end
+  end
+
+  private
+
+  def build_style_guide(config = "config")
+    repo_config = double("RepoConfig", raw_for: config)
+    StyleGuide::Go.new(repo_config, "ralph")
+  end
+end

--- a/spec/models/style_guide/haml_spec.rb
+++ b/spec/models/style_guide/haml_spec.rb
@@ -54,14 +54,7 @@ describe StyleGuide::Haml do
     StyleGuide::Haml.new(repo_config, repository_owner_name)
   end
 
-  def build_file(text)
-    line = double(
-      "Line",
-      changed?: true,
-      content: "blah",
-      number: 1,
-      patch_position: 2,
-    )
-    double("CommitFile", content: text, filename: "a/b.haml", line_at: line)
+  def build_file(content)
+    build_commit_file(filename: "a/b.haml", content: content)
   end
 end

--- a/spec/models/style_guide/java_script_spec.rb
+++ b/spec/models/style_guide/java_script_spec.rb
@@ -7,7 +7,7 @@ describe StyleGuide::JavaScript do
     it "returns a completed file review" do
       repo_config = double("RepoConfig", enabled_for?: true, for: {})
       style_guide = StyleGuide::JavaScript.new(repo_config, "bob")
-      commit_file = build_commit_file
+      commit_file = build_js_file
 
       result = style_guide.file_review(commit_file)
 
@@ -18,7 +18,7 @@ describe StyleGuide::JavaScript do
       context "when semicolon is missing" do
         it "returns a collection of violation objects" do
           repo_config = double("RepoConfig", for: {})
-          commit_file = build_commit_file("var foo = 'bar'")
+          commit_file = build_js_file("var foo = 'bar'")
 
           violations = violations_in(
             commit_file: commit_file,
@@ -40,7 +40,7 @@ describe StyleGuide::JavaScript do
       context "when semicolon is missing" do
         it "returns no violation" do
           repo_config = double("RepoConfig", for: { "asi" => true })
-          commit_file = build_commit_file("parseFloat('1')")
+          commit_file = build_js_file("parseFloat('1')")
 
           violations = violations_in(
             commit_file: commit_file,
@@ -70,7 +70,7 @@ describe StyleGuide::JavaScript do
     context "when a global variable is ignored" do
       it "returns no violations" do
         repo_config = double("RepoConfig", for: { "predef" => ["myGlobal"] })
-        commit_file = build_commit_file("$(myGlobal).hide();")
+        commit_file = build_js_file("$(myGlobal).hide();")
 
         violations = violations_in(
           commit_file: commit_file,
@@ -89,7 +89,7 @@ describe StyleGuide::JavaScript do
           StyleGuide::JavaScript
         )
         repo_config = double("RepoConfig", for: {})
-        commit_file = build_commit_file("$(myGlobal).hide();")
+        commit_file = build_js_file("$(myGlobal).hide();")
 
         violations_in(
           commit_file: commit_file,
@@ -107,7 +107,7 @@ describe StyleGuide::JavaScript do
       it "uses the thoughtbot hound configuration" do
         spy_on_file_read
         spy_on_jshintrb
-        commit_file = build_commit_file("$(myGlobal).hide();")
+        commit_file = build_js_file("$(myGlobal).hide();")
         configuration_file_path = thoughtbot_configuration_file(
           StyleGuide::JavaScript
         )
@@ -128,7 +128,7 @@ describe StyleGuide::JavaScript do
     context "with ES6 support enabled" do
       it "respects ES6" do
         repo_config = double("RepoConfig", for: { esnext: true })
-        commit_file = build_commit_file("import Ember from 'ember'")
+        commit_file = build_js_file("import Ember from 'ember'")
 
         violations = violations_in(
           commit_file: commit_file,
@@ -192,10 +192,8 @@ describe StyleGuide::JavaScript do
     end
   end
 
-  def build_commit_file(content = "foo")
-    filename = "some-file.js"
-    line = double("Line", number: 1, patch_position: 1, changed?: true)
-    double("CommitFile", filename: filename, line_at: line, content: content)
+  def build_js_file(content = "foo")
+    build_commit_file(filename: "some-file.js", content: content)
   end
 
   def violations_in(

--- a/spec/models/style_guide/ruby_spec.rb
+++ b/spec/models/style_guide/ruby_spec.rb
@@ -693,15 +693,7 @@ describe StyleGuide::Ruby do
     end
 
     def build_file(content)
-      filename = "app/models/user.rb"
-      line = double(
-        "Line",
-        changed?: true,
-        content: "blah",
-        number: 1,
-        patch_position: 2,
-      )
-      double("CommitFile", content: content, line_at: line, filename: filename)
+      build_commit_file(filename: "app/models/user.rb", content: content)
     end
 
     def default_configuration

--- a/spec/models/style_guide/scss_spec.rb
+++ b/spec/models/style_guide/scss_spec.rb
@@ -4,7 +4,7 @@ describe StyleGuide::Scss do
   describe "#file_review" do
     it "returns an incompleted file review" do
       style_guide = build_style_guide
-      commit_file = build_commit_file
+      commit_file = build_commit_file(filename: "lib/a.scss")
 
       result = style_guide.file_review(commit_file)
 
@@ -14,7 +14,7 @@ describe StyleGuide::Scss do
     it "schedules a review job" do
       allow(Resque).to receive(:enqueue)
       style_guide = build_style_guide("config")
-      commit_file = build_commit_file
+      commit_file = build_commit_file(filename: "lib/a.scss")
 
       style_guide.file_review(commit_file)
 
@@ -43,24 +43,5 @@ describe StyleGuide::Scss do
   def build_style_guide(config = "config")
     repo_config = double("RepoConfig", raw_for: config)
     StyleGuide::Scss.new(repo_config, "ralph")
-  end
-
-  def build_commit_file
-    line = double(
-      "Line",
-      changed?: true,
-      content: "blah",
-      number: 1,
-      patch_position: 2
-    )
-    double(
-      "CommitFile",
-      content: "codes",
-      filename: "lib/a.scss",
-      line_at: line,
-      sha: "abc123",
-      patch: "patch",
-      pull_request_number: 123
-    )
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,6 +20,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.include AnalyticsHelper
   config.include AuthenticationHelper
+  config.include CommitFileHelper
   config.include Features, type: :feature
   config.include HttpsHelper
   config.include OauthHelper

--- a/spec/support/helpers/commit_file_helper.rb
+++ b/spec/support/helpers/commit_file_helper.rb
@@ -1,0 +1,20 @@
+module CommitFileHelper
+  def build_commit_file(filename:, content: "code")
+    line = double(
+      "Line",
+      changed?: true,
+      content: "blah",
+      number: 1,
+      patch_position: 2,
+    )
+    double(
+      "CommitFile",
+      content: content,
+      filename: filename,
+      line_at: line,
+      sha: "abc123",
+      patch: "patch",
+      pull_request_number: 123,
+    )
+  end
+end


### PR DESCRIPTION
This adds basic support to Hound for Go,
by integrating against [hound-go]
via Hound's external review Resque API.

This should be considered an early release feature.
As the review service matures
and the feature-set stabilizes,
we can define supported configuration options
and the necessary documentation
to promote this to an officially supported language.

  [hound-go]: github.com/thoughtbot/hound-go