### PR TITLE
Remove unnecessary Haml docs

### DIFF
--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -243,16 +243,6 @@
             haml:
               config_file: .haml-style.yml
 
-      %p
-        Add the following code to your
-        %em.code .hound.yml
-        to disable Haml style checking.
-
-        %code.code-block
-          :preserve
-            haml:
-              enabled: false
-
     %article#go
       %h3 Go (beta)
 


### PR DESCRIPTION
It should be clear how to disable Haml since it's disabled by default and we show instructions for enabling.