### PR TITLE
Add support for Markdown service

### DIFF
--- a/app/jobs/markdown_review_job.rb
+++ b/app/jobs/markdown_review_job.rb
@@ -1,0 +1,3 @@
+class MarkdownReviewJob
+  @queue = :markdown_review
+end

--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -1,14 +1,31 @@
 # Load and parse config files from GitHub repo
 class RepoConfig
   HOUND_CONFIG = ".hound.yml"
-  BETA_LANGUAGES = %w(go haml python swift)
-  LANGUAGES = %w(ruby coffeescript javascript scss haml go python swift)
+  BETA_LANGUAGES = %w(
+    go
+    haml
+    markdown
+    python
+    swift
+  )
+  LANGUAGES = %w(
+    coffeescript
+    go
+    haml
+    javascript
+    markdown
+    python
+    ruby
+    scss
+    swift
+  )
   FILE_TYPES = {
-    "ruby" => "yaml",
-    "javascript" => "json",
     "coffeescript" => "json",
+    "haml" => "yaml",
+    "javascript" => "json",
+    "markdown" => "rb",
+    "ruby" => "yaml",
     "scss" => "yaml",
-    "haml" => "yaml"
   }
 
   pattr_initialize :commit

--- a/app/models/style_checker.rb
+++ b/app/models/style_checker.rb
@@ -52,6 +52,8 @@ class StyleChecker
       StyleGuide::Python
     when /.+\.swift\z/
       StyleGuide::Swift
+    when /.+(?:\.md|\.markdown)\z/
+      StyleGuide::Markdown
     else
       StyleGuide::Unsupported
     end

--- a/app/models/style_guide/markdown.rb
+++ b/app/models/style_guide/markdown.rb
@@ -1,0 +1,5 @@
+module StyleGuide
+  class Markdown < Base
+    LANGUAGE = "markdown"
+  end
+end

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -48,6 +48,8 @@ describe RepoConfig do
             enabled: true
           swift:
             enabled: true
+          markdown:
+            enabled: true
         EOS
         repo_config = RepoConfig.new(commit)
 
@@ -134,6 +136,8 @@ describe RepoConfig do
             Python:
               Enabled: true
             Swift:
+              Enabled: true
+            Markdown:
               Enabled: true
           EOS
           repo_config = RepoConfig.new(commit)
@@ -524,6 +528,20 @@ describe RepoConfig do
         expect(result).to eq raw_config
       end
     end
+
+    context "with Markdown config" do
+      it "returns parsed config" do
+        config_text = <<-EOS.strip_heredoc
+          rule 'MD030', :ol_multi => 2
+          rule 'MD036'
+        EOS
+        config = config_for_file(".mdl.rb", config_text)
+
+        result = config.raw_for("markdown")
+
+        expect(result).to eq("rule 'MD030', :ol_multi => 2\nrule 'MD036'\n")
+      end
+    end
   end
 
   describe "#fail_on_violations?" do
@@ -612,12 +630,12 @@ describe RepoConfig do
       haml:
         enabled: true
         config_file: #{file_path}
-    EOS
 
-    commit = stub_commit(
-      hound_config: hound_config,
-      "#{file_path}" => content
-    )
+      markdown:
+        enabled: true
+        config_file: #{file_path}
+    EOS
+    commit = stub_commit(hound_config: hound_config, "#{file_path}" => content)
 
     RepoConfig.new(commit)
   end

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -222,6 +222,17 @@ describe StyleChecker do
       end
     end
 
+    context "for a Markdown file" do
+      it "does not immediately return violations" do
+        commit_file = stub_commit_file("README.md", "#Hello world")
+        pull_request = stub_pull_request(commit_files: [commit_file])
+
+        violation_messages = pull_request_violations(pull_request)
+
+        expect(violation_messages).to be_empty
+      end
+    end
+
     context "with unsupported file type" do
       it "uses unsupported style guide" do
         commit_file = stub_commit_file(

--- a/spec/models/style_guide/markdown_spec.rb
+++ b/spec/models/style_guide/markdown_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe StyleGuide::Markdown do
+  describe "#file_review" do
+    it "returns a saved and incomplete file review" do
+      style_guide = build_style_guide
+      commit_file = build_commit_file(filename: "README.md")
+
+      result = style_guide.file_review(commit_file)
+
+      expect(result).to be_persisted
+      expect(result).not_to be_completed
+    end
+
+    it "schedules a review job" do
+      build = build(:build, commit_sha: "foo", pull_request_number: 123)
+      style_guide = build_style_guide("config", build)
+      commit_file = build_commit_file(filename: "doc/SECURITY.md")
+      allow(Resque).to receive(:enqueue)
+
+      style_guide.file_review(commit_file)
+
+      expect(Resque).to have_received(:enqueue).with(
+        MarkdownReviewJob,
+        filename: commit_file.filename,
+        commit_sha: build.commit_sha,
+        pull_request_number: build.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
+        config: "config",
+      )
+    end
+  end
+end


### PR DESCRIPTION
Why:

* Reviewing Markdown for style violations is neat.
* We should support well-know Markdown file extensions.

https://trello.com/c/mzlQMOCl