### PR TITLE
Save file reviews before queueing a review job

### DIFF
--- a/app/jobs/completed_file_review_job.rb
+++ b/app/jobs/completed_file_review_job.rb
@@ -13,7 +13,7 @@ class CompletedFileReviewJob
       pull_request_number: attributes.fetch("pull_request_number"),
       commit_sha: attributes.fetch("commit_sha")
     )
-    file_review = build.file_reviews.find_by(
+    file_review = build.file_reviews.find_by!(
       filename: attributes.fetch("filename")
     )
     commit_file = CommitFile.new(

--- a/app/models/style_checker.rb
+++ b/app/models/style_checker.rb
@@ -2,20 +2,21 @@
 # Builds style guide based on file extension.
 # Delegates to style guide for line violations.
 class StyleChecker
-  def initialize(pull_request)
+  def initialize(pull_request, build)
     @pull_request = pull_request
+    @build = build
     @style_guides = {}
   end
 
-  def file_reviews
-    commit_files_to_check.map do |commit_file|
+  def review_files
+    commit_files_to_check.each do |commit_file|
       style_guide(commit_file.filename).file_review(commit_file)
     end
   end
 
   private
 
-  attr_reader :pull_request, :style_guides
+  attr_reader :build, :pull_request, :style_guides
 
   def commit_files_to_check
     pull_request.commit_files.select do |file|
@@ -27,8 +28,9 @@ class StyleChecker
   def style_guide(filename)
     style_guide_class = style_guide_class(filename)
     style_guides[style_guide_class] ||= style_guide_class.new(
-      config,
-      pull_request.repository_owner_name
+      repo_config: config,
+      build: build,
+      repository_owner_name: pull_request.repository_owner_name,
     )
   end
 

--- a/app/models/style_guide/base.rb
+++ b/app/models/style_guide/base.rb
@@ -1,7 +1,12 @@
 module StyleGuide
   class Base
-    pattr_initialize :repo_config, :repository_owner_name
     attr_implement :file_review
+
+    def initialize(repo_config:, build:, repository_owner_name:)
+      @repo_config = repo_config
+      @build = build
+      @repository_owner_name = repository_owner_name
+    end
 
     def enabled?
       repo_config.enabled_for?(name)
@@ -14,6 +19,8 @@ module StyleGuide
     end
 
     private
+
+    attr_reader :repo_config, :build, :repository_owner_name
 
     def name
       self.class.name.demodulize.underscore

--- a/app/models/style_guide/coffee_script.rb
+++ b/app/models/style_guide/coffee_script.rb
@@ -5,7 +5,7 @@ module StyleGuide
     ERB_TAGS = /<%.*%>/
 
     def file_review(commit_file)
-      FileReview.new(filename: commit_file.filename) do |file_review|
+      FileReview.create!(filename: commit_file.filename) do |file_review|
         content = content_for_file(commit_file)
 
         lint(content).each do |violation|
@@ -13,6 +13,7 @@ module StyleGuide
           file_review.build_violation(line, violation["message"])
         end
 
+        file_review.build = build
         file_review.complete
       end
     end

--- a/app/models/style_guide/go.rb
+++ b/app/models/style_guide/go.rb
@@ -3,6 +3,11 @@ module StyleGuide
     LANGUAGE = "go"
 
     def file_review(commit_file)
+      file_review = FileReview.create!(
+        filename: commit_file.filename,
+        build: build,
+      )
+
       Resque.enqueue(
         GoReviewJob,
         filename: commit_file.filename,
@@ -13,7 +18,7 @@ module StyleGuide
         config: repo_config.raw_for(LANGUAGE),
       )
 
-      FileReview.new(filename: commit_file.filename)
+      file_review
     end
 
     def file_included?(commit_file)

--- a/app/models/style_guide/haml.rb
+++ b/app/models/style_guide/haml.rb
@@ -5,12 +5,14 @@ module StyleGuide
     def file_review(commit_file)
       @commit_file = commit_file
 
-      FileReview.new(filename: commit_file.filename) do |file_review|
+      FileReview.create!(filename: commit_file.filename) do |file_review|
         run_linters.map do |violation|
           line = commit_file.line_at(violation.line)
 
           file_review.build_violation(line, violation.message)
         end
+
+        file_review.build = build
         file_review.complete
       end
     end

--- a/app/models/style_guide/java_script.rb
+++ b/app/models/style_guide/java_script.rb
@@ -3,11 +3,13 @@ module StyleGuide
     DEFAULT_CONFIG_FILENAME = "javascript.json"
 
     def file_review(commit_file)
-      FileReview.new(filename: commit_file.filename) do |file_review|
+      FileReview.create!(filename: commit_file.filename) do |file_review|
         Jshintrb.lint(commit_file.content, config).compact.each do |violation|
           line = commit_file.line_at(violation["line"])
           file_review.build_violation(line, violation["reason"])
         end
+
+        file_review.build = build
         file_review.complete
       end
     end

--- a/app/models/style_guide/python.rb
+++ b/app/models/style_guide/python.rb
@@ -3,6 +3,11 @@ module StyleGuide
     LANGUAGE = "python"
 
     def file_review(commit_file)
+      file_review = FileReview.create!(
+        build: build,
+        filename: commit_file.filename,
+      )
+
       Resque.push(
         "python_review",
         {
@@ -18,7 +23,7 @@ module StyleGuide
         }
       )
 
-      FileReview.new(filename: commit_file.filename)
+      file_review
     end
 
     def file_included?(_)

--- a/app/models/style_guide/ruby.rb
+++ b/app/models/style_guide/ruby.rb
@@ -14,11 +14,13 @@ module StyleGuide
     private
 
     def perform_file_review(commit_file)
-      FileReview.new(filename: commit_file.filename) do |file_review|
+      FileReview.create!(filename: commit_file.filename) do |file_review|
         team.inspect_file(parsed_source(commit_file)).each do |violation|
           line = commit_file.line_at(violation.line)
           file_review.build_violation(line, violation.message)
         end
+
+        file_review.build = build
         file_review.complete
       end
     end

--- a/app/models/style_guide/scss.rb
+++ b/app/models/style_guide/scss.rb
@@ -3,6 +3,11 @@ module StyleGuide
     LANGUAGE = "scss"
 
     def file_review(commit_file)
+      file_review = FileReview.create!(
+        filename: commit_file.filename,
+        build: build,
+      )
+
       Resque.enqueue(
         ScssReviewJob,
         filename: commit_file.filename,
@@ -13,7 +18,7 @@ module StyleGuide
         config: repo_config.raw_for(LANGUAGE)
       )
 
-      FileReview.new(filename: commit_file.filename)
+      file_review
     end
 
     def file_included?(_)

--- a/app/models/style_guide/swift.rb
+++ b/app/models/style_guide/swift.rb
@@ -3,6 +3,11 @@ module StyleGuide
     LANGUAGE = "swift"
 
     def file_review(commit_file)
+      file_review = FileReview.create!(
+        filename: commit_file.filename,
+        build: build,
+      )
+
       Resque.enqueue(
         SwiftReviewJob,
         filename: commit_file.filename,
@@ -13,7 +18,7 @@ module StyleGuide
         config: repo_config.raw_for(LANGUAGE),
       )
 
-      FileReview.new(filename: commit_file.filename)
+      file_review
     end
 
     def file_included?(_)

--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -38,8 +38,8 @@ class BuildRunner
     pull_request.opened? || pull_request.synchronize?
   end
 
-  def style_checker
-    StyleChecker.new(pull_request)
+  def review_files(build)
+    StyleChecker.new(pull_request, build).review_files
   end
 
   def create_build
@@ -49,10 +49,6 @@ class BuildRunner
       payload: payload.build_data.to_json,
       user: current_user_with_token,
     )
-  end
-
-  def review_files(build)
-    build.update!(file_reviews: style_checker.file_reviews)
   end
 
   def pull_request

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe StyleChecker, "#file_reviews" do
+describe StyleChecker, "#review_files" do
   it "returns a collection of file reviews with violations" do
     stylish_commit_file = stub_commit_file("good.rb", "def good; end")
     violated_commit_file = stub_commit_file("bad.rb", "def bad( a ); a; end  ")
@@ -219,9 +219,10 @@ describe StyleChecker, "#file_reviews" do
   end
 
   def pull_request_violations(pull_request)
-    StyleChecker.new(pull_request).file_reviews.
-      flat_map(&:violations).
-      flat_map(&:messages)
+    build = build(:build)
+    StyleChecker.new(pull_request, build).review_files
+
+    build.violations.flat_map(&:messages)
   end
 
   def stub_pull_request(options = {})

--- a/spec/models/style_guide/go_spec.rb
+++ b/spec/models/style_guide/go_spec.rb
@@ -2,19 +2,20 @@ require "rails_helper"
 
 describe StyleGuide::Go do
   describe "#file_review" do
-    it "returns an incompleted file review" do
+    it "returns a saved and incomplete file review" do
       style_guide = build_style_guide
       commit_file = build_commit_file(filename: "a.go")
 
       result = style_guide.file_review(commit_file)
 
+      expect(result).to be_persisted
       expect(result).not_to be_completed
     end
 
     it "schedules a review job" do
-      allow(Resque).to receive(:enqueue)
       style_guide = build_style_guide("config")
       commit_file = build_commit_file(filename: "a.go")
+      allow(Resque).to receive(:enqueue)
 
       style_guide.file_review(commit_file)
 
@@ -71,7 +72,12 @@ describe StyleGuide::Go do
   private
 
   def build_style_guide(config = "config")
+    build = build(:build)
     repo_config = double("RepoConfig", raw_for: config)
-    StyleGuide::Go.new(repo_config, "ralph")
+    StyleGuide::Go.new(
+      repo_config: repo_config,
+      build: build,
+      repository_owner_name: "ralph",
+    )
   end
 end

--- a/spec/models/style_guide/haml_spec.rb
+++ b/spec/models/style_guide/haml_spec.rb
@@ -4,11 +4,14 @@ describe StyleGuide::Haml do
   let(:filename) { "app/views/show.html.haml" }
 
   describe "#file_review" do
-    it "returns complete file review" do
+    it "returns a saved and completed file review" do
       style_guide = build_style_guide({})
       file = build_file("")
 
-      expect(style_guide.file_review(file)).to be_completed
+      result = style_guide.file_review(file)
+
+      expect(result).to be_persisted
+      expect(result).to be_completed
     end
 
     context "with default configuration" do
@@ -95,8 +98,11 @@ describe StyleGuide::Haml do
 
   def build_style_guide(config)
     repo_config = double("RepoConfig", enabled_for?: true, for: config)
-    repository_owner_name = "ralph"
-    StyleGuide::Haml.new(repo_config, repository_owner_name)
+    StyleGuide::Haml.new(
+      repo_config: repo_config,
+      build: build(:build),
+      repository_owner_name: "ralph",
+    )
   end
 
   def build_file(content)

--- a/spec/models/style_guide/python_spec.rb
+++ b/spec/models/style_guide/python_spec.rb
@@ -2,12 +2,13 @@ require "rails_helper"
 
 describe StyleGuide::Python do
   describe "#file_review" do
-    it "returns an incompleted file review" do
+    it "returns a saved, incomplete file review" do
       style_guide = build_style_guide
       commit_file = build_commit_file
 
       result = style_guide.file_review(commit_file)
 
+      expect(result).to be_persisted
       expect(result).not_to be_completed
     end
 
@@ -47,7 +48,11 @@ describe StyleGuide::Python do
 
   def build_style_guide(config = "config")
     repo_config = double("RepoConfig", raw_for: config)
-    StyleGuide::Python.new(repo_config, "ralph")
+    StyleGuide::Python.new(
+      repo_config: repo_config,
+      build: build(:build),
+      repository_owner_name: "ralph",
+    )
   end
 
   def build_commit_file

--- a/spec/models/style_guide/scss_spec.rb
+++ b/spec/models/style_guide/scss_spec.rb
@@ -2,19 +2,20 @@ require "rails_helper"
 
 describe StyleGuide::Scss do
   describe "#file_review" do
-    it "returns an incompleted file review" do
+    it "returns a saved and incomplete file review" do
       style_guide = build_style_guide
       commit_file = build_commit_file(filename: "lib/a.scss")
 
       result = style_guide.file_review(commit_file)
 
+      expect(result).to be_persisted
       expect(result).not_to be_completed
     end
 
     it "schedules a review job" do
-      allow(Resque).to receive(:enqueue)
       style_guide = build_style_guide("config")
       commit_file = build_commit_file(filename: "lib/a.scss")
+      allow(Resque).to receive(:enqueue)
 
       style_guide.file_review(commit_file)
 
@@ -42,6 +43,11 @@ describe StyleGuide::Scss do
 
   def build_style_guide(config = "config")
     repo_config = double("RepoConfig", raw_for: config)
-    StyleGuide::Scss.new(repo_config, "ralph")
+    build = build(:build)
+    StyleGuide::Scss.new(
+      repo_config: repo_config,
+      build: build,
+      repository_owner_name: "ralph",
+    )
   end
 end

--- a/spec/models/style_guide/swift_spec.rb
+++ b/spec/models/style_guide/swift_spec.rb
@@ -2,12 +2,13 @@ require "rails_helper"
 
 describe StyleGuide::Swift do
   describe "#file_review" do
-    it "returns an incompleted file review" do
+    it "returns a saved, incomplete file review" do
       style_guide = build_style_guide
       commit_file = build_commit_file(filename: "a.swift")
 
       result = style_guide.file_review(commit_file)
 
+      expect(result).to be_persisted
       expect(result).not_to be_completed
     end
 
@@ -42,6 +43,10 @@ describe StyleGuide::Swift do
 
   def build_style_guide(config = "config")
     repo_config = double("RepoConfig", raw_for: config)
-    StyleGuide::Swift.new(repo_config, "ralph")
+    StyleGuide::Swift.new(
+      repo_config: repo_config,
+      build: build(:build),
+      repository_owner_name: "ralph",
+    )
   end
 end

--- a/spec/models/style_guide/test_spec.rb
+++ b/spec/models/style_guide/test_spec.rb
@@ -9,7 +9,11 @@ describe StyleGuide::Test do
   describe "#file_included?" do
     context "when #file_included? is not defined" do
       it "raises with a helpful message" do
-        style_guide = StyleGuide::Test.new(double, double)
+        style_guide = StyleGuide::Test.new(
+          repo_config: double,
+          build: double,
+          repository_owner_name: "foo",
+        )
 
         expect { style_guide.file_included?(double) }.to raise_error(
           "Implement #file_included? in your StyleGuide class"

--- a/spec/models/style_guide/unsupported_spec.rb
+++ b/spec/models/style_guide/unsupported_spec.rb
@@ -3,7 +3,11 @@ require "rails_helper"
 describe StyleGuide::Unsupported do
   describe "#file_review" do
     it "raises" do
-      style_guide = StyleGuide::Unsupported.new({}, nil)
+      style_guide = StyleGuide::Unsupported.new(
+        repo_config: double,
+        build: double,
+        repository_owner_name: "foo",
+      )
       commit_file = double("CommitFile", filename: "unsupported.f95")
 
       expect { style_guide.file_review(commit_file) }.to raise_error(
@@ -14,7 +18,11 @@ describe StyleGuide::Unsupported do
 
   describe "#file_included?" do
     it "return false" do
-      style_guide = StyleGuide::Unsupported.new({}, nil)
+      style_guide = StyleGuide::Unsupported.new(
+        repo_config: double,
+        build: double,
+        repository_owner_name: "foo",
+      )
 
       expect(style_guide.file_included?(double)).to eq false
     end


### PR DESCRIPTION
Why:

* SCSS worker is very fast and sometimes performs a review before the
  build and file reviews are saved.
  This will case the complete job to fail, since it won't find the
  file review.

Addresses: https://app.getsentry.com/hound-1/production/group/70334013