### PR TITLE
Use RuboCop defaults for most cops

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -1,109 +1,8 @@
 AllCops:
-  Include:
-  - "**/*.gemspec"
-  - "**/*.podspec"
-  - "**/*.jbuilder"
-  - "**/*.rake"
-  - "**/*.opal"
-  - "**/Gemfile"
-  - "**/Rakefile"
-  - "**/Capfile"
-  - "**/Guardfile"
-  - "**/Podfile"
-  - "**/Thorfile"
-  - "**/Vagrantfile"
-  - "**/Berksfile"
-  - "**/Cheffile"
-  - "**/Vagabondfile"
   Exclude:
-  - "vendor/**/*"
-  - "db/schema.rb"
-  RunRailsCops: false
-  DisplayCopNames: false
-  DisplayStyleGuide: false
-  StyleGuideCopsOnly: false
-  DisabledByDefault: false
+    - "vendor/**/*"
+    - "db/schema.rb"
   UseCache: false
-  MaxFilesInCache: 20000
-  CacheRootDirectory: "/tmp"
-Style/AccessModifierIndentation:
-  Description: Check indentation of private/protected visibility modifiers.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected
-  Enabled: true
-  EnforcedStyle: indent
-  SupportedStyles:
-  - outdent
-  - indent
-Style/AlignHash:
-  Description: Align the elements of a hash literal if they span more than one line.
-  Enabled: true
-  EnforcedHashRocketStyle: key
-  EnforcedColonStyle: key
-  EnforcedLastArgumentHashStyle: always_inspect
-  SupportedLastArgumentHashStyles:
-  - always_inspect
-  - always_ignore
-  - ignore_implicit
-  - ignore_explicit
-Style/AlignParameters:
-  Description: Align the parameters of a method call if they span more than one line.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-double-indent
-  Enabled: true
-  EnforcedStyle: with_first_parameter
-  SupportedStyles:
-  - with_first_parameter
-  - with_fixed_indentation
-Style/AndOr:
-  Description: Use &&/|| instead of and/or.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-and-or-or
-  Enabled: true
-  EnforcedStyle: always
-  SupportedStyles:
-  - always
-  - conditionals
-Style/AutoResourceCleanup:
-  Description: Suggests the usage of an auto resource cleanup version of a method
-    (if available).
-  Enabled: false
-Style/BarePercentLiterals:
-  Description: Checks if usage of %() or %Q() matches configuration.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-q-shorthand
-  Enabled: true
-  EnforcedStyle: bare_percent
-  SupportedStyles:
-  - percent_q
-  - bare_percent
-Style/BracesAroundHashParameters:
-  Description: Enforce braces style around hash parameters.
-  Enabled: true
-  EnforcedStyle: no_braces
-  SupportedStyles:
-  - braces
-  - no_braces
-  - context_dependent
-Style/CaseIndentation:
-  Description: Indentation of when in a case/when/[else/]end.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-when-to-case
-  Enabled: true
-  IndentWhenRelativeTo: case
-  SupportedStyles:
-  - case
-  - end
-  IndentOneStep: false
-Style/ClassAndModuleChildren:
-  Description: Checks style of children classes and modules.
-  Enabled: false
-  EnforcedStyle: nested
-  SupportedStyles:
-  - nested
-  - compact
-Style/ClassCheck:
-  Description: Enforces consistent use of `Object#is_a?` or `Object#kind_of?`.
-  Enabled: true
-  EnforcedStyle: is_a?
-  SupportedStyles:
-  - is_a?
-  - kind_of?
 Style/CollectionMethods:
   Description: Preferred collection methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size
@@ -114,20 +13,6 @@ Style/CollectionMethods:
     find: detect
     find_all: select
     reduce: inject
-Style/CommentAnnotation:
-  Description: Checks formatting of special comments (TODO, FIXME, OPTIMIZE, HACK,
-    REVIEW).
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#annotate-keywords
-  Enabled: false
-  Keywords:
-  - TODO
-  - FIXME
-  - OPTIMIZE
-  - HACK
-  - REVIEW
-Style/Copyright:
-  Description: Include a copyright notice in each file before any code.
-  Enabled: false
 Style/DotPosition:
   Description: Checks the position of the dot in multi-line method calls.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
@@ -136,164 +21,24 @@ Style/DotPosition:
   SupportedStyles:
   - leading
   - trailing
-Style/EmptyLineBetweenDefs:
-  Description: Use empty lines between defs.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods
-  Enabled: true
-  AllowAdjacentOneLineDefs: false
-Style/EmptyLinesAroundBlockBody:
-  Description: Keeps track of empty lines around block bodies.
-  Enabled: true
-  EnforcedStyle: no_empty_lines
-  SupportedStyles:
-  - empty_lines
-  - no_empty_lines
-Style/EmptyLinesAroundClassBody:
-  Description: Keeps track of empty lines around class bodies.
-  Enabled: true
-  EnforcedStyle: no_empty_lines
-  SupportedStyles:
-  - empty_lines
-  - no_empty_lines
-Style/EmptyLinesAroundModuleBody:
-  Description: Keeps track of empty lines around module bodies.
-  Enabled: true
-  EnforcedStyle: no_empty_lines
-  SupportedStyles:
-  - empty_lines
-  - no_empty_lines
-Style/Encoding:
-  Description: Use UTF-8 as the source file encoding.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#utf-8
-  Enabled: false
-  EnforcedStyle: always
-  SupportedStyles:
-  - when_needed
-  - always
 Style/FileName:
   Description: Use snake_case for source file names.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
   Enabled: false
   Exclude: []
