### PR TITLE
Allow users to try Hound without giving access to private repos

### DIFF
--- a/app/assets/javascripts/directives/repo_list.js.coffee.erb
+++ b/app/assets/javascripts/directives/repo_list.js.coffee.erb
@@ -3,6 +3,8 @@ App.directive 'repoList', ['Repo', 'Sync', 'User', '$timeout', (Repo, Sync, User
   templateUrl: '/templates/repo_list'
 
   link: (scope, element, attributes) ->
+    scope.includePrivateReposButtonText = '<%= I18n.t('include_private_repos') %>'
+
     loadRepos = ->
       scope.syncingRepos = false
 

--- a/app/assets/stylesheets/repos/_index.scss
+++ b/app/assets/stylesheets/repos/_index.scss
@@ -175,7 +175,7 @@ aside.org-nav {
     vertical-align: middle;
 
     .search-wrapper {
-      @include span-columns(6 of 9, table);
+      @include span-columns(5 of 12, table);
       padding-right: 1em;
       position: relative;
       vertical-align: top;
@@ -231,17 +231,29 @@ aside.org-nav {
       }
     }
 
-    .refresh-wrapper {
-      @include span-columns(3 of 9, table);
-      vertical-align: top;
 
+    .refresh-wrapper, .include-private-repos-wrapper {
+      vertical-align: top;
+    }
+
+    .include-private-repos-wrapper {
+      @include span-columns(4 of 12, table);
+      @include media($medium-screen) {
+        display: none;
+      }
+
+      padding-right: 1em;
+    }
+
+    .refresh-wrapper {
+      @include span-columns(3 of 12, table);
       @include media($small-screen) {
         display: block;
         width: 100%;
       }
     }
 
-    button.refresh {
+    button.refresh, button.include-private-repos {
       @include transition(all 0.15s linear);
       background-color: rgb(248,248,248);
       border-radius: 3px;

--- a/app/models/github_auth_options.rb
+++ b/app/models/github_auth_options.rb
@@ -1,0 +1,13 @@
+class GithubAuthOptions
+  def initialize(env)
+    @request = Rack::Request.new(env)
+  end
+
+  def to_hash
+    if @request.params["access"] == "full"
+      { scope: "repo,user:email" }
+    else
+      { scope: "user:email" }
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,14 @@ class User < ActiveRecord::Base
     end
   end
 
+  def access_to_private_repos?
+    if token_scopes
+      token_scopes.split(",").include? "repo"
+    else
+      false
+    end
+  end
+
   private
 
   def crypt

--- a/app/views/application/_header.haml
+++ b/app/views/application/_header.haml
@@ -17,7 +17,7 @@
             .avatar(style="background-image: url('#{avatar_url(current_user)}')")
           %span #{current_user.github_username}
       %li
-        = link_to "Sign Out", sign_out_path, class: "sign-out"
+        = link_to t("sign_out"), sign_out_path, class: "sign-out"
     - else
       %li
         = link_to "Pricing", "#pricing", class: "pricing"

--- a/app/views/templates/repo_list.haml
+++ b/app/views/templates/repo_list.haml
@@ -2,6 +2,10 @@
   .search-wrapper
     %i.fa.fa-search
     %input.search{'type' => 'text', 'placeholder' => t('search_placeholder'), 'ng-model' => 'search.full_github_name'}
+  - unless current_user.access_to_private_repos?
+    .include-private-repos-wrapper
+      = button_to "/auth/github?access=full", class: "include-private-repos", "ng-disabled" => "syncingRepos" do
+        %span {{ includePrivateReposButtonText }}
   .refresh-wrapper
     %button{'class' => 'refresh', 'ng-click' => 'sync()', 'ng-disabled' => 'syncingRepos'}
       %span {{ syncButtonText }}

--- a/config/initializers/omni_auth.rb
+++ b/config/initializers/omni_auth.rb
@@ -3,6 +3,9 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     :github,
     ENV['GITHUB_CLIENT_ID'],
     ENV['GITHUB_CLIENT_SECRET'],
-    scope: 'user:email,repo'
+    setup: ->(env) {
+      options = GithubAuthOptions.new(env)
+      env["omniauth.strategy"].options.merge!(options.to_hash)
+    }
   )
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,9 @@
 en:
   sync_repos: "Refresh repo list"
-  syncing_repos: "Loading repos..."
+  include_private_repos: "Include private repos"
+  syncing_repos: "Loading..."
   authenticate: "Sign In with GitHub"
+  sign_out: "Sign Out"
   active_repos: "Active repos"
   search_placeholder: "Search by repo"
   pending_status: "Hound is busy reviewing changes..."

--- a/db/migrate/20150728154011_add_token_scopes_to_users.rb
+++ b/db/migrate/20150728154011_add_token_scopes_to_users.rb
@@ -1,0 +1,10 @@
+class AddTokenScopesToUsers < ActiveRecord::Migration
+  def up
+    add_column :users, :token_scopes, :string
+    execute "UPDATE users SET token_scopes = 'repo,user:email' WHERE token IS NOT NULL"
+  end
+
+  def down
+    remove_column :users, :token_scopes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -125,6 +125,7 @@ ActiveRecord::Schema.define(version: 20150731212842) do
     t.string   "stripe_customer_id", limit: 255
     t.string   "token"
     t.string   "utm_source"
+    t.string   "token_scopes"
   end
 
   add_index "users", ["remember_token"], name: "index_users_on_remember_token", using: :btree

--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -8,7 +8,6 @@ class GithubApi
 
   attr_reader :file_cache, :token
 
-  # doesn't look like we need a default token
   def initialize(token)
     @token = token
     @file_cache = {}
@@ -16,6 +15,10 @@ class GithubApi
 
   def client
     @client ||= Octokit::Client.new(access_token: token, auto_paginate: true)
+  end
+
+  def scopes
+    client.scopes(token).join(",")
   end
 
   def repos

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -4,9 +4,11 @@ describe SessionsController do
   describe "#create" do
     context "with valid new user" do
       it "creates new user" do
+        stub_scopes_request(token: "letmein")
         request.env["omniauth.auth"] = stub_oauth(
           username: "jimtom",
-          email: "jimtom@example.com"
+          email: "jimtom@example.com",
+          token: "letmein"
         )
 
         expect { post :create }.to change { User.count }.by(1)

--- a/spec/features/repo_list_spec.rb
+++ b/spec/features/repo_list_spec.rb
@@ -2,70 +2,56 @@ require "rails_helper"
 
 feature "Repo list", js: true do
   let(:username) { ENV.fetch("HOUND_GITHUB_USERNAME") }
+  let(:user) { create(:user, token_scopes: "user:email") }
 
   scenario "signed in user views repo list" do
-    user = create(:user)
     repo = create(:repo, full_github_name: "thoughtbot/my-repo")
     repo.users << user
-    sign_in_as(user)
 
-    visit root_path
+    sign_in_as(user)
 
     expect(page).to have_content repo.full_github_name
   end
 
   scenario "signed out user views repo list" do
-    user = create(:user)
     repo = create(:repo, full_github_name: "thoughtbot/my-repo")
     repo.users << user
-    sign_in_as(user, nil)
-
-    visit root_path
 
     expect(page).not_to have_content repo.full_github_name
   end
 
   scenario "user sees onboarding" do
     token = "letmein"
-    user = create(:user)
-
     stub_repos_requests(token)
-    sign_in_as(user)
 
-    visit repos_path
+    sign_in_as(user)
 
     expect(page).to have_content I18n.t("onboarding.title")
   end
 
   scenario "user does not see onboarding" do
-    user = create(:user)
     build = create(:build)
     build.repo.users << user
-    sign_in_as(user)
 
-    visit repos_path
+    sign_in_as(user)
 
     expect(page).to_not have_content I18n.t("onboarding.title")
   end
 
   scenario "user views list" do
-    user = create(:user)
     repo = create(:repo, full_github_name: "thoughtbot/my-repo")
     repo.users << user
-    sign_in_as(user)
 
-    visit repos_path
+    sign_in_as(user)
 
     expect(page).to have_content repo.full_github_name
   end
 
   scenario "user filters list" do
-    user = create(:user)
     repo = create(:repo, full_github_name: "thoughtbot/my-repo")
     repo.users << user
 
     sign_in_as(user)
-    visit repos_path
     find(".search").set(repo.full_github_name)
 
     expect(page).to have_content repo.full_github_name
@@ -73,13 +59,11 @@ feature "Repo list", js: true do
 
   scenario "user syncs repos" do
     token = "letmein"
-    user = create(:user)
     repo = create(:repo, full_github_name: "user1/test-repo")
     user.repos << repo
     stub_repos_requests(token)
 
     sign_in_as(user, token)
-    visit repos_path
 
     expect(page).to have_content(repo.full_github_name)
 
@@ -91,17 +75,15 @@ feature "Repo list", js: true do
 
   scenario "user signs up" do
     token = "letmein"
-    user = create(:user)
 
     stub_repos_requests(token)
     sign_in_as(user)
 
-    expect(page).to have_content I18n.t("syncing_repos")
+    expect(page).to have_content I18n.t("sign_out")
   end
 
   scenario "user activates repo" do
     token = "letmein"
-    user = create(:user)
     repo = create(:repo, private: false)
     repo.users << user
     hook_url = "http://#{ENV["HOST"]}/builds"
@@ -125,7 +107,6 @@ feature "Repo list", js: true do
 
   scenario "user with admin access activates organization repo" do
     token = "letmein"
-    user = create(:user)
     repo = create(:repo, private: false, full_github_name: "testing/repo")
     repo.users << user
     hook_url = "http://#{ENV["HOST"]}/builds"
@@ -152,7 +133,6 @@ feature "Repo list", js: true do
 
   scenario "user deactivates repo" do
     token = "letmein"
-    user = create(:user)
     repo = create(:repo, :active)
     repo.users << user
     stub_repo_request(repo.full_github_name, token)
@@ -160,7 +140,6 @@ feature "Repo list", js: true do
     stub_remove_collaborator_request(username, repo.full_github_name, token)
 
     sign_in_as(user, token)
-    visit repos_path
     find(".repos .toggle").click
 
     expect(page).not_to have_css(".active")
@@ -174,7 +153,6 @@ feature "Repo list", js: true do
 
   scenario "user deactivates private repo without subscription" do
     token = "letmein"
-    user = create(:user)
     repo = create(:repo, :active, private: true)
     repo.users << user
     stub_repo_request(repo.full_github_name, token)
@@ -182,7 +160,6 @@ feature "Repo list", js: true do
     stub_remove_collaborator_request(username, repo.full_github_name, token)
 
     sign_in_as(user, token)
-    visit repos_path
     find(".repos .toggle").click
 
     expect(page).not_to have_css(".active")

--- a/spec/lib/github_api_spec.rb
+++ b/spec/lib/github_api_spec.rb
@@ -17,6 +17,18 @@ describe GithubApi do
     end
   end
 
+  describe "#scopes" do
+    it "returns scopes as a string" do
+      token = "token"
+      api = GithubApi.new(token)
+      stub_scopes_request(token: token, scopes: "repo,user:email")
+
+      scopes = api.scopes
+
+      expect(scopes).to eq "repo,user:email"
+    end
+  end
+
   describe "#file_contents" do
     context "used multiple times with same arguments" do
       it "requests file content once" do

--- a/spec/models/github_auth_options_spec.rb
+++ b/spec/models/github_auth_options_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+require "app/models/github_auth_options"
+require "rack"
+
+describe GithubAuthOptions do
+  describe "#to_hash" do
+    context "when request access param is full" do
+      it "returns expected scopes, sorted by name" do
+        env = { Rack::QUERY_STRING => "access=full", "rack.input" => "whatevs" }
+        options = GithubAuthOptions.new(env)
+
+        options_as_hash = options.to_hash
+
+        expect(options_as_hash[:scope]).to eq "repo,user:email"
+      end
+    end
+
+    context "when request access param is not full" do
+      it "returns expected scope" do
+        env = { "rack.input" => "whatevs" }
+        options = GithubAuthOptions.new(env)
+
+        options_as_hash = options.to_hash
+
+        expect(options_as_hash[:scope]).to eq "user:email"
+      end
+    end
+  end
+end

--- a/spec/support/helpers/authentication_helper.rb
+++ b/spec/support/helpers/authentication_helper.rb
@@ -10,6 +10,7 @@ module AuthenticationHelper
       email: user.email_address,
       token: token
     )
+    stub_scopes_request(token: token)
     visit root_path(SPLIT_DISABLE: "true")
     click_link(I18n.t('authenticate'), match: :first)
   end

--- a/spec/support/helpers/github_api_helper.rb
+++ b/spec/support/helpers/github_api_helper.rb
@@ -254,6 +254,21 @@ module GithubApiHelper
     )
   end
 
+  def stub_scopes_request(token: "token", scopes: "user:email")
+    stub_request(:get, "https://api.github.com/user").
+      with(
+        headers: {
+          "Accept" => "application/vnd.github.v3+json",
+          "Authorization" => "token #{token}",
+          "Content-Type" => "application/json",
+          "User-Agent" => "Octokit Ruby Gem 4.0.0"
+        }
+      ).
+      to_return(
+        status: 200, body: "", headers: { "X-OAuth-Scopes" => scopes }
+      )
+  end
+
   private
 
   def stub_repos_requests(token)


### PR DESCRIPTION
Addresses https://github.com/thoughtbot/hound/issues/597 and https://github.com/thoughtbot/hound/issues/701.

![hound private access](https://cloud.githubusercontent.com/assets/154463/9308854/2ac59ca0-44bb-11e5-87d1-04e1e953f91f.gif)
