### PR TITLE
Document failing on violations

### DIFF
--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -41,7 +41,7 @@
         With a
         %em.code .hound.yml
         file you can tell Hound which languages not to review
-        (all supported languages are reviewed by default)
+        (all supported, non-beta languages are reviewed by default)
         and specify paths to custom style rules and an ignore file
         for JavaScript.
 

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -66,6 +66,20 @@
         pointing Hound to a custom config file for Ruby style checking and
         an ignore file for JavaScript.
 
+      %p
+        Hound can be configured to use
+        = link_to "GitHub's Status API",
+          "https://github.com/blog/1935-see-results-from-all-pull-request-status-checks",
+          target: :blank
+        to mark a pull request as failed if any violations are found. To do so,
+        add the following to your
+        %em.code .hound.yml
+        file:
+
+      %code.code-block
+        :preserve
+          fail_on_violations: true
+
     %article#ruby
       %h3 Ruby
       %p


### PR DESCRIPTION
This feature has been in production for awhile and is working well.
Documenting it will allow users to know of its existence, without having
to ask us.

Closes #943 

![configuration___hound](https://cloud.githubusercontent.com/assets/72176/10114626/fc409b52-63a8-11e5-8f4e-a9da4e38644f.png)
