### PR TITLE
Remove unnecessary scss config in JavaScript config section

### DIFF
--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -144,8 +144,6 @@
           :preserve
             javascript:
               config_file: .javascript-style.json
-            scss:
-              enabled: false
 
       %p
         If you would like to ignore certain JavaScript files, simply copy the


### PR DESCRIPTION
This section is about JavaScript config, remove unnecessary scss config.

<img width="757" alt="screenshot_2015-09-19_01_56_13" src="https://cloud.githubusercontent.com/assets/1000669/9966873/c949a810-5e71-11e5-90e8-f5e16889b44b.png">

See: https://houndci.com/configuration#javascript