### PR TITLE
Add Swift Support

### DIFF
--- a/app/jobs/swift_review_job.rb
+++ b/app/jobs/swift_review_job.rb
@@ -1,0 +1,3 @@
+class SwiftReviewJob
+  @queue = :swift_review
+end

--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -1,8 +1,8 @@
 # Load and parse config files from GitHub repo
 class RepoConfig
   HOUND_CONFIG = ".hound.yml"
-  BETA_LANGUAGES = %w(go haml python)
-  LANGUAGES = %w(ruby coffeescript javascript scss haml go python)
+  BETA_LANGUAGES = %w(go haml python swift)
+  LANGUAGES = %w(ruby coffeescript javascript scss haml go python swift)
   FILE_TYPES = {
     "ruby" => "yaml",
     "javascript" => "json",

--- a/app/models/style_checker.rb
+++ b/app/models/style_checker.rb
@@ -48,6 +48,8 @@ class StyleChecker
       StyleGuide::Go
     when /.+\.py\z/
       StyleGuide::Python
+    when /.+\.swift\z/
+      StyleGuide::Swift
     else
       StyleGuide::Unsupported
     end

--- a/app/models/style_guide/swift.rb
+++ b/app/models/style_guide/swift.rb
@@ -1,0 +1,23 @@
+module StyleGuide
+  class Swift < Base
+    LANGUAGE = "swift"
+
+    def file_review(commit_file)
+      Resque.enqueue(
+        SwiftReviewJob,
+        filename: commit_file.filename,
+        commit_sha: commit_file.sha,
+        pull_request_number: commit_file.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
+        config: repo_config.raw_for(LANGUAGE),
+      )
+
+      FileReview.new(filename: commit_file.filename)
+    end
+
+    def file_included?(_)
+      true
+    end
+  end
+end

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -46,6 +46,8 @@ describe RepoConfig do
             enabled: true
           python:
             enabled: true
+          swift:
+            enabled: true
         EOS
         repo_config = RepoConfig.new(commit)
 
@@ -130,6 +132,8 @@ describe RepoConfig do
             Go:
               Enabled: true
             Python:
+              Enabled: true
+            Swift:
               Enabled: true
           EOS
           repo_config = RepoConfig.new(commit)

--- a/spec/models/style_guide/swift_spec.rb
+++ b/spec/models/style_guide/swift_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+describe StyleGuide::Swift do
+  describe "#file_review" do
+    it "returns an incompleted file review" do
+      style_guide = build_style_guide
+      commit_file = build_commit_file(filename: "a.swift")
+
+      result = style_guide.file_review(commit_file)
+
+      expect(result).not_to be_completed
+    end
+
+    it "schedules a review job" do
+      allow(Resque).to receive(:enqueue)
+      style_guide = build_style_guide("config")
+      commit_file = build_commit_file(filename: "a.swift")
+
+      style_guide.file_review(commit_file)
+
+      expect(Resque).to have_received(:enqueue).with(
+        SwiftReviewJob,
+        filename: commit_file.filename,
+        commit_sha: commit_file.sha,
+        pull_request_number: commit_file.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
+        config: "config",
+      )
+    end
+  end
+
+  describe "#file_included?" do
+    it "returns true" do
+      style_guide = build_style_guide
+
+      expect(style_guide.file_included?(double)).to eq true
+    end
+  end
+
+  private
+
+  def build_style_guide(config = "config")
+    repo_config = double("RepoConfig", raw_for: config)
+    StyleGuide::Swift.new(repo_config, "ralph")
+  end
+end


### PR DESCRIPTION
Why:

* Requested by Users
* We want to use it internally :)

This change addresses the need by:

* Adding Swift support so that Hound queues jobs for Swift
  that the worker can pick up.

Swift Service Repo: https://github.com/thoughtbot/hound-swift