### PR TITLE
Add option to fail the build

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,4 @@
+fail_on_violations: true
+
 ruby:
   config_file: .ruby-style.yml

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -10,11 +10,16 @@ class CommitStatus
   end
 
   def set_success(violation_count)
-    message = I18n.t(:success_status, count: violation_count)
+    message = I18n.t(:complete_status, count: violation_count)
     github.create_success_status(repo_name, sha, message)
   end
 
-  def set_failure
+  def set_failure(violation_count)
+    message = I18n.t(:complete_status, count: violation_count)
+    github.create_error_status(repo_name, sha, message)
+  end
+
+  def set_config_error
     message = I18n.t(:config_error_status)
     github.create_error_status(repo_name, sha, message, configuration_url)
   end

--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -53,6 +53,10 @@ class RepoConfig
     ignore_file_content.split("\n")
   end
 
+  def fail_on_violations?
+    hound_config["fail_on_violations"]
+  end
+
   private
 
   def beta?(language)

--- a/app/services/build_report.rb
+++ b/app/services/build_report.rb
@@ -14,7 +14,7 @@ class BuildReport
   def run
     if build.completed?
       Commenter.new(pull_request).comment_on_violations(priority_violations)
-      commit_status.set_success(build.violation_count)
+      set_commit_status
       track_subscribed_build_completed
     end
   end
@@ -33,6 +33,22 @@ class BuildReport
       analytics = Analytics.new(user)
       analytics.track_build_completed(build.repo)
     end
+  end
+
+  def set_commit_status
+    if fail_build?
+      commit_status.set_failure(build.violation_count)
+    else
+      commit_status.set_success(build.violation_count)
+    end
+  end
+
+  def fail_build?
+    repo_config.fail_on_violations? && build.violation_count > 0
+  end
+
+  def repo_config
+    RepoConfig.new(pull_request.head_commit)
   end
 
   def commit_status

--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -8,7 +8,7 @@ class BuildRunner
       review_pull_request
     end
   rescue RepoConfig::ParserError
-    commit_status.set_failure
+    commit_status.set_config_error
   rescue Octokit::Unauthorized
     if users_with_token.any?
       reset_token

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,7 @@ en:
   active_repos: "Active repos"
   search_placeholder: "Search by repo"
   pending_status: "Hound is busy reviewing changes..."
-  success_status:
+  complete_status:
     zero: "No violations found. Woof!"
     one: "1 violation found."
     other: "%{count} violations found."

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -511,6 +511,39 @@ describe RepoConfig do
     end
   end
 
+  describe "#fail_on_violations?" do
+    context "when fail on violations is not present" do
+      it "returns false" do
+        commit = double("Commit", file_content: "")
+        repo_config = RepoConfig.new(commit)
+
+        expect(repo_config).not_to be_fail_on_violations
+      end
+    end
+
+    context "when fail on violations is disabled" do
+      it "returns false" do
+        commit = double("Commit", file_content: <<-EOS.strip_heredoc)
+          fail_on_violations: false
+        EOS
+        repo_config = RepoConfig.new(commit)
+
+        expect(repo_config).not_to be_fail_on_violations
+      end
+    end
+
+    context "when fail on violations is enabled" do
+      it "returns true" do
+        commit = double("Commit", file_content: <<-EOS.strip_heredoc)
+          fail_on_violations: true
+        EOS
+        repo_config = RepoConfig.new(commit)
+
+        expect(repo_config).to be_fail_on_violations
+      end
+    end
+  end
+
   it "converts legacy coffee_script key to coffeescript" do
     commit = double("Commit", file_content: <<-EOS.strip_heredoc)
       coffee_script:

--- a/spec/services/build_report_spec.rb
+++ b/spec/services/build_report_spec.rb
@@ -16,26 +16,52 @@ describe BuildReport do
 
           run_service(file_review.build)
 
-          expect(commenter).to have_received(:comment_on_violations).
-            with(file_review.violations.take(BuildReport::MAX_COMMENTS))
+          expect(commenter).to have_received(:comment_on_violations) do |arg|
+            expect(arg.size).to eq 1
+            expect(arg.first).to be_a Violation
+          end
         end
 