-Style/FirstParameterIndentation:
-  Description: Checks the indentation of the first parameter in a method call.
-  Enabled: true
-  EnforcedStyle: special_for_inner_method_call_in_parentheses
-  SupportedStyles:
-  - consistent
-  - special_for_inner_method_call
-  - special_for_inner_method_call_in_parentheses
-Style/For:
-  Description: Checks use of for or each in multiline loops.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-for-loops
-  Enabled: true
-  EnforcedStyle: each
-  SupportedStyles:
-  - for
-  - each
-Style/FormatString:
-  Description: Enforce the use of Kernel#sprintf, Kernel#format or String#%.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#sprintf
-  Enabled: false
-  EnforcedStyle: format
-  SupportedStyles:
-  - format
-  - sprintf
-  - percent
-Style/GlobalVars:
-  Description: Do not introduce global variables.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#instance-vars
-  Enabled: false
-  AllowedVariables: []
 Style/GuardClause:
   Description: Check for conditionals that can be replaced with guard clauses
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
   Enabled: false
   MinBodyLength: 1
-Style/HashSyntax:
-  Description: 'Prefer Ruby 1.9 hash syntax { a: 1, b: 2 } over 1.8 syntax { :a =>
-    1, :b => 2 }.'
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-literals
-  Enabled: true
-  EnforcedStyle: ruby19
-  SupportedStyles:
-  - ruby19
-  - hash_rockets
 Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
   Enabled: false
   MaxLineLength: 80
-Style/IndentationWidth:
-  Description: Use 2 spaces for indentation.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
-  Enabled: true
-  Width: 2
-Style/IndentHash:
-  Description: Checks the indentation of the first key in a hash literal.
-  Enabled: true
-  EnforcedStyle: special_inside_parentheses
-  SupportedStyles:
-  - special_inside_parentheses
-  - consistent
-Style/LambdaCall:
-  Description: Use lambda.call(...) instead of lambda.(...).
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#proc-call
-  Enabled: false
-  EnforcedStyle: call
-  SupportedStyles:
-  - call
-  - braces
-Style/Next:
-  Description: Use `next` to skip iteration instead of a condition at the end.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
-  Enabled: false
-  EnforcedStyle: skip_modifier_ifs
-  MinBodyLength: 3
-  SupportedStyles:
-  - skip_modifier_ifs
-  - always
-Style/NonNilCheck:
-  Description: Checks for redundant nil checks.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-non-nil-checks
-  Enabled: true
-  IncludeSemanticChanges: false
-Style/MethodDefParentheses:
-  Description: Checks if the method definitions have or don't have parentheses.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#method-parens
-  Enabled: true
-  EnforcedStyle: require_parentheses
-  SupportedStyles:
-  - require_parentheses
-  - require_no_parentheses
-Style/MethodName:
-  Description: Use the configured style when naming methods.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars
-  Enabled: true
-  EnforcedStyle: snake_case
-  SupportedStyles:
-  - snake_case
-  - camelCase
-Style/MultilineOperationIndentation:
-  Description: Checks indentation of binary operations that span more than one line.
-  Enabled: true
-  EnforcedStyle: aligned
-  SupportedStyles:
-  - aligned
-  - indented
-Style/NumericLiterals:
-  Description: Add underscores to large numeric literals to improve their readability.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics
-  Enabled: false
-  MinDigits: 5
 Style/OptionHash:
   Description: Don't use option hashes when you can use keyword arguments.
   Enabled: false
-Style/ParenthesesAroundCondition:
-  Description: Don't use parentheses around the condition of an if/unless/while.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-parens-if
-  Enabled: true
-  AllowSafeAssignment: true
 Style/PercentLiteralDelimiters:
   Description: Use `%`-literal delimiters consistently
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-literal-braces
@@ -308,13 +53,6 @@ Style/PercentLiteralDelimiters:
     "%w": "()"
     "%W": "()"
     "%x": "()"
-Style/PercentQLiterals:
-  Description: Checks if uses of %Q/%q match the configured preference.
-  Enabled: true
-  EnforcedStyle: lower_case_q
-  SupportedStyles:
-  - lower_case_q
-  - upper_case_q
 Style/PredicateName:
   Description: Check the names of predicate methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark
@@ -335,22 +73,6 @@ Style/RaiseArgs:
   SupportedStyles:
   - compact
   - exploded
