### PR TITLE
Send active repo ids to Intercom to simplify support

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -9,6 +9,7 @@ module AnalyticsHelper
       email: user.email_address,
       username: user.github_username,
       user_id: user.id,
+      active_repo_ids: user.active_repos.ids,
     }
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,10 @@ class User < ActiveRecord::Base
     github_username
   end
 
+  def active_repos
+    repos.active
+  end
+
   def billable_email
     payment_gateway_customer.email
   end
@@ -23,7 +27,7 @@ class User < ActiveRecord::Base
   end
 
   def has_active_repos?
-    repos.active.count > 0
+    active_repos.count > 0
   end
 
   def token=(value)

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -17,5 +17,22 @@ describe AnalyticsHelper do
         expect(analytics?).to eq false
       end
     end
+
+    describe "#identify_hash" do
+      it "includes user data" do
+        user = create(:user)
+        repo = create(:repo, :active, users: [user])
+
+        identify_hash = identify_hash(user)
+
+        expect(identify_hash).to eq(
+          created: user.created_at,
+          email: user.email_address,
+          username: user.github_username,
+          user_id: user.id,
+          active_repo_ids: [repo.id],
+        )
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -41,6 +41,16 @@ describe User do
     end
   end
 
+  describe "#active_repos" do
+    it "returns active repos" do
+      user = create(:user)
+      active_repo = create(:repo, :active, users: [user])
+      create(:repo, :inactive, users: [user])
+
+      expect(user.active_repos).to eq([active_repo])
+    end
+  end
+
   describe '#has_repos_with_missing_information?' do
     context 'with repo without organization info' do
       it 'returns true' do


### PR DESCRIPTION
Why:

* When providing support via Intercom it saves us a step asking the
  customer to provide their repo information.

https://trello.com/c/FOZl9Sg3