### PR TITLE
Consider Haml review as beta

### DIFF
--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -1,7 +1,7 @@
 # Load and parse config files from GitHub repo
 class RepoConfig
   HOUND_CONFIG = ".hound.yml"
-  BETA_LANGUAGES = %w(go)
+  BETA_LANGUAGES = %w(go haml)
   LANGUAGES = %w(ruby coffeescript javascript scss haml go)
   FILE_TYPES = {
     "ruby" => "yaml",

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -213,7 +213,17 @@
               enabled: false
 
     %article#haml
-      %h3 Haml
+      %h3 Haml (beta)
+
+      %p
+        Add the following code to your
+        %em.code .hound.yml
+        to enable Haml style checking.
+
+        %code.code-block
+          :preserve
+            haml:
+              enabled: true
 
       %p
         Hound uses
@@ -244,7 +254,7 @@
               enabled: false
 
     %article#go
-      %h3 Go
+      %h3 Go (beta)
 
       %p
         Add the following code to your

--- a/config/style_guides/haml.yml
+++ b/config/style_guides/haml.yml
@@ -7,64 +7,64 @@ linters:
     enabled: false
 
   ClassAttributeWithStaticValue:
-    enabled: false
+    enabled: true
 
   ClassesBeforeIds:
-    enabled: false
+    enabled: true
 
   ConsecutiveComments:
-    enabled: false
+    enabled: true
 
   ConsecutiveSilentScripts:
-    enabled: false
+    enabled: true
     max_consecutive: 2
 
   EmptyScript:
-    enabled: false
+    enabled: true
 
   HtmlAttributes:
-    enabled: false
+    enabled: true
 
   ImplicitDiv:
-    enabled: false
+    enabled: true
 
   LeadingCommentSpace:
-    enabled: false
+    enabled: true
 
   LineLength:
-    enabled: false
+    enabled: true
     max: 80
 
   MultilinePipe:
-    enabled: false
+    enabled: true
 
   MultilineScript:
-    enabled: false
+    enabled: true
 
   ObjectReferenceAttributes:
-    enabled: false
+    enabled: true
 
   RuboCop:
     enabled: false
 
   RubyComments:
-    enabled: false
+    enabled: true
 
   SpaceBeforeScript:
-    enabled: false
+    enabled: true
 
   SpaceInsideHashAttributes:
-    enabled: false
+    enabled: true
     style: space
 
   TagName:
-    enabled: false
+    enabled: true
 
   TrailingWhitespace:
-    enabled: false
+    enabled: true
 
   UnnecessaryInterpolation:
-    enabled: false
+    enabled: true
 
   UnnecessaryStringOutput:
-    enabled: false
+    enabled: true

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -40,6 +40,8 @@ describe RepoConfig do
             enabled: true
           scss:
             enabled: true
+          haml:
+            enabled: true
           go:
             enabled: true
         EOS
@@ -120,6 +122,8 @@ describe RepoConfig do
             CoffeeScript:
               Enabled: true
             SCSS:
+              Enabled: true
+            Haml:
               Enabled: true
             Go:
               Enabled: true

--- a/spec/models/style_guide/haml_spec.rb
+++ b/spec/models/style_guide/haml_spec.rb
@@ -13,10 +13,10 @@ describe StyleGuide::Haml do
 
     context "with default configuration" do
       context "with an implicit %div violation" do
-        it "does not return violations" do
-          content = "%div#container Hello\n"
+        it "returns violations" do
+          content = "%div#container Hello"
 
-          expect(violations_in(content)).to be_empty
+          expect(violations_in(content)).not_to be_empty
         end
       end
     end
@@ -33,7 +33,7 @@ describe StyleGuide::Haml do
         }
         content = "%div#bar.foo\n"
 
-        expect(violations_in(content, config)).to be_empty
+        expect(violations_in(content, config)).not_to be_empty
       end
     end
 
@@ -57,6 +57,7 @@ describe StyleGuide::Haml do
         }
 
         expect(violations_in(content, config)).to match_array [
+          "Avoid defining `class` in attributes hash for static class names",
           "`%div#foo` can be written as `#foo` since `%div` is implicit",
           "Hash attribute should end with no space before the closing brace",
         ]


### PR DESCRIPTION
* Now that we have `BETA_LANGUAGES`, thanks @bernerdschaefer, we don't have to disable all rules in config to disable Haml review.
* If you want Haml review you will need to enable it in `.hound.yml`.