-Style/RedundantReturn:
-  Description: Don't use return where it's not required.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-explicit-return
-  Enabled: true
-  AllowMultipleReturnValues: false
-Style/RegexpLiteral:
-  Description: Use %r for regular expressions matching more than `MaxSlashes` '/'
-    characters. Use %r only for regular expressions matching more than `MaxSlashes`
-    '/' character.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-r
-  Enabled: false
-Style/Semicolon:
-  Description: Don't use semicolons to terminate expressions.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-semicolon
-  Enabled: true
-  AllowAsExpressionSeparator: false
 Style/SignalException:
   Description: Checks for proper usage of fail and raise.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#fail-method
@@ -392,73 +114,6 @@ Style/StringLiteralsInInterpolation:
   SupportedStyles:
   - single_quotes
   - double_quotes
-Style/StringMethods:
-  Description: Checks if configured preferred methods are used over non-preferred.
-  Enabled: false
-Style/SpaceAroundBlockParameters:
-  Description: Checks the spacing inside and after block parameters pipes.
-  Enabled: true
-  EnforcedStyleInsidePipes: no_space
-  SupportedStyles:
-  - space
-  - no_space
-Style/SpaceAroundEqualsInParameterDefault:
-  Description: Checks that the equals signs in parameter default assignments have
-    or don't have surrounding space depending on configuration.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-around-equals
-  Enabled: true
-  EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
-Style/SpaceBeforeBlockBraces:
-  Description: Checks that the left block brace has or doesn't have space before it.
-  Enabled: true
-  EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
-Style/SpaceInsideBlockBraces:
-  Description: Checks that block braces have or don't have surrounding space. For
-    blocks taking parameters, checks that the left brace has or doesn't have trailing
-    space.
-  Enabled: true
-  EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
-  EnforcedStyleForEmptyBraces: no_space
-  SpaceBeforeBlockParameters: true
-Style/SpaceInsideHashLiteralBraces:
-  Description: Use spaces inside hash literal braces - or don't.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-  EnforcedStyle: space
-  EnforcedStyleForEmptyBraces: no_space
-  SupportedStyles:
-  - space
-  - no_space
-Style/SpaceInsideStringInterpolation:
-  EnforcedStyle: no_space
-  SupportedStyles:
-  - space
-  - no_space
-  Description: Checks for padding/surrounding spaces inside string interpolation.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#string-interpolation
-  Enabled: true
-Style/SymbolProc:
-  Description: Use symbols as procs instead of blocks when possible.
-  Enabled: true
-  IgnoredMethods:
-  - respond_to
-Style/TrailingBlankLines:
-  Description: Checks trailing blank lines and final newline.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#newline-eof
-  Enabled: true
-  EnforcedStyle: final_newline
-  SupportedStyles:
-  - final_newline
-  - final_blank_line
 Style/TrailingComma:
   Description: Checks for trailing comma in parameter lists and literals.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
@@ -467,60 +122,11 @@ Style/TrailingComma:
   SupportedStyles:
   - comma
   - no_comma
-Style/TrivialAccessors:
-  Description: Prefer attr_* methods to trivial readers/writers.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#attr_family
-  Enabled: false
-  ExactNameMatch: false
-  AllowPredicates: false
-  AllowDSLWriters: false
-  Whitelist:
-  - to_ary
-  - to_a
-  - to_c
-  - to_enum
-  - to_h
-  - to_hash
-  - to_i
-  - to_int
-  - to_io
-  - to_open
-  - to_path
-  - to_proc
-  - to_r
-  - to_regexp
-  - to_str
-  - to_s
-  - to_sym
-Style/VariableName:
-  Description: Use the configured style when naming variables.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars
-  Enabled: true
-  EnforcedStyle: snake_case
-  SupportedStyles:
-  - snake_case
-  - camelCase
-Style/WhileUntilModifier:
-  Description: Favor modifier while/until usage when you have a single-line body.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier
-  Enabled: false
-  MaxLineLength: 80
-Style/WordArray:
-  Description: Use %w or %W for arrays of words.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-w
-  Enabled: false
-  MinSize: 0
-  WordRegex: !ruby/regexp /\A[\p{Word}]+\z/
 Metrics/AbcSize:
   Description: A calculated magnitude based on number of assignments, branches, and
     conditions.
-  Enabled: true
-  Max: 15
-Metrics/BlockNesting:
-  Description: Avoid excessive block nesting
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count
   Enabled: false
-  Max: 3
+  Max: 15
 Metrics/ClassLength:
   Description: Avoid classes longer than 100 lines of code.
   Enabled: false
@@ -530,21 +136,12 @@ Metrics/ModuleLength:
   CountComments: false
   Max: 100
   Description: Avoid modules longer than 100 lines of code.
-  Enabled: true
+  Enabled: false
 Metrics/CyclomaticComplexity:
   Description: A complexity metric that is strongly correlated to the number of test
     cases needed to validate a method.
   Enabled: false
   Max: 6
-Metrics/LineLength:
-  Description: Limit lines to 80 characters.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#80-character-limits
-  Enabled: true
-  Max: 80
-  AllowURI: true
-  URISchemes:
-  - http
-  - https
 Metrics/MethodLength:
   Description: Avoid methods longer than 10 lines of code.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
