### PR TITLE
Add configuration page docs for Swift

### DIFF
--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -27,6 +27,10 @@ module ConfigurationHelper
     "https://raw.githubusercontent.com/thoughtbot/hound/master/config/style_guides/haml.yml"
   end
 
+  def swift_config_url
+    config_url("thoughtbot/hound-swift", "config/default.yml")
+  end
+
   private
 
   def config_url(slug, config_file)

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -21,6 +21,8 @@
         = link_to "Go config", "#go"
       %li
         = link_to "Python config", "#python"
+      %li
+        = link_to "Swift config", "#swift"
 
   %section.doc-content
     %article
@@ -353,6 +355,47 @@
             python:
               enabled: true
               config_file: .flake8.ini
+
+    %article#swift
+      %h3 Swift (beta)
+
+      %p
+        Add the following code to your
+        %em.code .hound.yml
+        to enable Swift style checking.
+
+        %code.code-block
+          :preserve
+            swift:
+              enabled: true
+      %p
+        Hound uses
+        = link_to "SwiftLint",
+          "https://github.com/realm/SwiftLint",
+          target: :blank
+        with this
+        = link_to "config", swift_config_url, target: :blank
+
+      %p
+        If you need to change the way Hound is configured, simply copy the
+        #{link_to "default config", swift_config_url, target: :blank}.
+        into your project, make changes and reference the file in your
+        %em.code .hound.yml
+
+      %p
+        %code.code-block
+          :preserve
+            swift:
+              enabled: true
+              config_file: .swiftlint.yml
+
+      %p
+        For more information on the available configuration in your
+        %em.code config_file
+        , you can read about it on the
+        = link_to "SwiftLint Configuration Documentation",
+          "https://github.com/realm/SwiftLint#configuration",
+          target: :blank
 
     %article
       %h3 Didn't find what you where looking for?


### PR DESCRIPTION
This can remain open while it's in beta
but I figured I'd open a PR now
since I have the time.

Why:

* Users would like to know how to add Swift to their projects.

This change addresses the need by:

* Adding the Swift section to the configuration page.

![screen shot 2015-09-25 at 2 40 18 pm](https://cloud.githubusercontent.com/assets/3799709/10112831/6699ded4-6393-11e5-9764-f913849269f7.png)
