### PR TITLE
Add Python linting via hound-python service.

### DIFF
--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -1,8 +1,8 @@
 # Load and parse config files from GitHub repo
 class RepoConfig
   HOUND_CONFIG = ".hound.yml"
-  BETA_LANGUAGES = %w(go)
-  LANGUAGES = %w(ruby coffeescript javascript scss haml go)
+  BETA_LANGUAGES = %w(go python)
+  LANGUAGES = %w(ruby coffeescript javascript scss haml go python)
   FILE_TYPES = {
     "ruby" => "yaml",
     "javascript" => "json",

--- a/app/models/style_checker.rb
+++ b/app/models/style_checker.rb
@@ -46,6 +46,8 @@ class StyleChecker
       StyleGuide::Scss
     when /.+\.go\z/
       StyleGuide::Go
+    when /.+\.py\z/
+      StyleGuide::Python
     else
       StyleGuide::Unsupported
     end

--- a/app/models/style_guide/python.rb
+++ b/app/models/style_guide/python.rb
@@ -1,0 +1,28 @@
+module StyleGuide
+  class Python < Base
+    LANGUAGE = "python"
+
+    def file_review(commit_file)
+      Resque.push(
+        "python_review",
+        {
+          class: "review.PythonReviewJob",
+          args: [
+            commit_file.filename,
+            commit_file.sha,
+            commit_file.pull_request_number,
+            commit_file.patch,
+            commit_file.content,
+            repo_config.raw_for(LANGUAGE),
+          ],
+        }
+      )
+
+      FileReview.new(filename: commit_file.filename)
+    end
+
+    def file_included?(_)
+      true
+    end
+  end
+end

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -42,6 +42,8 @@ describe RepoConfig do
             enabled: true
           go:
             enabled: true
+          python:
+            enabled: true
         EOS
         repo_config = RepoConfig.new(commit)
 
@@ -122,6 +124,8 @@ describe RepoConfig do
             SCSS:
               Enabled: true
             Go:
+              Enabled: true
+            Python:
               Enabled: true
           EOS
           repo_config = RepoConfig.new(commit)

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -167,6 +167,17 @@ describe StyleChecker, "#file_reviews" do
     end
   end
 
+  context "for a Python file" do
+    it "does not immediately return violations" do
+      commit_file = stub_commit_file("test.py", "import this")
+      pull_request = stub_pull_request(commit_files: [commit_file])
+
+      violation_messages = pull_request_violations(pull_request)
+
+      expect(violation_messages).to be_empty
+    end
+  end
+
   context "for a Haml file" do
     context "with style violations" do
       it "returns no violations" do

--- a/spec/models/style_guide/python_spec.rb
+++ b/spec/models/style_guide/python_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+describe StyleGuide::Python do
+  describe "#file_review" do
+    it "returns an incompleted file review" do
+      style_guide = build_style_guide
+      commit_file = build_commit_file
+
+      result = style_guide.file_review(commit_file)
+
+      expect(result).not_to be_completed
+    end
+
+    it "schedules a review job" do
+      allow(Resque).to receive(:push)
+      style_guide = build_style_guide("config")
+      commit_file = build_commit_file
+
+      style_guide.file_review(commit_file)
+
+      expect(Resque).to have_received(:push).with(
+        "python_review",
+        {
+          class: "review.PythonReviewJob",
+          args: [
+            commit_file.filename,
+            commit_file.sha,
+            commit_file.pull_request_number,
+            commit_file.patch,
+            commit_file.content,
+            "config",
+          ],
+        }
+      )
+    end
+  end
+
+  describe "#file_included?" do
+    it "returns true" do
+      style_guide = build_style_guide
+
+      expect(style_guide.file_included?(double)).to eq true
+    end
+  end
+
+  private
+
+  def build_style_guide(config = "config")
+    repo_config = double("RepoConfig", raw_for: config)
+    StyleGuide::Python.new(repo_config, "ralph")
+  end
+
+  def build_commit_file
+    line = double(
+      "Line",
+      changed?: true,
+      content: "blah",
+      number: 1,
+      patch_position: 2,
+    )
+    double(
+      "CommitFile",
+      content: "codes",
+      filename: "lib/a.py",
+      line_at: line,
+      sha: "abc123",
+      patch: "patch",
+      pull_request_number: 123,
+    )
+  end
+end


### PR DESCRIPTION
Add support for Python linting via https://github.com/jmcarp/hound-python. Replaces #754.