### PR TITLE
Configure New Relic to ignore /assets

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -176,6 +176,11 @@ common: &default_settings
   # implications if your memcached keys are sensitive
   # capture_memcache_keys: true
 
+  # Ignore assets path so New Relic won't report asset request times that might
+  # bring down averages and be misleading.
+  rules:
+    ignore_url_regexes: ["^/assets"]
+
 # Application Environments
 # ------------------------------------------
 # Environment-specific settings are in this section.


### PR DESCRIPTION
This should make our request time charts more realistic.