### PR TITLE
Update and use token in database when creating a session

### DIFF
--- a/app/controllers/activations_controller.rb
+++ b/app/controllers/activations_controller.rb
@@ -31,6 +31,6 @@ class ActivationsController < ApplicationController
   end
 
   def github_token
-    session.fetch(:github_token)
+    current_user.token
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,7 @@ class ApplicationController < ActionController::Base
   end
 
   def signed_in?
-    current_user.present?
+    current_user.present? && current_user.token.present?
   end
 
   def current_user

--- a/app/controllers/deactivations_controller.rb
+++ b/app/controllers/deactivations_controller.rb
@@ -24,7 +24,7 @@ class DeactivationsController < ApplicationController
   end
 
   def github_token
-    session.fetch(:github_token)
+    current_user.token
   end
 
   def check_for_subscription

--- a/app/controllers/repo_syncs_controller.rb
+++ b/app/controllers/repo_syncs_controller.rb
@@ -3,10 +3,7 @@ class RepoSyncsController < ApplicationController
     unless current_user.refreshing_repos?
       current_user.update_attribute(:refreshing_repos, true)
 
-      RepoSynchronizationJob.perform_later(
-        current_user,
-        session[:github_token]
-      )
+      RepoSynchronizationJob.perform_later(current_user)
     end
 
     head 201

--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -1,6 +1,4 @@
 class ReposController < ApplicationController
-  before_action :save_token
-
   def index
     respond_to do |format|
       format.html
@@ -17,14 +15,6 @@ class ReposController < ApplicationController
 
         render json: repos
       end
-    end
-  end
-
-  private
-
-  def save_token
-    if current_user.token.blank?
-      current_user.update!(token: session[:github_token])
     end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,6 +4,7 @@ class SessionsController < ApplicationController
   def create
     user = find_user || create_user
     create_session_for(user)
+    user.update(token: github_token)
     finished("auth_button")
     redirect_to repos_path
   end
@@ -35,7 +36,6 @@ class SessionsController < ApplicationController
 
   def create_session_for(user)
     session[:remember_token] = user.remember_token
-    session[:github_token] = github_token
   end
 
   def destroy_session

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -37,7 +37,7 @@ class SubscriptionsController < ApplicationController
   end
 
   def github_token
-    session.fetch(:github_token)
+    current_user.token
   end
 
   def create_subscription

--- a/app/jobs/repo_synchronization_job.rb
+++ b/app/jobs/repo_synchronization_job.rb
@@ -1,8 +1,8 @@
 class RepoSynchronizationJob < ApplicationJob
   queue_as :high
 
-  def perform(user, github_token)
-    synchronization = RepoSynchronization.new(user, github_token)
+  def perform(user)
+    synchronization = RepoSynchronization.new(user)
     synchronization.start
     user.update_attribute(:refreshing_repos, false)
   end

--- a/app/services/repo_synchronization.rb
+++ b/app/services/repo_synchronization.rb
@@ -1,5 +1,5 @@
 class RepoSynchronization
-  pattr_initialize :user, :github_token
+  pattr_initialize :user
   attr_reader :user
 
   def start
@@ -17,7 +17,7 @@ class RepoSynchronization
   private
 
   def api
-    @api ||= GithubApi.new(github_token)
+    @api ||= GithubApi.new(user.token)
   end
 
   def repo_attributes(attributes)

--- a/spec/controllers/deactivations_controller_spec.rb
+++ b/spec/controllers/deactivations_controller_spec.rb
@@ -3,12 +3,11 @@ require "rails_helper"
 describe DeactivationsController, "#create" do
   context "when deactivation succeeds" do
     it "returns successful response" do
-      token = "sometoken"
       membership = create(:membership)
       repo = membership.repo
       activator = double(:repo_activator, deactivate: true)
       allow(RepoActivator).to receive(:new).and_return(activator)
-      stub_sign_in(membership.user, token)
+      stub_sign_in(membership.user)
 
       post :create, repo_id: repo.id, format: :json
 
@@ -16,7 +15,7 @@ describe DeactivationsController, "#create" do
       expect(response.body).to eq RepoSerializer.new(repo).to_json
       expect(activator).to have_received(:deactivate)
       expect(RepoActivator).to have_received(:new).