@@ -567,224 +164,15 @@ Lint/AssignmentInCondition:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition
   Enabled: false
   AllowSafeAssignment: true
-Lint/EndAlignment:
-  Description: Align ends correctly.
-  Enabled: true
-  AlignWith: keyword
-  SupportedStyles:
-  - keyword
-  - variable
-Lint/DefEndAlignment:
-  Description: Align ends corresponding to defs correctly.
-  Enabled: true
-  AlignWith: start_of_line
-  SupportedStyles:
-  - start_of_line
-  - def
-Rails/ActionFilter:
-  Description: Enforces consistent use of action filter methods.
-  Enabled: false
-  EnforcedStyle: action
-  SupportedStyles:
-  - action
-  - filter
-  Include:
-  - app/controllers/**/*.rb
-Rails/Date:
-  EnforcedStyle: flexible
-  SupportedStyles:
-  - strict
-  - flexible
-  Description: Checks the correct usage of date aware methods, such as Date.today,
-    Date.current etc.
-  Enabled: true
-Rails/DefaultScope:
-  Description: Checks if the argument passed to default_scope is a block.
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
-Rails/FindBy:
-  Include:
-  - app/models/**/*.rb
-  Description: Prefer find_by over where.first.
-  Enabled: true
-Rails/FindEach:
-  Include:
-  - app/models/**/*.rb
-  Description: Prefer all.find_each over all.find.
-  Enabled: true
-Rails/HasAndBelongsToMany:
-  Description: Prefer has_many :through to has_and_belongs_to_many.
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
-Rails/Output:
-  Description: Checks for calls to puts, print, etc.
-  Enabled: true
-  Include:
-  - app/**/*.rb
-  - config/**/*.rb
-  - db/**/*.rb
-  - lib/**/*.rb
-Rails/ReadWriteAttribute:
-  Description: Checks for read_attribute(:attr) and write_attribute(:attr, val).
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
-Rails/ScopeArgs:
-  Description: Checks the arguments of ActiveRecord scopes.
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
-Rails/TimeZone:
-  EnforcedStyle: flexible
-  SupportedStyles:
-  - strict
-  - flexible
-  Description: Checks the correct usage of time zone aware methods.
-  StyleGuide: https://github.com/bbatsov/rails-style-guide#time
-  Reference: http://danilenko.org/2012/7/6/rails_timezones
-  Enabled: true
-Rails/Validation:
-  Description: Use validates :attribute, hash of validations.
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
 Style/InlineComment:
   Description: Avoid inline comments.
   Enabled: false
-Style/MethodCalledOnDoEndBlock:
-  Description: Avoid chaining a method call on a do...end block.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#single-line-blocks
-  Enabled: false
-Style/MissingElse:
-  Description: Require if/case expressions to have an else branches. If enabled, it
-    is recommended that Style/UnlessElse and Style/EmptyElse be enabled. This will
-    conflict with Style/EmptyElse if Style/EmptyElse is configured to style "both"
-  Enabled: false
-  EnforcedStyle: both
-  SupportedStyles:
-  - if
-  - case
-  - both
-Style/MutableConstant:
-  Description: Do not assign mutable objects to constants.
-  Enabled: false
-Style/SymbolArray:
-  Description: Use %i or %I for arrays of symbols.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-i
-  Enabled: false
-Style/ExtraSpacing:
-  Description: Do not use unnecessary spacing.
-  Enabled: true
 Style/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   Enabled: false
 Style/Alias:
   Description: Use alias_method instead of alias.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#alias-method
-  Enabled: false
-Style/AlignArray:
-  Description: Align the elements of an array literal if they span more than one line.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays
-  Enabled: true
-Style/ArrayJoin:
-  Description: Use Array#join instead of Array#*.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#array-join
-  Enabled: false
-Style/AsciiComments:
-  Description: Use only ascii symbols in comments.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#english-comments
-  Enabled: false
-Style/AsciiIdentifiers:
-  Description: Use only ascii symbols in identifiers.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#english-identifiers
-  Enabled: false
-Style/Attr:
-  Description: Checks for uses of Module#attr.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#attr
-  Enabled: false
-Style/BeginBlock:
-  Description: Avoid the use of BEGIN blocks.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-BEGIN-blocks
-  Enabled: true
-Style/BlockComments:
-  Description: Do not use block comments.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-block-comments
-  Enabled: true
-Style/BlockEndNewline:
-  Description: Put end statement of multiline block on its own line.
-  Enabled: true
-Style/BlockDelimiters:
-  EnforcedStyle: line_count_based
-  SupportedStyles:
-  - line_count_based
-  - semantic
-  ProceduralMethods:
-  - benchmark
-  - bm
-  - bmbm
-  - create
-  - each_with_object
-  - measure
-  - new
-  - realtime
-  - tap
-  - with_object
-  FunctionalMethods:
-  - let
-  - let!
-  - subject
-  - watch
-  IgnoredMethods:
-  - lambda
-  - proc
-  - it
-  Description: Avoid using {...} for multi-line blocks (multiline chaining is always
-    ugly). Prefer {...} over do...end for single-line blocks.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#single-line-blocks
-  Enabled: true
-Style/CaseEquality:
-  Description: Avoid explicit use of the case equality operator(===).
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-case-equality
-  Enabled: false
-Style/CharacterLiteral:
-  Description: Checks for uses of character literals.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-character-literals
-  Enabled: false
-Style/ClassAndModuleCamelCase:
-  Description: Use CamelCase for classes and modules.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#camelcase-classes
-  Enabled: true
-Style/ClassMethods:
-  Description: Use self when defining module/class methods.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#def-self-singletons
-  Enabled: true
-Style/ClassVars:
-  Description: Avoid the use of class variables.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-class-vars
-  Enabled: false
-Style/ClosingParenthesisIndentation:
-  Description: Checks the indentation of hanging closing parentheses.
-  Enabled: true
-Style/ColonMethodCall:
-  Description: 'Do not use :: for method call.'
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#double-colons
-  Enabled: false
-Style/CommentIndentation:
-  Description: Indentation of comments.
-  Enabled: true
-Style/ConstantName:
-  Description: Constants should use SCREAMING_SNAKE_CASE.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#screaming-snake-case
-  Enabled: true
-Style/DefWithParentheses:
-  Description: Use def with parentheses when there are arguments.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#method-parens
-  Enabled: true
-Style/DeprecatedHashMethods:
-  Description: Checks for use of deprecated Hash methods.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-key
   Enabled: false
 Style/Documentation:
   Description: Document classes and non-namespace modules.
