### PR TITLE
Standardize Python service attributes

### DIFF
--- a/app/models/style_guide/base.rb
+++ b/app/models/style_guide/base.rb
@@ -13,7 +13,7 @@ module StyleGuide
         filename: commit_file.filename,
       )
 
-      Resque.enqueue(job_class, attributes)
+      enqueue_job(attributes)
 
       file_review
     end
@@ -43,6 +43,10 @@ module StyleGuide
 
     def job_class
       "#{language.capitalize}ReviewJob".constantize
+    end
+
+    def enqueue_job(attributes)
+      Resque.enqueue(job_class, attributes)
     end
 
     def language

--- a/app/models/style_guide/python.rb
+++ b/app/models/style_guide/python.rb
@@ -2,28 +2,16 @@ module StyleGuide
   class Python < Base
     LANGUAGE = "python"
 
-    def file_review(commit_file)
-      file_review = FileReview.create!(
-        build: build,
-        filename: commit_file.filename,
-      )
+    private
 
+    def enqueue_job(attributes)
       Resque.push(
         "python_review",
         {
           class: "review.PythonReviewJob",
-          args: [
-            commit_file.filename,
-            build.commit_sha,
-            build.pull_request_number,
-            commit_file.patch,
-            commit_file.content,
-            repo_config.raw_for(LANGUAGE),
-          ],
+          args: [attributes],
         }
       )
-
-      file_review
     end
   end
 end

--- a/spec/models/style_guide/python_spec.rb
+++ b/spec/models/style_guide/python_spec.rb
@@ -25,12 +25,12 @@ describe StyleGuide::Python do
         {
           class: "review.PythonReviewJob",
           args: [
-            commit_file.filename,
-            build.commit_sha,
-            build.pull_request_number,
-            commit_file.patch,
-            commit_file.content,
-            "config",
+            filename: commit_file.filename,
+            commit_sha: build.commit_sha,
+            pull_request_number: build.pull_request_number,
+            patch: commit_file.patch,
+            content: commit_file.content,
+            config: "config",
           ],
         }
       )


### PR DESCRIPTION
* Updates the Python service to be serialized with a hash argument, rather
  than an array.
* Adds a `StyleGuide::Base#enqueue_job` private method that handles the
  Resqueue details. The Python linter overrides this because it has a
  non-standard class name, `review.PythonReviewJob`. As far as I can
  tell, this name is required because the Python Resuque library, Pyres,
  uses the python import system, which needs a module name. I'd love to
  hear more about this from anyone with more knowledge.