-        with(repo: repo, github_token: token)
+        with(repo: repo, github_token: membership.user.token)
       expect(analytics).to have_tracked("Repo Deactivated").
         for_user(membership.user).
         with(
@@ -31,19 +30,18 @@ describe DeactivationsController, "#create" do
 
   context "when deactivation fails" do
     it "returns error response" do
-      token = "sometoken"
       membership = create(:membership)
       repo = membership.repo
       activator = double(:repo_activator, deactivate: false)
       allow(RepoActivator).to receive(:new).and_return(activator)
-      stub_sign_in(membership.user, token)
+      stub_sign_in(membership.user)
 
       post :create, repo_id: repo.id, format: :json
 
       expect(response.code).to eq "502"
       expect(activator).to have_received(:deactivate)
       expect(RepoActivator).to have_received(:new).
-        with(repo: repo, github_token: token)
+        with(repo: repo, github_token: membership.user.token)
     end
   end
 

--- a/spec/controllers/repo_syncs_controller_spec.rb
+++ b/spec/controllers/repo_syncs_controller_spec.rb
@@ -3,30 +3,28 @@ require "rails_helper"
 describe RepoSyncsController, "#create" do
   context "user is refreshing repos" do
     it "will not enqueues repo sync job" do
-      token = "usergithubtoken"
       user = create(:user, refreshing_repos: true)
-      stub_sign_in(user, token)
+      stub_sign_in(user)
       allow(RepoSynchronizationJob).to receive(:perform_later)
 
       post :create
 
       expect(RepoSynchronizationJob).
-        not_to have_received(:perform_later).with(user, token)
+        not_to have_received(:perform_later).with(user)
     end
   end
 
   context "user is not refreshing repos" do
     it "sets user to refreshing repos true and enqueues repo sync job" do
-      token = "usergithubtoken"
       user = create(:user)
-      stub_sign_in(user, token)
+      stub_sign_in(user)
       allow(RepoSynchronizationJob).to receive(:perform_later)
 
       post :create
 
       expect(user.reload).to be_refreshing_repos
       expect(RepoSynchronizationJob).
-        to have_received(:perform_later).with(user, token)
+        to have_received(:perform_later).with(user)
     end
   end
 end

--- a/spec/features/repo_list_spec.rb
+++ b/spec/features/repo_list_spec.rb
@@ -2,9 +2,8 @@ require "rails_helper"
 
 feature "Repo list", js: true do
   let(:username) { ENV.fetch("HOUND_GITHUB_USERNAME") }
-  let(:token) { ENV.fetch("HOUND_GITHUB_TOKEN") }
 
-  scenario "user views landing page" do
+  scenario "signed in user views repo list" do
     user = create(:user)
     repo = create(:repo, full_github_name: "thoughtbot/my-repo")
     repo.users << user
@@ -15,7 +14,19 @@ feature "Repo list", js: true do
     expect(page).to have_content repo.full_github_name
   end
 
+  scenario "signed out user views repo list" do
+    user = create(:user)
+    repo = create(:repo, full_github_name: "thoughtbot/my-repo")
+    repo.users << user
+    sign_in_as(user, nil)
+
+    visit root_path
+
+    expect(page).not_to have_content repo.full_github_name
+  end
+
   scenario "user sees onboarding" do
+    token = "letmein"
     user = create(:user)
 
     stub_repos_requests(token)
@@ -61,6 +72,7 @@ feature "Repo list", js: true do
   end
 
   scenario "user syncs repos" do
+    token = "letmein"
     user = create(:user)
     repo = create(:repo, full_github_name: "user1/test-repo")
     user.repos << repo
@@ -78,6 +90,7 @@ feature "Repo list", js: true do
   end
 
   scenario "user signs up" do
+    token = "letmein"
     user = create(:user)
 
     stub_repos_requests(token)
@@ -87,6 +100,7 @@ feature "Repo list", js: true do
   end
 
   scenario "user activates repo" do
+    token = "letmein"
     user = create(:user)
     repo = create(:repo, private: false)
     repo.users << user
@@ -110,6 +124,7 @@ feature "Repo list", js: true do
   end
 
   scenario "user with admin access activates organization repo" do
+    token = "letmein"
     user = create(:user)
     repo = create(:repo, private: false, full_github_name: "testing/repo")
     repo.users << user
@@ -136,6 +151,7 @@ feature "Repo list", js: true do
   end
 
   scenario "user deactivates repo" do
+    token = "letmein"
     user = create(:user)
     repo = create(:repo, :active)
     repo.users << user
@@ -157,6 +173,7 @@ feature "Repo list", js: true do
   end
 
   scenario "user deactivates private repo without subscription" do
+    token = "letmein"
     user = create(:user)
     repo = create(:repo, :active, private: true)
     repo.users << user

--- a/spec/features/user_authentication_spec.rb
+++ b/spec/features/user_authentication_spec.rb
@@ -6,7 +6,7 @@ feature 'User authentication' do
     user = create(:user)
     stub_repos_requests(token)
 
-    sign_in_as(user)
+    sign_in_as(user, token)
 
     expect(page).to have_content user.github_username
     expect(analytics).to have_tracked("Signed In").for_user(user)

--- a/spec/jobs/repo_synchronization_job_spec.rb
+++ b/spec/jobs/repo_synchronization_job_spec.rb
@@ -12,31 +12,14 @@ describe RepoSynchronizationJob do
   describe "perform" do
     it "syncs repos and sets refreshing_repos to false" do
       user = create(:user, refreshing_repos: false)
-      github_token = "token"
       synchronization = double(:repo_synchronization, start: nil)
       allow(RepoSynchronization).to receive(:new).and_return(synchronization)
 
-      RepoSynchronizationJob.perform_now(user, github_token)
+      RepoSynchronizationJob.perform_now(user)
 
-      expect(RepoSynchronization).to have_received(:new).with(
-        user,
-        github_token
-      )
+      expect(RepoSynchronization).to have_received(:new).with(user)
       expect(synchronization).to have_received(:start)
       expect(user.reload).not_to be_refreshing_repos
-    end
-
-    it "retries when Resque::TermException is raised" do
-      allow(RepoSynchronization).to receive(:new).and_raise(Resque::TermException.new(1))
-      user = build_stubbed(:user)
-      github_token = "token"
-      allow(RepoSynchronizationJob.queue_adapter).to receive(:enqueue)
-
-      job = RepoSynchronizationJob.new(user, github_token)
-      job.perform_now
-
-      expect(RepoSynchronizationJob.queue_adapter).
-        to have_received(:enqueue).with(job)
     end
   end
 end

--- a/spec/services/repo_synchronization_spec.rb
+++ b/spec/services/repo_synchronization_spec.rb
@@ -10,7 +10,7 @@ describe RepoSynchronization do
         repo_name: "user/newrepo"
       )
       user = create(:user)
