### PR TITLE
Wrap review related jobs in ApplicationJob

### DIFF
--- a/app/jobs/completed_file_review_job.rb
+++ b/app/jobs/completed_file_review_job.rb
@@ -1,14 +1,14 @@
-class CompletedFileReviewJob
-  @queue = :high
+class CompletedFileReviewJob < ApplicationJob
+  queue_as :high
 
-  def self.perform(attributes)
-    # filename
-    # commit_sha
-    # pull_request_number
-    # patch
-    # violations
-    #   [{ line: 123, message: "WAT" }]
-
+  # attributes is a hash with the following required keys:
+  # - filename
+  # - commit_sha
+  # - pull_request_number
+  # - patch
+  # - violations (an array)
+  #   Example: [{ line: 123, message: "WAT" }]
+  def perform(attributes)
     build = Build.find_by!(
       pull_request_number: attributes.fetch("pull_request_number"),
       commit_sha: attributes.fetch("commit_sha")
@@ -40,9 +40,5 @@ class CompletedFileReviewJob
       build: build,
       token: build.user_token,
     )
-  rescue ActiveRecord::RecordNotFound
-    Resque.enqueue_in(30, self, attributes)
-  rescue Resque::TermException
-    Resque.enqueue(self, attributes)
   end
 end

--- a/app/jobs/go_review_job.rb
+++ b/app/jobs/go_review_job.rb
@@ -1,3 +1,3 @@
-class GoReviewJob
-  @queue = :go_review
+class GoReviewJob < ApplicationJob
+  queue_as :go_review
 end

--- a/app/jobs/scss_review_job.rb
+++ b/app/jobs/scss_review_job.rb
@@ -1,3 +1,3 @@
-class ScssReviewJob
-  @queue = :scss_review
+class ScssReviewJob < ApplicationJob
+  queue_as :scss_review
 end

--- a/app/models/style_guide/base.rb
+++ b/app/models/style_guide/base.rb
@@ -3,6 +3,12 @@ module StyleGuide
     pattr_initialize :repo_config, :repository_owner_name
     attr_implement :file_review
 
+    def file_review(commit_file)
+      attributes = build_attributes(commit_file)
+      job_class.perform_later(attributes)
+      FileReview.new(filename: commit_file.filename)
+    end
+
     def enabled?
       repo_config.enabled_for?(name)
     end
@@ -17,6 +23,25 @@ module StyleGuide
 
     def name
       self.class.name.demodulize.underscore
+    end
+
+    def language
+      self.class::LANGUAGE
+    end
+
+    def job_class
+      "#{language.capitalize}ReviewJob".constantize
+    end
+
+    def build_attributes(commit_file)
+      {
+        filename: commit_file.filename,
+        commit_sha: commit_file.sha,
+        pull_request_number: commit_file.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
+        config: repo_config.raw_for(language),
+      }
     end
   end
 end

--- a/app/models/style_guide/go.rb
+++ b/app/models/style_guide/go.rb
@@ -2,20 +2,6 @@ module StyleGuide
   class Go < Base
     LANGUAGE = "go"
 
-    def file_review(commit_file)
-      Resque.enqueue(
-        GoReviewJob,
-        filename: commit_file.filename,
-        commit_sha: commit_file.sha,
-        pull_request_number: commit_file.pull_request_number,
-        patch: commit_file.patch,
-        content: commit_file.content,
-        config: repo_config.raw_for(LANGUAGE),
-      )
-
-      FileReview.new(filename: commit_file.filename)
-    end
-
     def file_included?(commit_file)
       !vendored?(commit_file.filename)
     end

--- a/app/models/style_guide/scss.rb
+++ b/app/models/style_guide/scss.rb
@@ -2,20 +2,6 @@ module StyleGuide
   class Scss < Base
     LANGUAGE = "scss"
 
-    def file_review(commit_file)
-      Resque.enqueue(
-        ScssReviewJob,
-        filename: commit_file.filename,
-        commit_sha: commit_file.sha,
-        pull_request_number: commit_file.pull_request_number,
-        patch: commit_file.patch,
-        content: commit_file.content,
-        config: repo_config.raw_for(LANGUAGE)
-      )
-
-      FileReview.new(filename: commit_file.filename)
-    end
-
     def file_included?(_)
       true
     end

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -160,6 +160,7 @@ describe StyleChecker, "#file_reviews" do
     it "does not immediately return violations" do
       commit_file = stub_commit_file("test.scss", "* { color: red; }")
       pull_request = stub_pull_request(commit_files: [commit_file])
+      stub_scss_review_run
 
       violation_messages = pull_request_violations(pull_request)
 
@@ -268,5 +269,9 @@ describe StyleChecker, "#file_reviews" do
       for: {},
       ignored_javascript_files: []
     )
+  end
+
+  def stub_scss_review_run
+    allow(ScssReviewJob).to receive(:perform_later)
   end
 end

--- a/spec/models/style_guide/scss_spec.rb
+++ b/spec/models/style_guide/scss_spec.rb
@@ -5,6 +5,7 @@ describe StyleGuide::Scss do
     it "returns an incompleted file review" do
       style_guide = build_style_guide
       commit_file = build_commit_file(filename: "lib/a.scss")
+      stub_review_run
 
       result = style_guide.file_review(commit_file)
 
@@ -12,14 +13,13 @@ describe StyleGuide::Scss do
     end
 
     it "schedules a review job" do
-      allow(Resque).to receive(:enqueue)
       style_guide = build_style_guide("config")
       commit_file = build_commit_file(filename: "lib/a.scss")
+      stub_review_run
 
       style_guide.file_review(commit_file)
 
-      expect(Resque).to have_received(:enqueue).with(
-        ScssReviewJob,
+      expect(ScssReviewJob).to have_received(:perform_later).with(
         filename: commit_file.filename,
         commit_sha: commit_file.sha,
         pull_request_number: commit_file.pull_request_number,
@@ -39,6 +39,10 @@ describe StyleGuide::Scss do
   end
 
   private
+
+  def stub_review_run
+    allow(ScssReviewJob).to receive(:perform_later)
+  end
 
   def build_style_guide(config = "config")
     repo_config = double("RepoConfig", raw_for: config)


### PR DESCRIPTION
Why:

* `ApplicationJob` has logic to retry then give up
* Avoid re-scheduling jobs infinitely