### PR TITLE
CoffeeScript: Remove 'Empty function' violation

### DIFF
--- a/config/style_guides/thoughtbot/coffeescript.json
+++ b/config/style_guides/thoughtbot/coffeescript.json
@@ -51,7 +51,7 @@
     "level": "error"
   },
   "no_empty_functions": {
-    "level": "error"
+    "level": "ignore"
   },
   "no_empty_param_list": {
     "level": "error"

--- a/spec/models/style_guide/coffee_script_spec.rb
+++ b/spec/models/style_guide/coffee_script_spec.rb
@@ -88,6 +88,21 @@ describe StyleGuide::CoffeeScript do
       end
     end
 
+    context "with thoughtbot configuration" do
+      context "for an empty function" do
+        it "returns a file review without violations" do
+          code = <<-CODE.strip_heredoc
+            class FooBar
+              foo: ->
+          CODE
+
+          violations = violations_in(code, repository_owner_name: "thoughtbot")
+
+          expect(violations).to be_empty
+        end
+      end
+    end
+
     context "with violation on unchanged line" do
       it "finds no violations" do
         file = double(


### PR DESCRIPTION
Oftentimes it's useful in tests to stub out methods on objects with
empty functions.

For instance you might make a helper function in a test file:

``` coffee
buildSomeFakeObject = (overrides = {}) ->
  _.defaults overrides,
   foo: ->
   bar: ->
```

and then later on in the test, you might say:

``` coffee
fakeObject = buildSomeFakeObject()
spyOn(fakeObject, "foo")

...

expect(fakeObject.foo).toHaveBeenCalled()
```

Currently, Hound will complain within `buildSomeFakeObject` that `foo`
and `bar` are empty functions. This creates a lot of noise.

I don't think this rule is necessary in the general case anyway -- I've
never seen anyone make an empty function accidentally.