### PR TITLE
Extract duplicate file_review method into Base

### DIFF
--- a/app/models/style_guide/base.rb
+++ b/app/models/style_guide/base.rb
@@ -8,6 +8,18 @@ module StyleGuide
       @repository_owner_name = repository_owner_name
     end
 
+    def file_review(commit_file)
+      attributes = build_review_job_attributes(commit_file)
+      file_review = FileReview.create!(
+        build: build,
+        filename: commit_file.filename,
+      )
+
+      Resque.enqueue(job_class, attributes)
+
+      file_review
+    end
+
     def enabled?
       repo_config.enabled_for?(name)
     end
@@ -21,6 +33,25 @@ module StyleGuide
     private
 
     attr_reader :repo_config, :build, :repository_owner_name
+
+    def build_review_job_attributes(commit_file)
+      {
+        filename: commit_file.filename,
+        commit_sha: commit_file.sha,
+        pull_request_number: commit_file.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
+        config: repo_config.raw_for(language),
+      }
+    end
+
+    def job_class
+      "#{language.capitalize}ReviewJob".constantize
+    end
+
+    def language
+      self.class::LANGUAGE
+    end
 
     def name
       self.class.name.demodulize.underscore

--- a/app/models/style_guide/go.rb
+++ b/app/models/style_guide/go.rb
@@ -2,25 +2,6 @@ module StyleGuide
   class Go < Base
     LANGUAGE = "go"
 
-    def file_review(commit_file)
-      file_review = FileReview.create!(
-        filename: commit_file.filename,
-        build: build,
-      )
-
-      Resque.enqueue(
-        GoReviewJob,
-        filename: commit_file.filename,
-        commit_sha: commit_file.sha,
-        pull_request_number: commit_file.pull_request_number,
-        patch: commit_file.patch,
-        content: commit_file.content,
-        config: repo_config.raw_for(LANGUAGE),
-      )
-
-      file_review
-    end
-
     def file_included?(commit_file)
       !vendored?(commit_file.filename)
     end

--- a/app/models/style_guide/scss.rb
+++ b/app/models/style_guide/scss.rb
@@ -2,25 +2,6 @@ module StyleGuide
   class Scss < Base
     LANGUAGE = "scss"
 
-    def file_review(commit_file)
-      file_review = FileReview.create!(
-        filename: commit_file.filename,
-        build: build,
-      )
-
-      Resque.enqueue(
-        ScssReviewJob,
-        filename: commit_file.filename,
-        commit_sha: commit_file.sha,
-        pull_request_number: commit_file.pull_request_number,
-        patch: commit_file.patch,
-        content: commit_file.content,
-        config: repo_config.raw_for(LANGUAGE)
-      )
-
-      file_review
-    end
-
     def file_included?(_)
       true
     end

--- a/app/models/style_guide/swift.rb
+++ b/app/models/style_guide/swift.rb
@@ -2,25 +2,6 @@ module StyleGuide
   class Swift < Base
     LANGUAGE = "swift"
 
-    def file_review(commit_file)
-      file_review = FileReview.create!(
-        filename: commit_file.filename,
-        build: build,
-      )
-
-      Resque.enqueue(
-        SwiftReviewJob,
-        filename: commit_file.filename,
-        commit_sha: commit_file.sha,
-        pull_request_number: commit_file.pull_request_number,
-        patch: commit_file.patch,
-        content: commit_file.content,
-        config: repo_config.raw_for(LANGUAGE),
-      )
-
-      file_review
-    end
-
     def file_included?(_)
       true
     end


### PR DESCRIPTION
Why:

* All service-based style guides enqueue almost identical jobs.
* We can derive what is different from the class itself.
* Less code to add when we add more service-based linters.