### PR TITLE
Fetch file contents when file is being reviewed

### DIFF
--- a/app/jobs/completed_file_review_job.rb
+++ b/app/jobs/completed_file_review_job.rb
@@ -17,11 +17,9 @@ class CompletedFileReviewJob
       filename: attributes.fetch("filename")
     )
     commit_file = CommitFile.new(
-      filename: file_review.filename,
-      content: "",
       patch: attributes.fetch("patch"),
-      pull_request_number: attributes.fetch("pull_request_number"),
-      sha: build.commit_sha
+      filename: nil,
+      commit: nil,
     )
 
     attributes.fetch("violations").each do |violation|

--- a/app/models/commit_file.rb
+++ b/app/models/commit_file.rb
@@ -1,12 +1,14 @@
 class CommitFile
-  attr_reader :filename, :content, :patch, :pull_request_number, :sha
+  attr_reader :filename, :commit, :patch
 
-  def initialize(filename:, content:, patch:, pull_request_number:, sha:)
+  def initialize(filename:, commit:, patch:)
     @filename = filename
-    @content = content
+    @commit = commit
     @patch = patch
-    @pull_request_number = pull_request_number
-    @sha = sha
+  end
+
+  def content
+    commit.file_content(filename)
   end
 
   def line_at(line_number)

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -43,10 +43,8 @@ class PullRequest
     modified_github_files.map do |github_file|
       CommitFile.new(
         filename: github_file.filename,
-        content: head_commit.file_content(github_file.filename),
         patch: github_file.patch,
-        pull_request_number: number,
-        sha: head_commit.sha
+        commit: head_commit,
       )
     end
   end

--- a/app/models/style_guide/base.rb
+++ b/app/models/style_guide/base.rb
@@ -36,12 +36,12 @@ module StyleGuide
 
     def build_review_job_attributes(commit_file)
       {
-        filename: commit_file.filename,
-        commit_sha: commit_file.sha,
-        pull_request_number: commit_file.pull_request_number,
-        patch: commit_file.patch,
-        content: commit_file.content,
+        commit_sha: build.commit_sha,
         config: repo_config.raw_for(language),
+        content: commit_file.content,
+        filename: commit_file.filename,
+        patch: commit_file.patch,
+        pull_request_number: build.pull_request_number,
       }
     end
 