@@ -796,272 +184,31 @@ Style/DoubleNegation:
 Style/EachWithObject:
   Description: Prefer `each_with_object` over `inject` or `reduce`.
   Enabled: false
-Style/ElseAlignment:
-  Description: Align elses and elsifs correctly.
-  Enabled: true
-Style/EmptyElse:
-  Description: Avoid empty else-clauses.
-  Enabled: true
-Style/EmptyLines:
-  Description: Don't use several empty lines in a row.
-  Enabled: true
-Style/EmptyLinesAroundAccessModifier:
-  Description: Keep blank lines around access modifiers.
-  Enabled: true
-Style/EmptyLinesAroundMethodBody:
-  Description: Keeps track of empty lines around method bodies.
-  Enabled: true
 Style/EmptyLiteral:
   Description: Prefer literals to Array.new/Hash.new/String.new.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#literal-array-hash
   Enabled: false
-Style/EndBlock:
-  Description: Avoid the use of END blocks.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-END-blocks
-  Enabled: true
-Style/EndOfLine:
-  Description: Use Unix-style line endings.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#crlf
-  Enabled: true
-Style/EvenOdd:
-  Description: Favor the use of Fixnum#even? && Fixnum#odd?
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#predicate-methods
-  Enabled: false
-Style/InitialIndentation:
-  Description: Checks the indentation of the first non-blank non-comment line in a
-    file.
-  Enabled: true
-Style/FlipFlop:
-  Description: Checks for flip flops
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-flip-flops
-  Enabled: false
-Style/IfWithSemicolon:
-  Description: Do not use if x; .... Use the ternary operator instead.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs
-  Enabled: false
-Style/IndentationConsistency:
-  Description: Keep indentation straight.
-  Enabled: true
-Style/IndentArray:
-  Description: Checks the indentation of the first element in an array literal.
-  Enabled: true
-Style/InfiniteLoop:
-  Description: Use Kernel#loop for infinite loops.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#infinite-loop
-  Enabled: true
-Style/Lambda:
-  Description: Use the new lambda literal syntax for single-line blocks.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#lambda-multi-line
-  Enabled: false
-Style/LeadingCommentSpace:
-  Description: Comments should start with a space.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-space
-  Enabled: true
-Style/LineEndConcatenation:
-  Description: Use \ instead of + or << to concatenate two string literals at line
-    end.
-  Enabled: false
-Style/MethodCallParentheses:
-  Description: Do not use parentheses for method calls with no arguments.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-args-no-parens
-  Enabled: true
 Style/ModuleFunction:
   Description: Checks for usage of `extend self` in modules.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#module-function
-  Enabled: false
-Style/MultilineBlockChain:
-  Description: Avoid multi-line chains of blocks.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#single-line-blocks
-  Enabled: true
-Style/MultilineBlockLayout:
-  Description: Ensures newlines after multiline block do statements.
-  Enabled: true
-Style/MultilineIfThen:
-  Description: Do not use then for multi-line if/unless.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-then
-  Enabled: true
-Style/MultilineTernaryOperator:
-  Description: 'Avoid multi-line ?: (the ternary operator); use if/unless instead.'
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-multiline-ternary
-  Enabled: true
-Style/NegatedIf:
-  Description: Favor unless over if for negative conditions (or control flow or).
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#unless-for-negatives
-  Enabled: false
-Style/NegatedWhile:
-  Description: Favor until over while for negative conditions.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#until-for-negatives
-  Enabled: false
-Style/NestedTernaryOperator:
-  Description: Use one expression per branch in a ternary operator.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-ternary
-  Enabled: true
-Style/NilComparison:
-  Description: Prefer x.nil? to x == nil.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#predicate-methods
-  Enabled: false
-Style/Not:
-  Description: Use ! instead of not.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#bang-not-not
   Enabled: false
 Style/OneLineConditional:
   Description: Favor the ternary operator(?:) over if/then/else/end constructs.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#ternary-operator
   Enabled: false
