### PR TITLE
Add an admin dashboard through Administrate

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 # Don't modify this file. Create `.env.local` and put your overrides in there.
+ADMIN_GITHUB_USERNAMES=your_github_handle,another_github_handle
 CHANGED_FILES_THRESHOLD=300
 DB_POOL=5
 DB_REAPING_FREQUENCY=10

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 ruby "2.2.3"
 
 gem "active_model_serializers", "0.8.3"
+gem "administrate", "~> 0.0.8"
 gem "analytics-ruby", "~> 2.0.0", require: "segment/analytics"
 gem "angularjs-rails"
 gem "angular_rails_csrf"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,12 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.7)
+    administrate (0.0.8)
+      neat (~> 1.1)
+      normalize-rails (~> 3.0)
+      rails (~> 4.2)
+      sass (~> 3.4)
+      selectize-rails (~> 0.6)
     analytics-ruby (2.0.6)
     angular_rails_csrf (1.0.3)
       rails (>= 3, < 5)
@@ -158,6 +164,7 @@ GEM
     newrelic_rpm (3.9.9.275)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    normalize-rails (3.0.3)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
@@ -282,6 +289,7 @@ GEM
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
+    selectize-rails (0.12.1)
     sentry-raven (0.9.4)
       faraday (>= 0.7.6)
       hashie (>= 1.1.0)
@@ -332,6 +340,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (= 0.8.3)
+  administrate (~> 0.0.8)
   analytics-ruby (~> 2.0.0)
   angular_rails_csrf
   angularjs-rails

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,0 +1,27 @@
+class Admin::ApplicationController < Administrate::ApplicationController
+  before_action :authenticate_admin
+
+  private
+
+  def controller_path
+    params[:resource_class].to_s
+  end
+
+  def authenticate_admin
+    unless github_admin?
+      redirect_to :root
+    end
+  end
+
+  def github_admin?
+    current_user && admin_github_handles.include?(current_user.github_username)
+  end
+
+  def current_user
+    @current_user ||= User.find_by(remember_token: session[:remember_token])
+  end
+
+  def admin_github_handles
+    ENV.fetch("ADMIN_GITHUB_USERNAMES", "").split(",")
+  end
+end

--- a/app/dashboards/bulk_customer_dashboard.rb
+++ b/app/dashboards/bulk_customer_dashboard.rb
@@ -1,0 +1,31 @@
+require "administrate/base_dashboard"
+
+class BulkCustomerDashboard < Administrate::BaseDashboard
+  READ_ONLY_ATTRIBUTES = [
+    :id,
+    :created_at,
+    :updated_at,
+  ]
+
+  ATTRIBUTE_TYPES = {
+    id: Field::String,
+    created_at: Field::String,
+    updated_at: Field::String,
+    org: Field::String,
+    description: Field::String,
+    interval: Field::String,
+    repo_limit: Field::String,
+    current_repos: Field::String,
+    subscription_token: Field::String,
+  }
+
+  TABLE_ATTRIBUTES = [
+    :org,
+    :description,
+    :repo_limit,
+    :current_repos,
+  ]
+
+  SHOW_PAGE_ATTRIBUTES = ATTRIBUTE_TYPES.keys
+  FORM_ATTRIBUTES = ATTRIBUTE_TYPES.keys - READ_ONLY_ATTRIBUTES
+end

--- a/app/dashboards/dashboard_manifest.rb
+++ b/app/dashboards/dashboard_manifest.rb
@@ -1,0 +1,5 @@
+class DashboardManifest
+  DASHBOARDS = [
+    :bulk_customers,
+  ]
+end

--- a/app/models/bulk_customer.rb
+++ b/app/models/bulk_customer.rb
@@ -18,4 +18,8 @@ class BulkCustomer < ActiveRecord::Base
 
     update(current_repos: repo_count)
   end
+
+  def to_s
+    org
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,16 @@
 Houndapp::Application.routes.draw do
+  namespace :admin do
+    DashboardManifest::DASHBOARDS.each do |dashboard_resource|
+      resources(
+        dashboard_resource,
+        controller: "application",
+        resource_class: dashboard_resource,
+      )
+    end
+
+    root to: "application#index", resource_class: :bulk_customers
+  end
+
   mount Resque::Server, at: "/queue"
   mount JasmineRails::Engine => "/specs" if defined?(JasmineRails)
   mount Split::Dashboard, at: "split"

--- a/spec/features/admin_authorization_spec.rb
+++ b/spec/features/admin_authorization_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+feature "Admin authorization" do
+  scenario "admin accesses dashboard" do
+    stub_repos_requests(token)
+    stub_admin_github_usernames("admin_user,other_admin_user")
+    admin = create(:user, github_username: "admin_user")
+
+    sign_in_as(admin, token)
+    visit admin_bulk_customers_path
+
+    expect(page).to have_admin_bulk_customers_header
+  end
+
+  scenario "non-admin cannot access dashboard" do
+    stub_repos_requests(token)
+    stub_admin_github_usernames("admin_user,other_admin_user")
+    non_admin = create(:user, github_username: "not_admin_user")
+
+    sign_in_as(non_admin, token)
+    visit admin_bulk_customers_path
+
+    expect(page).not_to have_admin_bulk_customers_header
+  end
+
+  def stub_admin_github_usernames(usernames)
+    allow(ENV).to receive(:fetch).
+      with("ADMIN_GITHUB_USERNAMES", "").
+      and_return(usernames)
+  end
+
+  def have_admin_bulk_customers_header
+    have_css("h1", text: "Bulk Customers")
+  end
+
+  def token
+    "usergithubtoken"
+  end
+end


### PR DESCRIPTION
- Admin handles can be set through an environment variable, `ADMIN_GITHUB_USERNAMES`.

See individual commit messages for more detailed descriptions of changes