### PR TITLE
Remove force_https? from BuildsController

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -12,10 +12,6 @@ class BuildsController < ApplicationController
 
   private
 
-  def force_https?
-    false
-  end
-
   def ignore_confirmation_pings
     if payload.ping?
       head :ok


### PR DESCRIPTION
As this has been removed in aaef09bb2ee10d5d7370ce62b77c93063bafa626