-Style/OpMethod:
-  Description: When defining binary operators, name the argument other.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#other-arg
-  Enabled: false
-Style/OptionalArguments:
-  Description: Checks for optional arguments that do not appear at the end of the
-    argument list
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#optional-arguments
-  Enabled: true
-Style/ParallelAssignment:
-  Description: Check for simple usages of parallel assignment. It will only warn when
-    the number of variables matches on both sides of the assignment.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#parallel-assignment
-  Enabled: true
 Style/PerlBackrefs:
   Description: Avoid Perl-style regex back references.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers
-  Enabled: false
-Style/Proc:
-  Description: Use proc instead of Proc.new.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#proc
-  Enabled: false
-Style/RedundantBegin:
-  Description: Don't use begin blocks when they are not needed.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#begin-implicit
-  Enabled: true
-Style/RedundantException:
-  Description: Checks for an obsolete RuntimeException argument in raise/fail.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-explicit-runtimeerror
-  Enabled: true
-Style/RedundantFreeze:
-  Description: Checks usages of Object#freeze on immutable objects.
-  Enabled: true
-Style/RedundantSelf:
-  Description: Don't use self where it's not needed.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-self-unless-required
-  Enabled: true
-Style/RescueEnsureAlignment:
-  Description: Align rescues and ensures correctly.
-  Enabled: true
-Style/RescueModifier:
-  Description: Avoid using rescue in its modifier form.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-rescue-modifiers
-  Enabled: true
-Style/SelfAssignment:
-  Description: Checks for places where self-assignment shorthand should have been
-    used.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#self-assignment
   Enabled: false
 Style/Send:
   Description: Prefer `Object#__send__` or `Object#public_send` to `send`, as `send`
     may overlap with existing methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#prefer-public-send
   Enabled: false
-Style/SingleSpaceBeforeFirstArg:
-  Description: Checks that exactly one space is used between a method name and the
-    first argument for method calls without parentheses.
-  Enabled: true
-Style/SpaceAfterColon:
-  Description: Use spaces after colons.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-Style/SpaceAfterComma:
-  Description: Use spaces after commas.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-Style/SpaceAfterControlKeyword:
-  Description: Use spaces after if/elsif/unless/while/until/case/when.
-  Enabled: true
-Style/SpaceAfterMethodName:
-  Description: Do not put a space between a method name and the opening parenthesis
-    in a method definition.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-no-spaces
-  Enabled: true
-Style/SpaceAfterNot:
-  Description: Tracks redundant space after the ! operator.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-space-bang
-  Enabled: true
-Style/SpaceAfterSemicolon:
-  Description: Use spaces after semicolons.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-Style/SpaceBeforeComma:
-  Description: No spaces before commas.
-  Enabled: true
-Style/SpaceBeforeComment:
-  Description: Checks for missing space between code and a comment on the same line.
-  Enabled: true
-Style/SpaceBeforeSemicolon:
-  Description: No spaces before semicolons.
-  Enabled: true
-Style/SpaceAroundOperators:
-  Description: Use spaces around operators.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-Style/SpaceBeforeModifierKeyword:
-  Description: Put a space before the modifier keyword.
-  Enabled: true
-Style/SpaceInsideBrackets:
-  Description: No spaces after [ or before ].
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-spaces-braces
-  Enabled: true
-Style/SpaceInsideParens:
-  Description: No spaces after ( or before ).
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-spaces-braces
-  Enabled: true
-Style/SpaceInsideRangeLiteral:
-  Description: No spaces inside range literals.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals
-  Enabled: true
 Style/SpecialGlobalVars:
   Description: Avoid Perl-style global variables.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms
   Enabled: false
-Style/StructInheritance:
-  Description: Checks for inheritance from Struct.new.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-extend-struct-new
-  Enabled: true
-Style/SymbolLiteral:
-  Description: Use plain symbols instead of string symbols when possible.
-  Enabled: true
-Style/Tab:
-  Description: No hard tabs.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
-  Enabled: true
-Style/TrailingWhitespace:
-  Description: Avoid trailing whitespace.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace
-  Enabled: true
-Style/UnlessElse:
-  Description: Do not use unless with else. Rewrite these with the positive case first.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-else-with-unless
-  Enabled: true
-Style/UnneededCapitalW:
-  Description: Checks for %W when interpolation is not needed.
-  Enabled: true
-Style/UnneededPercentQ:
-  Description: Checks for %q/%Q when single quotes or double quotes would do.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-q
-  Enabled: true
-Style/TrailingUnderscoreVariable:
-  Description: Checks for the usage of unneeded trailing underscores at the end of
-    parallel variable assignment.
-  Enabled: true
-Style/CommandLiteral:
-  EnforcedStyle: backticks
-  SupportedStyles:
-  - backticks
-  - percent_x
-  - mixed
-  AllowInnerBackticks: false
-  Description: Use `` or %x around command literals.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-x
-  Enabled: true
 Style/VariableInterpolation:
   Description: Don't interpolate global, instance and class variables directly in
     strings.