-        it "sets GitHub status to complete" do
-          file_review = create(
-            :file_review,
-            completed_at: Time.current,
-            violations: [build(:violation)],
-          )
-          stubbed_commenter
-          github_api = stubbed_github_api
+        context "when fail on violations is disabled" do
+          it "sets GitHub status to complete" do
+            file_review = create(
+              :file_review,
+              completed_at: Time.current,
+              violations: [build(:violation)],
+            )
+            stubbed_commenter
+            stubbed_repo_config(fail_on_violations?: false)
+            github_api = stubbed_github_api
 
-          run_service(file_review.build)
+            run_service(file_review.build)
 
-          expect(github_api).to have_received(:create_success_status).with(
-            file_review.build.repo_name,
-            file_review.build.commit_sha,
-            "1 violation found."
-          )
+            expect(github_api).to have_received(:create_success_status).with(
+              file_review.build.repo_name,
+              file_review.build.commit_sha,
+              "1 violation found.",
+            )
+          end
+        end
+
+        context "when fail on violations is enabled" do
+          it "sets GitHub status to failed" do
+            file_review = create(
+              :file_review,
+              completed_at: Time.current,
+              violations: [build(:violation)],
+            )
+            stubbed_commenter
+            stubbed_repo_config(fail_on_violations?: true)
+            github_api = stubbed_github_api
+
+            run_service(file_review.build)
+
+            expect(github_api).to have_received(:create_error_status).with(
+              file_review.build.repo_name,
+              file_review.build.commit_sha,
+              "1 violation found.",
+            )
+          end
         end
       end
 
@@ -70,6 +96,27 @@ describe BuildReport do
       end
     end
 
+    context "when build does not have violations" do
+      it "sets GitHub status to complete" do
+        file_review = create(
+          :file_review,
+          completed_at: Time.current,
+          violations: [],
+        )
+        stubbed_commenter
+        stubbed_repo_config(fail_on_violations?: false)
+        github_api = stubbed_github_api
+
+        run_service(file_review.build)
+
+        expect(github_api).to have_received(:create_success_status).with(
+          file_review.build.repo_name,
+          file_review.build.commit_sha,
+          I18n.t(:complete_status, count: 0),
+        )
+      end
+    end
+
     context "with subscribed private repo and opened pull request" do
       it "tracks build events" do
         repo = create(:repo, :active, github_id: 123, private: true)
@@ -94,14 +141,26 @@ describe BuildReport do
     end
 
     def stubbed_github_api
-      github_api = double("GithubApi", create_success_status: nil)
+      github_api = double(
+        "GithubApi",
+        create_success_status: nil,
+        create_error_status: nil,
+      )
       allow(GithubApi).to receive(:new).and_return(github_api)
 
       github_api
     end
 
+    def stubbed_repo_config(options = {})
+      repo_config = double("RepoConfig", options)
+      allow(RepoConfig).to receive(:new).and_return(repo_config)
+
+      repo_config
+    end
+
     def run_service(build)
-      pull_request = double("PullRequest")
+      head_commit = double("Commit", file_content: "")
+      pull_request = double("PullRequest", head_commit: head_commit)
       BuildReport.run(pull_request: pull_request, build: build, token: "abc123")
     end
   end

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -99,7 +99,7 @@ describe BuildRunner, '#run' do
       expect(github_api).to have_received(:create_success_status).with(
         "test/repo",
         "headsha",
-        I18n.t(:success_status, count: 3),
+        I18n.t(:complete_status, count: 3),
       )
     end
 
@@ -287,6 +287,7 @@ describe BuildRunner, '#run' do
       "HeadCommit",
       sha: "headsha",
       repo_name: "test/repo",
+      file_content: "",
     )
     pull_request = double(
       :pull_request,


### PR DESCRIPTION
Adds a configuration option to set the PR status to 'error' when
violations are found.

*.hound.yml*
```yaml
fail_on_violations: true
```

![more_dumb_stuff_with_custom_config_inheriting_by_thorncp_ _pull_request__59_ _thornco_dumb-ruby](https://cloud.githubusercontent.com/assets/72176/8841432/41be8bba-30a2-11e5-81dd-fd4f593b8b24.png)

https://trello.com/c/MtnDjmfF