### PR TITLE
Revert "Structure files according to used version of rails"

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ module Houndapp
   class Application < Rails::Application
     config.autoload_paths += %W(#{config.root}/lib)
     config.encoding = "utf-8"
+    config.filter_parameters += [:password]
     config.active_support.escape_html_entities_in_json = true
     config.active_job.queue_adapter = :resque
     config.middleware.insert_before "Rack::ETag", "Rack::Deflater"

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,5 +10,5 @@ test:
   database: hound_test
 
 production:
-  pool: <%= [ENV.fetch("MAX_THREADS", 5), ENV.fetch("DB_POOL", 5)].max %>
+  pool: <%= [Integer(ENV.fetch("MAX_THREADS", 5)), Integer(ENV.fetch("DB_POOL", 5))].max %>
   url:  <%= ENV.fetch("DATABASE_URL") if Rails.env.production? %>

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,1 +1,0 @@
-Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,1 +1,0 @@
-Rails.application.config.filter_parameters += [:password]


### PR DESCRIPTION
This reverts commit 9988a31724e61a7a4363bc582bc7ef776e91d428.

This change fixes this

<img width="1278" alt="screenshot 2015-08-21 07 40 51" src="https://cloud.githubusercontent.com/assets/154463/9411058/a9e0e39e-47d8-11e5-8494-4573c752a5ea.png">

and

<img width="1280" alt="screenshot 2015-08-21 07 41 05" src="https://cloud.githubusercontent.com/assets/154463/9411059/a9e47c70-47d8-11e5-9e8f-6a15828cced9.png">