@@ -1071,190 +218,16 @@ Style/WhenThen:
   Description: Use when x then ... for one-line cases.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#one-line-cases
   Enabled: false
-Style/WhileUntilDo:
-  Description: Checks for redundant do after while or until.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-multiline-while-do
-  Enabled: true
-Lint/AmbiguousOperator:
-  Description: Checks for ambiguous operators in the first argument of a method invocation
-    without parentheses.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-as-args
-  Enabled: false
-Lint/AmbiguousRegexpLiteral:
-  Description: Checks for ambiguous regexp literals in the first argument of a method
-    invocation without parenthesis.
-  Enabled: false
-Lint/BlockAlignment:
-  Description: Align block ends correctly.
-  Enabled: true
-Lint/CircularArgumentReference:
-  Description: Don't refer to the keyword argument in the default value.
-  Enabled: true
-Lint/ConditionPosition:
-  Description: Checks for condition placed in a confusing position relative to the
-    keyword.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#same-line-condition
-  Enabled: false
-Lint/Debugger:
-  Description: Check for debugger calls.
-  Enabled: true
-Lint/DeprecatedClassMethods:
-  Description: Check for deprecated class method calls.
-  Enabled: false
-Lint/DuplicateMethods:
-  Description: Check for duplicate methods calls.
-  Enabled: true
-Lint/DuplicatedKey:
-  Description: Check for duplicate keys in hash literals.
-  Enabled: true
 Lint/EachWithObjectArgument:
   Description: Check for immutable argument given to each_with_object.
-  Enabled: true
-Lint/ElseLayout:
-  Description: Check for odd code arrangement in an else block.
-  Enabled: false
-Lint/EmptyEnsure:
-  Description: Checks for empty ensure block.
-  Enabled: true
-Lint/EmptyInterpolation:
-  Description: Checks for empty string interpolation.
-  Enabled: true
-Lint/EndInMethod:
-  Description: END blocks should not be placed inside method definitions.
-  Enabled: true
-Lint/EnsureReturn:
-  Description: Do not use return in an ensure block.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-return-ensure
-  Enabled: true
-Lint/Eval:
-  Description: The use of eval represents a serious security risk.
-  Enabled: true
-Lint/FormatParameterMismatch:
-  Description: The number of parameters to format/sprint must match the fields.
   Enabled: true
 Lint/HandleExceptions:
   Description: Don't suppress exception.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
-  Enabled: false
-Lint/InvalidCharacterLiteral:
-  Description: Checks for invalid character literals with a non-escaped whitespace
-    character.
   Enabled: false
 Lint/LiteralInCondition:
   Description: Checks of literals used in conditions.
   Enabled: false
 Lint/LiteralInInterpolation:
   Description: Checks for literals used in interpolation.
