### PR TITLE
Ensure checkout modal can be displayed

### DIFF
--- a/app/assets/javascripts/directives/repo.js.coffee.erb
+++ b/app/assets/javascripts/directives/repo.js.coffee.erb
@@ -29,9 +29,9 @@ App.directive 'repo', ['Subscription', 'StripeCheckout', 'User', (Subscription, 
         createSubscriptionWithNewCard
       )
 
-    createSubscription = (user) ->
+    createSubscription = ->
       if scope.repo.price_in_cents > 0
-        if user.card_exists
+        if scope.userCardExists
           createSubscriptionWithExistingCard()
         else
           showCreditCardForm()
@@ -83,5 +83,5 @@ App.directive 'repo', ['Subscription', 'StripeCheckout', 'User', (Subscription, 
         else
           deactivateRepo()
       else
-        User.get().$promise.then(createSubscription)
+        createSubscription()
 ]

--- a/app/assets/javascripts/directives/repo_list.js.coffee.erb
+++ b/app/assets/javascripts/directives/repo_list.js.coffee.erb
@@ -13,6 +13,12 @@ App.directive 'repoList', ['Repo', 'Sync', 'User', '$timeout', (Repo, Sync, User
         alert('Your repos failed to load.')
       )
 
+    loadUserPaymentInfo = ->
+      user = User.get()
+      user.$promise
+        .then (result) -> scope.userCardExists = result.card_exists
+        .catch -> alert("Failed to load current user.")
+
     pollSyncStatus = ->
       successfulSync = (user) ->
         if user.refreshing_repos
@@ -46,6 +52,7 @@ App.directive 'repoList', ['Repo', 'Sync', 'User', '$timeout', (Repo, Sync, User
         scope.syncButtonText = '<%= I18n.t('sync_repos') %>'
 
     loadRepos().then ->
-      if scope.repos.length < 1
-        scope.sync()
+      loadUserPaymentInfo().then ->
+        if scope.repos.length < 1
+          scope.sync()
 ]


### PR DESCRIPTION
* Users without a credit card on file are currently unable to activate
  paid repos when using Safari on an iOS device: When the user attempts
  to activate a private repo in her repo list by clicking the "Activate"
  button, the Stripe Checkout popup does not appear and the user is
  unable to proceed with the transaction.

  This is because the trigger for displaying the popup is currently
  invoked in a callback. Per Stripe's documentation, this implementation
  causes "mobile devices and some version of Internet Explorer [to]
  block the popup and prevent users from checking out". Reference:
  https://stripe.com/docs/checkout#integration-more-runloop

* This commit changes the `Repo` and `RepoList` scripts to load user
  payment information earlier in the run loop, thereby allowing us to
  decouple fetching the current user and checking for an existing card
  from showing the popup.

https://trello.com/c/r2iCkXVA/617-stripe-credit-card-modal-fails-to-display-in-safari-on-iphones