-      synchronization = RepoSynchronization.new(user, "githubtoken")
+      synchronization = RepoSynchronization.new(user)
 
       synchronization.start
 
@@ -26,7 +26,7 @@ describe RepoSynchronization do
         repo_name: "user/newrepo"
       )
       user = create(:user)
-      synchronization = RepoSynchronization.new(user, "githubtoken")
+      synchronization = RepoSynchronization.new(user)
 
       synchronization.start
 
@@ -43,7 +43,7 @@ describe RepoSynchronization do
       )
       membership = create(:membership)
       user = membership.user
-      synchronization = RepoSynchronization.new(user, "githubtoken")
+      synchronization = RepoSynchronization.new(user)
 
       synchronization.start
 
@@ -61,7 +61,7 @@ describe RepoSynchronization do
         owner_name: "thoughtbot",
         repo_name: repo_name
       )
-      synchronization = RepoSynchronization.new(membership.user, "githubtoken")
+      synchronization = RepoSynchronization.new(membership.user)
 
       synchronization.start
 
@@ -80,7 +80,7 @@ describe RepoSynchronization do
           owner_name: "thoughtbot"
         )
         second_user = create(:user)
-        synchronization = RepoSynchronization.new(second_user, "githubtoken")
+        synchronization = RepoSynchronization.new(second_user)
 
         synchronization.start
 
@@ -100,7 +100,7 @@ describe RepoSynchronization do
             owner_id: owner_github_id,
             owner_name: owner_name
           )
-          synchronization = RepoSynchronization.new(user, "githubtoken")
+          synchronization = RepoSynchronization.new(user)
 
           synchronization.start
 
@@ -120,7 +120,7 @@ describe RepoSynchronization do
             owner_id: owner.github_id,
             owner_name: owner.name
           )
-          synchronization = RepoSynchronization.new(user, "githubtoken")
+          synchronization = RepoSynchronization.new(user)
 
           synchronization.start
 

--- a/spec/support/helpers/authentication_helper.rb
+++ b/spec/support/helpers/authentication_helper.rb
@@ -1,10 +1,10 @@
 module AuthenticationHelper
-  def stub_sign_in(user, token = hound_token)
+  def stub_sign_in(user)
+    user.update(token: "letmein")
     session[:remember_token] = user.remember_token
-    session[:github_token] = token
   end
 
-  def sign_in_as(user, token = hound_token)
+  def sign_in_as(user, token = "letmein")
     stub_oauth(
       username: user.github_username,
       email: user.email_address,


### PR DESCRIPTION
This change updates the user's token each time they sign in. The token used to be saved once, when the token in the database was null, and never updated again.

This change also requires a token be saved in the database and will redirect to the landing page if token is null. We used to allow users to sign in without saving a token to prevent currently authenticated users from going back through the auth flow.

This also sets us up for having two levels of access in Hound since we are updating the token during auth flow.