### PR TITLE
Ensure build exists before scheduling reviews

### DIFF
--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -30,6 +30,7 @@ class BuildRunner
     commit_status.set_pending
     upsert_owner
     build = create_build
+    review_files(build)
     BuildReport.run(pull_request: pull_request, build: build, token: token)
   end
 
@@ -43,12 +44,15 @@ class BuildRunner
 
   def create_build
     repo.builds.create!(
-      file_reviews: style_checker.file_reviews,
       pull_request_number: payload.pull_request_number,
       commit_sha: payload.head_sha,
       payload: payload.build_data.to_json,
       user: current_user_with_token,
     )
+  end
+
+  def review_files(build)
+    build.update!(file_reviews: style_checker.file_reviews)
   end
 
   def pull_request


### PR DESCRIPTION
Why:

* There is currently a problem where reviews have been schedules
  but the assosiated build cannot be found.
* Possibly the build creation failed for some reason,
  but, as is, the review jobs get scheduled anyways.