### PR TITLE
Update repo attributes on each build

### DIFF
--- a/app/jobs/buildable.rb
+++ b/app/jobs/buildable.rb
@@ -1,6 +1,8 @@
 module Buildable
   def perform(payload_data)
     payload = Payload.new(payload_data)
+
+    UpdateRepoStatus.new(payload).run
     build_runner = BuildRunner.new(payload)
     build_runner.run
   end

--- a/app/models/payload.rb
+++ b/app/models/payload.rb
@@ -62,6 +62,7 @@ class Payload
       "repository" => {
         "id" => github_repo_id,
         "full_name" => full_repo_name,
+        "private" => private_repo?,
         "owner" => {
           "id" => repository_owner_id,
           "login" => repository_owner_name,
@@ -69,6 +70,10 @@ class Payload
         }
       }
     }
+  end
+
+  def private_repo?
+    repository["private"]
   end
 
   private

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -31,16 +31,6 @@ class Repo < ActiveRecord::Base
     repo
   end
 
-  def self.find_and_update(github_id, repo_name)
-    repo = find_by(github_id: github_id)
-
-    if repo && repo.full_github_name != repo_name
-      repo.update(full_github_name: repo_name)
-    end
-
-    repo
-  end
-
   def activate
     update(active: true)
   end

--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -76,10 +76,7 @@ class BuildRunner
   end
 
   def repo
-    @repo ||= Repo.active.find_and_update(
-      payload.github_repo_id,
-      payload.full_repo_name,
-    )
+    @repo ||= Repo.active.find_by(github_id: payload.github_repo_id)
   end
 
   def reset_token

--- a/app/services/update_repo_status.rb
+++ b/app/services/update_repo_status.rb
@@ -1,0 +1,22 @@
+class UpdateRepoStatus
+  pattr_initialize :payload
+
+  def run
+    if repo
+      repo.update(repo_attributes)
+    end
+  end
+
+  private
+
+  def repo
+    @repo ||= Repo.active.find_by(github_id: payload.github_repo_id)
+  end
+
+  def repo_attributes
+    {
+      full_github_name: payload.full_repo_name,
+      private: payload.private_repo?,
+    }
+  end
+end

--- a/spec/jobs/buildable_spec.rb
+++ b/spec/jobs/buildable_spec.rb
@@ -1,19 +1,14 @@
-require "spec_helper"
-require "active_job"
-require "app/jobs/buildable"
-require "app/models/payload"
-require "app/services/build_runner"
-require "raven"
+require "rails_helper"
 
 describe Buildable do
   class BuildableTestJob < ActiveJob::Base
     include Buildable
   end
 
-  describe "perform" do
+  describe "#perform" do
     it 'runs build runner' do
       build_runner = double(:build_runner, run: nil)
-      payload = double("Payload")
+      payload = double("Payload", github_repo_id: 1)
       allow(Payload).to receive(:new).with(payload_data).and_return(payload)
       allow(BuildRunner).to receive(:new).and_return(build_runner)
 
@@ -23,11 +18,24 @@ describe Buildable do
       expect(BuildRunner).to have_received(:new).with(payload)
       expect(build_runner).to have_received(:run)
     end
+
+    it "runs repo updater" do
+      repo_updater = double("RepoUpdater", run: nil)
+      payload = double("Payload", github_repo_id: 1)
+      allow(Payload).to receive(:new).with(payload_data).and_return(payload)
+      allow(UpdateRepoStatus).to receive(:new).and_return(repo_updater)
+
+      BuildableTestJob.perform_now(payload_data)
+
+      expect(Payload).to have_received(:new).with(payload_data)
+      expect(UpdateRepoStatus).to have_received(:new).with(payload)
+      expect(repo_updater).to have_received(:run)
+    end
   end
 
   describe "#after_retry_exhausted" do
     it "sets internal server error on github" do
