### PR TITLE
Format style checker spec to conform to our guides

### DIFF
--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -1,120 +1,182 @@
 require "rails_helper"
 
-describe StyleChecker, "#review_files" do
-  it "returns a collection of file reviews with violations" do
-    stylish_commit_file = stub_commit_file("good.rb", "def good; end")
-    violated_commit_file = stub_commit_file("bad.rb", "def bad( a ); a; end  ")
-    pull_request = stub_pull_request(
-      commit_files: [stylish_commit_file, violated_commit_file]
-    )
-    expected_violations = [
-      "Unnecessary spacing detected.",
-      "Space inside parentheses detected.",
-      "Trailing whitespace detected.",
-    ]
-
-    violation_messages = pull_request_violations(pull_request)
-
-    expect(violation_messages).to eq expected_violations
-  end
-
-  it "only fetches content for supported files" do
-    ruby_file = double("GithubFile", filename: "ruby.rb", patch: "foo")
-    bogus_file = double("GithubFile", filename: "[:facebook]", patch: "bar")
-    head_commit = double("Commit", file_content: "foo bar")
-    pull_request = PullRequest.new(payload_stub, "anything")
-    allow(pull_request).to receive(:head_commit).and_return(head_commit)
-    allow(pull_request).to receive(:modified_github_files).
-      and_return([bogus_file, ruby_file])
-
-    pull_request_violations(pull_request)
-
-    expect(head_commit).to have_received(:file_content).with(ruby_file.filename)
-    expect(head_commit).not_to have_received(:file_content).
-      with(bogus_file.filename)
-  end
-
-  context "for a Ruby file" do
-    context "with style violations" do
-      it "returns violations" do
-        commit_file = stub_commit_file("ruby.rb", "puts 123    ")
-        pull_request = stub_pull_request(commit_files: [commit_file])
-        expected_violations = [
-          "Unnecessary spacing detected.",
-          "Trailing whitespace detected.",
-        ]
-
-        violation_messages = pull_request_violations(pull_request)
-
-        expect(violation_messages).to eq expected_violations
-      end
-    end
-
-    context "with style violation on unchanged line" do
-      it "returns no violations" do
-        commit_file = stub_commit_file(
-          "foo.rb",
-          "'wrong quotes'",
-          UnchangedLine.new
-        )
-        pull_request = stub_pull_request(commit_files: [commit_file])
-
-        violation_messages = pull_request_violations(pull_request)
-
-        expect(violation_messages).to be_empty
-      end
-    end
-
-    context "without style violations" do
-      it "returns no violations" do
-        commit_file = stub_commit_file("ruby.rb", "puts 123")
-        pull_request = stub_pull_request(commit_files: [commit_file])
-
-        violation_messages = pull_request_violations(pull_request)
-
-        expect(violation_messages).to be_empty
-      end
-    end
-  end
-
-  context "for a CoffeeScript file" do
-    it "is processed with a coffee.js extension" do
-      commit_file = stub_commit_file("test.coffee.js", "foo ->")
-      pull_request = stub_pull_request(commit_files: [commit_file])
-      allow(RepoConfig).to receive(:new).and_return(stub_repo_config)
-
-      violation_messages = pull_request_violations(pull_request)
-
-      expect(violation_messages).to eq ["Empty function"]
-    end
-
-    it "is processed with a coffee.erb extension" do
-      commit_file = stub_commit_file(
-        "test.coffee.erb",
-        "class strange_ClassNAME"
+describe StyleChecker do
+  describe "#review_files" do
+    it "returns a collection of file reviews with violations" do
+      stylish_commit_file = stub_commit_file("good.rb", "def good; end")
+      violated_commit_file = stub_commit_file("bad.rb", "def bad(a ); a; end  ")
+      pull_request = stub_pull_request(
+        commit_files: [stylish_commit_file, violated_commit_file],
       )
-      pull_request = stub_pull_request(commit_files: [commit_file])
-      allow(RepoConfig).to receive(:new).and_return(stub_repo_config)
+      expected_violations = [
+        "Unnecessary spacing detected.",
+        "Space inside parentheses detected.",
+        "Trailing whitespace detected.",
+      ]
 
       violation_messages = pull_request_violations(pull_request)
 
-      expect(violation_messages).to eq ["Class names should be camel cased"]
+      expect(violation_messages).to eq expected_violations
     end
 
-    context "with style violations" do
-      it "returns violations" do
-        commit_file = stub_commit_file("test.coffee", "foo: ->")
+    it "only fetches content for supported files" do
+      ruby_file = double("GithubFile", filename: "ruby.rb", patch: "foo")
+      bogus_file = double("GithubFile", filename: "[:facebook]", patch: "bar")
+      head_commit = double("Commit", file_content: "foo bar")
+      pull_request = PullRequest.new(payload_stub, "anything")
+      allow(pull_request).to receive(:head_commit).and_return(head_commit)
+      allow(pull_request).to receive(:modified_github_files).
+        and_return([bogus_file, ruby_file])
+
+      pull_request_violations(pull_request)
+
+      expect(head_commit).to have_received(:file_content).
+        with(ruby_file.filename)
+      expect(head_commit).not_to have_received(:file_content).
+        with(bogus_file.filename)
+    end
+
+    context "for a Ruby file" do
+      context "with style violations" do
+        it "returns violations" do
+          commit_file = stub_commit_file("ruby.rb", "puts 123    ")
+          pull_request = stub_pull_request(commit_files: [commit_file])
+          expected_violations = [
+            "Unnecessary spacing detected.",
+            "Trailing whitespace detected.",
+          ]
+
+          violation_messages = pull_request_violations(pull_request)
+
+          expect(violation_messages).to eq expected_violations
+        end
+      end
+
+      context "with style violation on unchanged line" do
+        it "returns no violations" do
+          commit_file = stub_commit_file(
+            "foo.rb",
+            "'wrong quotes'",
+            UnchangedLine.new,
+          )
+          pull_request = stub_pull_request(commit_files: [commit_file])
+
+          violation_messages = pull_request_violations(pull_request)
+
+          expect(violation_messages).to be_empty
+        end
+      end
+
+      context "without style violations" do
+        it "returns no violations" do
+          commit_file = stub_commit_file("ruby.rb", "puts 123")
+          pull_request = stub_pull_request(commit_files: [commit_file])
+
+          violation_messages = pull_request_violations(pull_request)
+
+          expect(violation_messages).to be_empty
+        end
+      end
+    end
+
+    context "for a CoffeeScript file" do
+      it "is processed with a coffee.js extension" do
+        commit_file = stub_commit_file("test.coffee.js", "foo ->")
         pull_request = stub_pull_request(commit_files: [commit_file])
+        allow(RepoConfig).to receive(:new).and_return(stub_repo_config)
 
         violation_messages = pull_request_violations(pull_request)
 
         expect(violation_messages).to eq ["Empty function"]
       end
+
+      it "is processed with a coffee.erb extension" do
+        commit_file = stub_commit_file(
+          "test.coffee.erb",
+          "class strange_ClassNAME",
+        )
+        pull_request = stub_pull_request(commit_files: [commit_file])
+        allow(RepoConfig).to receive(:new).and_return(stub_repo_config)
+
+        violation_messages = pull_request_violations(pull_request)
+
+        expect(violation_messages).to eq ["Class names should be camel cased"]
+      end
+
+      context "with style violations" do
+        it "returns violations" do
+          commit_file = stub_commit_file("test.coffee", "foo: ->")
+          pull_request = stub_pull_request(commit_files: [commit_file])
+
+          violation_messages = pull_request_violations(pull_request)
+
+          expect(violation_messages).to eq ["Empty function"]
+        end
+      end
+
+      context "without style violations" do
+        it "returns no violations" do
+          commit_file = stub_commit_file("test.coffee", "alert('Hello World')")
+          pull_request = stub_pull_request(commit_files: [commit_file])
+
+          violation_messages = pull_request_violations(pull_request)
+
+          expect(violation_messages).to be_empty
+        end
+      end
     end
 
-    context "without style violations" do
-      it "returns no violations" do
-        commit_file = stub_commit_file("test.coffee", "alert('Hello World')")
+    context "for a JavaScript file" do
+      context "with style violations" do
+        it "returns violations" do
+          commit_file = stub_commit_file("test.js", "var test = 'test'")
+          pull_request = stub_pull_request(commit_files: [commit_file])
+
+          violation_messages = pull_request_violations(pull_request)
+
+          expect(violation_messages).to include "Missing semicolon."
+        end
+      end
+
+      context "without style violations" do
+        it "returns no violations" do
+          commit_file = stub_commit_file("test.js", "var test = 'test';")
+          pull_request = stub_pull_request(commit_files: [commit_file])
+
+          violation_messages = pull_request_violations(pull_request)
+
+          expect(violation_messages).not_to include "Missing semicolon."
+        end
+      end
+
+      context "an excluded file" do
+        it "returns no violations" do
+          config = <<-YAML.strip_heredoc
+            javascript:
+              ignore_file: '.jshintignore'
+          YAML
+
+          head_commit = stub_head_commit(
+            ".hound.yml" => config,
+            ".jshintignore" => "test.js",
+          )
+
+          commit_file = stub_commit_file("test.js", "var test = 'test'")
+          pull_request = stub_pull_request(
+            head_commit: head_commit,
+            commit_files: [commit_file],
+          )
+
+          violation_messages = pull_request_violations(pull_request)
+
+          expect(violation_messages).to be_empty
+        end
+      end
+    end
+
+    context "for a SCSS file" do
+      it "does not immediately return violations" do
+        commit_file = stub_commit_file("test.scss", "* { color: red; }")
         pull_request = stub_pull_request(commit_files: [commit_file])
 
         violation_messages = pull_request_violations(pull_request)
@@ -122,82 +184,10 @@ describe StyleChecker, "#review_files" do
         expect(violation_messages).to be_empty
       end
     end
-  end
 
-  context "for a JavaScript file" do
-    context "with style violations" do
-      it "returns violations" do
-        commit_file = stub_commit_file("test.js", "var test = 'test'")
-        pull_request = stub_pull_request(commit_files: [commit_file])
-
-        violation_messages = pull_request_violations(pull_request)
-
-        expect(violation_messages).to include "Missing semicolon."
-      end
-    end
-
-    context "without style violations" do
-      it "returns no violations" do
-        commit_file = stub_commit_file("test.js", "var test = 'test';")
-        pull_request = stub_pull_request(commit_files: [commit_file])
-
-        violation_messages = pull_request_violations(pull_request)
-
-        expect(violation_messages).not_to include "Missing semicolon."
-      end
-    end
-
-    context "an excluded file" do
-      it "returns no violations" do
-        config = <<-YAML.strip_heredoc
-          javascript:
-            ignore_file: '.jshintignore'
-        YAML
-
-        head_commit = stub_head_commit(
-          ".hound.yml" => config,
-          ".jshintignore" => "test.js"
-        )
-
-        commit_file = stub_commit_file("test.js", "var test = 'test'")
-        pull_request = stub_pull_request(
-          head_commit: head_commit,
-          commit_files: [commit_file]
-        )
-
-        violation_messages = pull_request_violations(pull_request)
-
-        expect(violation_messages).to be_empty
-      end
-    end
-  end
-
-  context "for a SCSS file" do
-    it "does not immediately return violations" do
-      commit_file = stub_commit_file("test.scss", "* { color: red; }")
-      pull_request = stub_pull_request(commit_files: [commit_file])
-
-      violation_messages = pull_request_violations(pull_request)
-
-      expect(violation_messages).to be_empty
-    end
-  end
-
-  context "for a Python file" do
-    it "does not immediately return violations" do
-      commit_file = stub_commit_file("test.py", "import this")
-      pull_request = stub_pull_request(commit_files: [commit_file])
-
-      violation_messages = pull_request_violations(pull_request)
-
-      expect(violation_messages).to be_empty
-    end
-  end
-
-  context "for a Haml file" do
-    context "with style violations" do
-      it "returns no violations" do
-        commit_file = stub_commit_file("test.haml", "%div.message 123")
+    context "for a Python file" do
+      it "does not immediately return violations" do
+        commit_file = stub_commit_file("test.py", "import this")
         pull_request = stub_pull_request(commit_files: [commit_file])
 
         violation_messages = pull_request_violations(pull_request)
@@ -206,31 +196,44 @@ describe StyleChecker, "#review_files" do
       end
     end
 
-    context "without style violations" do
-      it "returns no violations" do
-        commit_file = stub_commit_file("test.haml", ".message 123")
+    context "for a Haml file" do
+      context "with style violations" do
+        it "returns no violations" do
+          commit_file = stub_commit_file("test.haml", "%div.message 123")
+          pull_request = stub_pull_request(commit_files: [commit_file])
+
+          violation_messages = pull_request_violations(pull_request)
+
+          expect(violation_messages).to be_empty
+        end
+      end
+
+      context "without style violations" do
+        it "returns no violations" do
+          commit_file = stub_commit_file("test.haml", ".foo 123")
+          pull_request = stub_pull_request(commit_files: [commit_file])
+
+          violation_messages = pull_request_violations(pull_request)
+
+          expect(violation_messages).not_to include(
+            "`%div.foo` can be written as `.foo` since `%div` is implicit",
+          )
+        end
+      end
+    end
+
+    context "with unsupported file type" do
+      it "uses unsupported style guide" do
+        commit_file = stub_commit_file(
+          "fortran.f",
+          %{PRINT *, "Hello World!"\nEND},
+        )
         pull_request = stub_pull_request(commit_files: [commit_file])
 
         violation_messages = pull_request_violations(pull_request)
 
-        expect(violation_messages).not_to include(
-          "`%div.message` can be written as `.message` since `%div` is implicit"
-        )
+        expect(violation_messages).to be_empty
       end
-    end
-  end
-
-  context "with unsupported file type" do
-    it "uses unsupported style guide" do
-      commit_file = stub_commit_file(
-        "fortran.f",
-        %{PRINT *, "Hello World!"\nEND}
-      )
-      pull_request = stub_pull_request(commit_files: [commit_file])
-
-      violation_messages = pull_request_violations(pull_request)
-
-      expect(violation_messages).to be_empty
     end
   end
 


### PR DESCRIPTION
Why:

* Because fitting such changes into PRs when we touch them generates
  a lot of noise, and thus doing them separately is an easier task.