### PR TITLE
Revert "Structure files according to used version of rails"

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ module Houndapp
   class Application < Rails::Application
     config.autoload_paths += %W(#{config.root}/lib)
     config.encoding = "utf-8"
+    config.filter_parameters += [:password]
     config.active_support.escape_html_entities_in_json = true
     config.active_job.queue_adapter = :resque
     config.middleware.insert_before "Rack::ETag", "Rack::Deflater"

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,1 +1,0 @@
-Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,1 +1,0 @@
-Rails.application.config.filter_parameters += [:password]


### PR DESCRIPTION
This reverts commit 9988a31724e61a7a4363bc582bc7ef776e91d428.

Changing cookie serialization to JSON causes the app to fail when attempting to parse old cookies that aren't JSON. See also: #892