### PR TITLE
Only fetch DATABASE_URL in production env

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -11,4 +11,4 @@ test:
 
 production:
   pool: <%= [ENV.fetch("MAX_THREADS", 5), ENV.fetch("DB_POOL", 5)].max %>
-  url:  <%= ENV.fetch("DATABASE_URL") %>
+  url:  <%= ENV.fetch("DATABASE_URL") if Rails.env.production? %>


### PR DESCRIPTION
Why:

* `DATABASE_URL` only needs to be defined in production environment
* Raises an error if not set in dev/test environments