-  Enabled: false
-Lint/Loop:
-  Description: Use Kernel#loop with break rather than begin/end/until or begin/end/while
-    for post-loop tests.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#loop-with-break
-  Enabled: false
-Lint/NestedMethodDefinition:
-  Description: Do not use nested method definitions.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-methods
-  Enabled: true
-Lint/NonLocalExitFromIterator:
-  Description: Do not use return in iterator to cause non-local exit.
-  Enabled: true
-Lint/ParenthesesAsGroupedExpression:
-  Description: Checks for method calls with a space before the opening parenthesis.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-no-spaces
-  Enabled: false
-Lint/RequireParentheses:
-  Description: Use parentheses in the method call to avoid confusion about precedence.
-  Enabled: false
-Lint/RescueException:
-  Description: Avoid rescuing the Exception class.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-blind-rescues
-  Enabled: true
-Lint/ShadowingOuterLocalVariable:
-  Description: Do not use the same name as outer local variable for block arguments
-    or block local variables.
-  Enabled: true
-Lint/SpaceBeforeFirstArg:
-  Description: Put a space between a method name and the first argument in a method
-    call without parentheses.
-  Enabled: true
-Lint/StringConversionInInterpolation:
-  Description: Checks for Object#to_s usage in string interpolation.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-to-s
-  Enabled: true
-Lint/UnderscorePrefixedVariableName:
-  Description: Do not use prefix `_` for a variable that is used.
-  Enabled: false
-Lint/UnneededDisable:
-  Description: 'Checks for rubocop:disable comments that can be removed. Note: this
-    cop is not disabled when disabling all cops. It must be explicitly disabled.'
-  Enabled: true
-Lint/UnusedBlockArgument:
-  Description: Checks for unused block arguments.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars
-  Enabled: true
-Lint/UnusedMethodArgument:
-  Description: Checks for unused method arguments.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars
-  Enabled: true
-Lint/UnreachableCode:
-  Description: Unreachable code.
-  Enabled: true
-Lint/UselessAccessModifier:
-  Description: Checks for useless access modifiers.
-  Enabled: true
-Lint/UselessAssignment:
-  Description: Checks for useless assignment to a local variable.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars
-  Enabled: true
-Lint/UselessComparison:
-  Description: Checks for comparison of something with itself.
-  Enabled: true
-Lint/UselessElseWithoutRescue:
-  Description: Checks for useless `else` in `begin..end` without `rescue`.
-  Enabled: true
-Lint/UselessSetterCall:
-  Description: Checks for useless setter call to a local variable.
-  Enabled: true
-Lint/Void:
-  Description: Possible use of operator/literal/variable in void context.
-  Enabled: false
-Performance/CaseWhenSplat:
-  Description: Place `when` conditions that use splat at the end of the list of `when`
-    branches.
-  Enabled: true
-Performance/Count:
-  Description: Use `count` instead of `select...size`, `reject...size`, `select...count`,
-    `reject...count`, `select...length`, and `reject...length`.
-  Enabled: true
-Performance/Detect:
-  Description: Use `detect` instead of `select.first`, `find_all.first`, `select.last`,
-    and `find_all.last`.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code
-  Enabled: true
-Performance/FlatMap:
-  Description: Use `Enumerable#flat_map` instead of `Enumerable#map...Array#flatten(1)`
-    or `Enumberable#collect..Array#flatten(1)`
-  Reference: https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code
-  Enabled: true
-  EnabledForFlattenWithoutParams: false
-Performance/ReverseEach:
-  Description: Use `reverse_each` instead of `reverse.each`.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code
-  Enabled: true
-Performance/Sample:
-  Description: Use `sample` instead of `shuffle.first`, `shuffle.last`, and `shuffle[Fixnum]`.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code
-  Enabled: true
-Performance/Size:
-  Description: Use `size` instead of `count` for counting the number of elements in
-    `Array` and `Hash`.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#arraycount-vs-arraysize-code
-  Enabled: true
-Performance/StringReplacement:
-  Description: Use `tr` instead of `gsub` when you are replacing the same number of
-    characters. Use `delete` instead of `gsub` when you are deleting characters.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code
-  Enabled: true
-Rails/Delegate:
-  Description: Prefer delegate method for delegations.
   Enabled: false

--- a/spec/models/linter/ruby_spec.rb
+++ b/spec/models/linter/ruby_spec.rb
@@ -32,14 +32,6 @@ describe Linter::Ruby do
     end
 
     context "with default configuration" do
-      describe "for { and } as %r literal delimiters" do
-        it "returns no violations" do
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq []
-            "test" =~ %r|test|
-          CODE
-        end
-      end
-
       describe "for private prefix" do
         it "returns no violations" do
           expect(violations_in(<<-CODE.strip_heredoc)).to eq []
@@ -70,8 +62,6 @@ describe Linter::Ruby do
         it "returns no violations" do
           expect(violations_in(<<-CODE.strip_heredoc)).to eq []
             if signed_in? then redirect_to dashboard_path end
-
-            while signed_in? do something end
           CODE
         end
       end
@@ -282,9 +272,9 @@ describe Linter::Ruby do
 
       context "for operator without surrounding spaces" do
         it "returns violations" do
-          violations = ["Surrounding space missing for operator `+`."]
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            1+1
+          violation = "Surrounding space missing for operator `+`."
+          expect(violations_in(<<-CODE.strip_heredoc)).to include violation
+            two = 1+1
           CODE
         end
       end


### PR DESCRIPTION
This is a move towards removing Hound's defaults and relying on underlying linter libraries for defaults.

The options that will break functionality for a majority of users will be updated after this change and after messaging users about the upcoming change.

Cops that are enabled by this change:
* Style/ClassAndModuleChildren
* Style/CommentAnnotation
* Style/FormatString
* Style/LambdaCall
* Style/Next
* Style/NumericLiterals
* Style/RegexpLiteral
* Style/WhileUntilModifier
* Style/WordArray
* Metrics/BlockNesting
* Rails/ActionFilter
* Style/EvenOdd
* Style/InitialIndentation
* Style/FlipFlop
* Style/IfWithSemicolon
* Style/Lambda
* Style/LineEndConcatenation
* Style/NegatedIf
* Style/NegatedWhile
* Style/Not
* Style/SelfAssignment
* Lint/ConditionPosition
* Lint/ElseLayout
* Lint/Void
* Style/Attr
* Style/CaseEquality
* Style/CharacterLiteral
* Style/DeprecatedHashMethods
* Lint/RequireParentheses
* Lint/UnderscorePrefixedVariableName
* Rails/Delegate
* Lint/ParenthesesAsGroupedExpression
* Lint/Loop
* Style/Proc
* Style/OpMethod
* Style/NilComparison
* Style/ModuleFunction
* Style/ClassVars
* Style/ArrayJoin
* Style/TrivialAccessors
* Lint/AmbiguousRegexpLiteral
* Lint/AmbiguousOperator
* Lint/DeprecatedClassMethods
* Lint/InvalidCharacterLiteral

Cops that are disabled by this change:
* Metrics/ModuleLength
* Metrics/AbcSize