### PR TITLE
Use correct glob for SCSS exclude example

### DIFF
--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -198,7 +198,7 @@
           :preserve
             scss:
               exclude:
-                - "app/assets/stylesheets/plugins/**"
+                - "**/app/assets/stylesheets/plugins/**"
 
       %p
         Add the following code to your


### PR DESCRIPTION
SCSS-Lint compares the `exclude` entries to the fully expanded path, so
it is expecting a glob that matches the whole thing.

https://github.com/thoughtbot/hound/issues/879