--- a/app/models/style_guide/python.rb
+++ b/app/models/style_guide/python.rb
@@ -14,8 +14,8 @@ module StyleGuide
           class: "review.PythonReviewJob",
           args: [
             commit_file.filename,
-            commit_file.sha,
-            commit_file.pull_request_number,
+            build.commit_sha,
+            build.pull_request_number,
             commit_file.patch,
             commit_file.content,
             repo_config.raw_for(LANGUAGE),

--- a/spec/models/commit_file_spec.rb
+++ b/spec/models/commit_file_spec.rb
@@ -46,25 +46,8 @@ describe CommitFile do
     end
   end
 
-  describe "#pull_request_number" do
-    it "returns pull request number" do
-      expect(commit_file.pull_request_number).to eq 123
-    end
-  end
-
-  describe "#sha" do
-    it "returns sha" do
-      expect(commit_file.sha).to eq "abc123"
-    end
-  end
-
   def commit_file(options = {})
-    CommitFile.new(
-      filename: "test.rb",
-      content: "content",
-      patch: "patch",
-      pull_request_number: 123,
-      sha: "abc123"
-    )
+    commit = double("Commit", file_content: "content")
+    CommitFile.new(filename: "test.rb", patch: "patch", commit: commit)
   end
 end

--- a/spec/models/style_guide/go_spec.rb
+++ b/spec/models/style_guide/go_spec.rb
@@ -13,7 +13,8 @@ describe StyleGuide::Go do
     end
 
     it "schedules a review job" do
-      style_guide = build_style_guide("config")
+      build = build(:build, commit_sha: "foo", pull_request_number: 123)
+      style_guide = build_style_guide("config", build)
       commit_file = build_commit_file(filename: "a.go")
       allow(Resque).to receive(:enqueue)
 
@@ -22,8 +23,8 @@ describe StyleGuide::Go do
       expect(Resque).to have_received(:enqueue).with(
         GoReviewJob,
         filename: commit_file.filename,
-        commit_sha: commit_file.sha,
-        pull_request_number: commit_file.pull_request_number,
+        commit_sha: build.commit_sha,
+        pull_request_number: build.pull_request_number,
         patch: commit_file.patch,
         content: commit_file.content,
         config: "config",
@@ -67,17 +68,5 @@ describe StyleGuide::Go do
         expect(style_guide.file_included?(commit_file)).to eq true
       end
     end
-  end
-
-  private
-
-  def build_style_guide(config = "config")
-    build = build(:build)
-    repo_config = double("RepoConfig", raw_for: config)
-    StyleGuide::Go.new(
-      repo_config: repo_config,
-      build: build,
-      repository_owner_name: "ralph",
-    )
   end
 end

--- a/spec/models/style_guide/python_spec.rb
+++ b/spec/models/style_guide/python_spec.rb
@@ -14,7 +14,8 @@ describe StyleGuide::Python do
 
     it "schedules a review job" do
       allow(Resque).to receive(:push)
-      style_guide = build_style_guide("config")
+      build = build(:build, commit_sha: "foo", pull_request_number: 123)
+      style_guide = build_style_guide("config", build)
       commit_file = build_commit_file
 
       style_guide.file_review(commit_file)
@@ -25,8 +26,8 @@ describe StyleGuide::Python do
           class: "review.PythonReviewJob",
           args: [
             commit_file.filename,
-            commit_file.sha,
-            commit_file.pull_request_number,
+            build.commit_sha,
+            build.pull_request_number,
             commit_file.patch,
             commit_file.content,
             "config",
@@ -44,17 +45,6 @@ describe StyleGuide::Python do
     end
   end
 
-  private
-
-  def build_style_guide(config = "config")
-    repo_config = double("RepoConfig", raw_for: config)
-    StyleGuide::Python.new(
-      repo_config: repo_config,
-      build: build(:build),
-      repository_owner_name: "ralph",
-    )
-  end
-
   def build_commit_file
     line = double(
       "Line",
@@ -68,9 +58,7 @@ describe StyleGuide::Python do
       content: "codes",
       filename: "lib/a.py",
       line_at: line,
-      sha: "abc123",
       patch: "patch",
-      pull_request_number: 123,
     )
   end
 end

--- a/spec/models/style_guide/scss_spec.rb
+++ b/spec/models/style_guide/scss_spec.rb
@@ -13,7 +13,8 @@ describe StyleGuide::Scss do
     end
 
     it "schedules a review job" do
-      style_guide = build_style_guide("config")
+      build = build(:build, commit_sha: "foo", pull_request_number: 123)
+      style_guide = build_style_guide("config", build)
       commit_file = build_commit_file(filename: "lib/a.scss")
       allow(Resque).to receive(:enqueue)
 
@@ -22,8 +23,8 @@ describe StyleGuide::Scss do
       expect(Resque).to have_received(:enqueue).with(
         ScssReviewJob,
         filename: commit_file.filename,
-        commit_sha: commit_file.sha,
-        pull_request_number: commit_file.pull_request_number,
+        commit_sha: build.commit_sha,
+        pull_request_number: build.pull_request_number,
         patch: commit_file.patch,
         content: commit_file.content,
         config: "config"
@@ -37,17 +38,5 @@ describe StyleGuide::Scss do
 
       expect(style_guide.file_included?(double)).to eq true
     end
-  end
-
-  private
-
-  def build_style_guide(config = "config")
-    repo_config = double("RepoConfig", raw_for: config)
-    build = build(:build)
-    StyleGuide::Scss.new(
-      repo_config: repo_config,
-      build: build,
-      repository_owner_name: "ralph",
-    )
   end
 end

--- a/spec/models/style_guide/swift_spec.rb
+++ b/spec/models/style_guide/swift_spec.rb
@@ -14,7 +14,8 @@ describe StyleGuide::Swift do
 
     it "schedules a review job" do
       allow(Resque).to receive(:enqueue)
-      style_guide = build_style_guide("config")
+      build = build(:build, commit_sha: "foo", pull_request_number: 123)
+      style_guide = build_style_guide("config", build)
       commit_file = build_commit_file(filename: "a.swift")
 
       style_guide.file_review(commit_file)
@@ -22,8 +23,8 @@ describe StyleGuide::Swift do
       expect(Resque).to have_received(:enqueue).with(
         SwiftReviewJob,
         filename: commit_file.filename,
-        commit_sha: commit_file.sha,
-        pull_request_number: commit_file.pull_request_number,
+        commit_sha: build.commit_sha,
+        pull_request_number: build.pull_request_number,
         patch: commit_file.patch,
         content: commit_file.content,
         config: "config",
@@ -37,16 +38,5 @@ describe StyleGuide::Swift do
 
       expect(style_guide.file_included?(double)).to eq true
     end
-  end
-
-  private
-
-  def build_style_guide(config = "config")
-    repo_config = double("RepoConfig", raw_for: config)
-    StyleGuide::Swift.new(
-      repo_config: repo_config,
-      build: build(:build),
-      repository_owner_name: "ralph",
-    )
   end
 end

--- a/spec/support/helpers/style_guide_helper.rb
+++ b/spec/support/helpers/style_guide_helper.rb
@@ -1,0 +1,14 @@
+module StyleGuideHelper
+  def build_style_guide(config = "config", build = build(:build))
+    repo_config = double("RepoConfig", raw_for: config)
+    described_class.new(
+      repo_config: repo_config,
+      build: build,
+      repository_owner_name: "ralph",
+    )
+  end
+end
+
+RSpec.configure do |config|
+  config.include StyleGuideHelper
+end


### PR DESCRIPTION
Why:

* We were fetching content for all changed files,
  even ones that we won't review because of their unsupported extension.
* Because of this we were wasting API requests on such files.
* There was an issue where a file was named `[:facebook]`
  and we tried to fetch its content.
  Because, by GitHub's design, file path is part of th URL,
  it was raising an error, because that is not a valid URL