### PR TITLE
Include filename in config parse error

### DIFF
--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -19,8 +19,8 @@ class CommitStatus
     github.create_error_status(repo_name, sha, message)
   end
 
-  def set_config_error
-    message = I18n.t(:config_error_status)
+  def set_config_error(filename)
+    message = I18n.t(:config_error_status, filename: filename)
     github.create_error_status(repo_name, sha, message, configuration_url)
   end
 

--- a/app/models/repo_config/parser_error.rb
+++ b/app/models/repo_config/parser_error.rb
@@ -1,0 +1,10 @@
+class RepoConfig
+  class ParserError < StandardError
+    attr_reader :filename
+
+    def initialize(message, filename:)
+      super(message)
+      @filename = filename
+    end
+  end
+end

--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -7,8 +7,8 @@ class BuildRunner
     if repo && relevant_pull_request?
       review_pull_request
     end
-  rescue RepoConfig::ParserError
-    commit_status.set_config_error
+  rescue RepoConfig::ParserError => e
+    commit_status.set_config_error(e.filename)
   rescue Octokit::Unauthorized
     if users_with_token.any?
       reset_token

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,7 @@ en:
     one: "1 violation found."
     other: "%{count} violations found."
   config_error_status:
-    "Error parsing your config file. Click \"details\" for
+    "Error parsing config file: %{filename}. Click \"details\" for
     assistance."
 
   account:

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -287,7 +287,10 @@ describe RepoConfig do
               ;foo:
           EOS
 
-          expect { config.for("ruby") }.to raise_error(RepoConfig::ParserError)
+          expect { config.for("ruby") }.to raise_error do |error|
+            expect(error).to be_a RepoConfig::ParserError
+            expect(error.filename).to eq "config/rubocop.yml"
+          end
         end
       end
 

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -153,7 +153,7 @@ describe BuildRunner, '#run' do
       expect(github_api).to have_received(:create_error_status).with(
         "test/repo",
         "headsha",
-        I18n.t(:config_error_status),
+        I18n.t(:config_error_status, filename: "javascript.json"),
         configuration_url
       )
     end


### PR DESCRIPTION

Adds a `filename` field to the `RepoConfig::ParserError` exception class
and uses it when setting the GitHub status.

https://trello.com/c/vCW2P0eX


![more_dumb_stuff_with_custom_config_inheriting_by_thorncp_ _pull_request__62_ _thornco_dumb-ruby](https://cloud.githubusercontent.com/assets/72176/8886699/c2312d0c-3223-11e5-8a3d-59eb1c6b2046.png)