### PR TITLE
Configure OmniAuth to use Rail's logger

### DIFF
--- a/config/initializers/omni_auth.rb
+++ b/config/initializers/omni_auth.rb
@@ -1,3 +1,5 @@
+OmniAuth.config.logger = Rails.logger
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   setup = ->(env) do
     options = GithubAuthOptions.new(env)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,4 @@
 Raven.configure do |config|
   config.environments = %w{production staging}
+  config.logger = Rails.logger
 end


### PR DESCRIPTION
The default is STDOUT, which is inconsistent with other logs and was
filling test output with irrelevant messages.