### PR TITLE
Fix pricing link

### DIFF
--- a/app/views/application/_header.haml
+++ b/app/views/application/_header.haml
@@ -20,7 +20,7 @@
         = link_to "Sign Out", sign_out_path, class: "sign-out"
     - else
       %li
-        = link_to "Pricing", "#pricing", class: "pricing"
+        = link_to "Pricing", root_path(anchor: "pricing"), class: "pricing"
       %li
         = link_to "https://twitter.com/houndci", target: "_blank", class: "tweet-us" do
           %span @houndci


### PR DESCRIPTION
> Go to houndci.com, click on docs or FAQ link at the top, then click pricing link at the top. The #pricing gets added to the URL but that doesn't go anywhere unless you're on the initial houndci.com URL.