### PR TITLE
Revert SSL refactoring

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,25 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
 
+  before_action :force_https
   before_action :capture_campaign_params
   before_action :authenticate
 
   helper_method :current_user, :signed_in?
 
   private
+
+  def force_https
+    if ENV['ENABLE_HTTPS'] == 'yes'
+      if !request.ssl? && force_https?
+        redirect_to protocol: "https://", status: :moved_permanently
+      end
+    end
+  end
+
+  def force_https?
+    true
+  end
 
   def capture_campaign_params
     session[:campaign_params] ||= {

--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -12,6 +12,10 @@ class BuildsController < ApplicationController
 
   private
 
+  def force_https?
+    false
+  end
+
   def ignore_confirmation_pings
     if payload.ping?
       head :ok

--- a/app/services/repo_activator.rb
+++ b/app/services/repo_activator.rb
@@ -70,12 +70,20 @@ class RepoActivator
     end
   end
 
+  def builds_url
+    URI.join("#{protocol}://#{ENV["HOST"]}", "builds").to_s
+  end
+
+  def protocol
+    if ENV.fetch("ENABLE_HTTPS") == "yes"
+      "https"
+    else
+      "http"
+    end
+  end
+
   def add_error(error)
     error_message = ErrorMessageTranslation.from_error_response(error)
     errors.push(error_message).compact!
-  end
-
-  def builds_url
-    Rails.application.routes.url_helpers.builds_url
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,5 @@ module Houndapp
       "RedirectToConfiguration"
     )
     config.exceptions_app = routes
-
-    Rails.application.routes.default_url_options[:host] = ENV.fetch("HOST")
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Houndapp::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = (ENV["ENABLE_HTTPS"] == "yes")
+  # config.force_ssl = true
 
   # See everything in the log (default is :info)
   config.log_level = :debug
@@ -51,7 +51,7 @@ Houndapp::Application.configure do
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = { host: ENV.fetch("HOST") }
+  config.action_mailer.default_url_options = { :host => 'houndci.com' }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,4 +1,5 @@
 require_relative "production"
 
 Houndapp::Application.configure do
+  config.action_mailer.default_url_options = { :host => 'staging.houndci.com' }
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe HomeController, "#index" do
+  context "when https is enabled" do
+    context "and http is used" do
+      it "redirects to https" do
+        with_https_enabled do
+          get :index
+
+          expect(response).to redirect_to(root_url(protocol: "https"))
+        end
+      end
+    end
+
+    context "and https is used" do
+      it "does not redirect" do
+        with_https_enabled do
+          request.env["HTTPS"] = "on"
+
+          get :index
+
+          expect(response).not_to be_redirect
+        end
+      end
+    end
+  end
+
+  context "when https is disabled" do
+    context "and http is used" do
+      it "does not redirect" do
+        get :index
+
+        expect(response).not_to be_redirect
+      end
+    end
+  end
+end

--- a/spec/support/helpers/https_helper.rb
+++ b/spec/support/helpers/https_helper.rb
@@ -1,7 +1,7 @@
 module HttpsHelper
   def with_https_enabled
-    Rails.application.routes.default_url_options[:protocol] = "https"
+    ENV['ENABLE_HTTPS'] = 'yes'
     yield
-    Rails.application.routes.default_url_options[:protocol] = "http"
+    ENV['ENABLE_HTTPS'] = 'no'
   end
 end


### PR DESCRIPTION
Reverts aaef09bb2ee10d5d7370ce62b77c93063bafa626 and 3b22d42c1ded47a485e2f8bf6bc9e6138784aa58.

The SSL refactorings were forcing all incoming traffic to use `https`, but we have old webhooks in the wild that still use `http`. GitHub's webhooks do not honor redirects, so those payloads will fail and users will not have their PRs reviews.

![webhook_-_https___houndci_com_builds](https://cloud.githubusercontent.com/assets/72176/9420115/fb01d498-4816-11e5-944e-65fa27a6f41c.png)