-      build_runner = double(:build_runner, set_internal_error: nil)
+      build_runner = double("BuildRunner", set_internal_error: nil)
       payload = double("Payload")
       allow(Payload).to receive(:new).with(payload_data).and_return(payload)
       allow(BuildRunner).to receive(:new).and_return(build_runner)

--- a/spec/models/payload_spec.rb
+++ b/spec/models/payload_spec.rb
@@ -150,6 +150,34 @@ describe Payload do
     end
   end
 
+  describe "#private_repo?" do
+    context "when repo is private" do
+      it "returns true" do
+        payload_json = {
+          "repository" => {
+            "private" => true,
+          }
+        }
+        payload = Payload.new(payload_json)
+
+        expect(payload.private_repo?).to eq(true)
+      end
+    end
+
+    context "when repo is public" do
+      it "returns false" do
+        payload_json = {
+          "repository" => {
+            "private" => false,
+          }
+        }
+        payload = Payload.new(payload_json)
+
+        expect(payload.private_repo?).to eq(false)
+      end
+    end
+  end
+
   describe "#build_data" do
     it "returns a subset of original data" do
       payload_data = File.read(
@@ -170,6 +198,7 @@ describe Payload do
           "repository" => {
             "id" => 2937493,
             "full_name" => "salbertson/life",
+            "private" => false,
             "owner" => {
               "id" => 154463,
               "login" => "salbertson",

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -154,18 +154,4 @@ describe Repo do
       end
     end
   end
-
-  describe ".find_and_update" do
-    context "when repo name doesn't match db record" do
-      it "updates the record" do
-        new_repo_name = "new/name"
-        repo = create(:repo, name: "foo/bar")
-
-        Repo.find_and_update(repo.github_id, new_repo_name)
-        repo.reload
-
-        expect(repo.full_github_name).to eq new_repo_name
-      end
-    end
-  end
 end

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -74,10 +74,11 @@ describe BuildRunner do
       end
 
       it "creates GitHub statuses" do
-        repo = create(:repo, :active)
+        repo_name = "test/repo"
+        repo = create(:repo, :active, name: repo_name)
         payload = stubbed_payload(
           github_repo_id: repo.github_id,
-          full_repo_name: "test/repo",
+          full_repo_name: repo_name,
           head_sha: "headsha",
         )
         build_runner = BuildRunner.new(payload)
@@ -93,12 +94,12 @@ describe BuildRunner do
         build_runner.run
 
         expect(github_api).to have_received(:create_pending_status).with(
-          "test/repo",
+          repo_name,
           "headsha",
           I18n.t(:pending_status),
         )
         expect(github_api).to have_received(:create_success_status).with(
-          "test/repo",
+          repo_name,
           "headsha",
           I18n.t(:complete_status, count: 3),
         )

--- a/spec/services/update_repo_status_spec.rb
+++ b/spec/services/update_repo_status_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe UpdateRepoStatus do
+  describe "#run" do
+    it "updates the repo full_github_name" do
+      expected_repo_name = "foo/bar"
+      repo = create(:repo, :active)
+      payload = double(
+        "Payload",
+        github_repo_id: repo.github_id,
+        full_repo_name: expected_repo_name,
+        private_repo?: repo.private,
+      )
+
+      UpdateRepoStatus.new(payload).run
+
+      repo.reload
+      expect(repo.full_github_name).to eq(expected_repo_name)
+    end
+
+    it "updates the private flag for repo" do
+      expected_status = true
+      repo = create(:repo, :active)
+      payload = double(
+        "Payload",
+        github_repo_id: repo.github_id,
+        full_repo_name: repo.full_github_name,
+        private_repo?: expected_status,
+      )
+
+      UpdateRepoStatus.new(payload).run
+
+      repo.reload
+      expect(repo.private).to eq(expected_status)
+    end
+  end
+end


### PR DESCRIPTION
The idea is to keep repo attributes updated always so we can track public/private flag change on repo from GitHub.