### PR TITLE
Change pricing description

### DIFF
--- a/app/views/home/index.haml
+++ b/app/views/home/index.haml
@@ -154,7 +154,7 @@
         .plan
           %h4
             %i.fa.fa-lock
-            Private Repos
+            Private Repo
           %span.tagline
             Keep your codebase clean:
           .price


### PR DESCRIPTION
Hopefully this makes pricing more clear. We've had questions about whether Hound subscription is for a single private repo or all private repos.

before:

<img width="947" alt="screenshot 2015-08-28 08 22 39" src="https://cloud.githubusercontent.com/assets/154463/9550096/3034df60-4d5e-11e5-9e07-819310a35543.png">

after:

<img width="915" alt="screenshot 2015-08-28 08 22 50" src="https://cloud.githubusercontent.com/assets/154463/9550097/3061ef1e-4d5e-11e5-82f0-db1d108e5b4c.png">
