### PR TITLE
Add Slack badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://circleci.com/gh/thoughtbot/hound/tree/master.svg?style=svg)](https://circleci.com/gh/thoughtbot/hound/tree/master)
 [![Code Climate](https://codeclimate.com/repos/526ab75ff3ea007df603b773/badges/32cb8e64b2e265d8cad6/gpa.svg)](https://codeclimate.com/repos/526ab75ff3ea007df603b773/feed)
+[![Slack](http://slack.houndci.com/badge.svg)](http://slack.houndci.com)
 
 This codebase is the Rails app for
 [Hound](http://houndci.com),


### PR DESCRIPTION
Adds readme badge that links to our Slack group and shows the
embarrassingly low user count.

![thoughtbot_hound_at_ct-slack-readme-badge](https://cloud.githubusercontent.com/assets/72176/9559250/4bb33af6-4da5-11e5-8464-33ed5a830867.png)
