### PR TITLE
Allow multiline block chaining

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -757,10 +757,6 @@ Style/ModuleFunction:
   Description: Checks for usage of `extend self` in modules.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#module-function
   Enabled: false
-Style/MultilineBlockChain:
-  Description: Avoid multi-line chains of blocks.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#single-line-blocks
-  Enabled: true
 Style/MultilineBlockLayout:
   Description: Ensures newlines after multiline block do statements.
   Enabled: true

--- a/config/style_guides/thoughtbot/ruby.yml
+++ b/config/style_guides/thoughtbot/ruby.yml
@@ -356,3 +356,8 @@ TimeZone:
 
 Validation:
   Enabled: false
+
+Style/MultilineBlockChain:
+  Description: 'Avoid multi-line chains of blocks.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
+  Enabled: false


### PR DESCRIPTION
Allow multiline block chaining

For testing that an exception occured, multiline block chaining
might be needed to follow other guides we have.

Example:

```ruby
expect do
  Config::Parser.load_yaml(hound_config, "config/rubocop.yml")
end.to raise_error do |exception|
   expect(exception).to be_a Config::Parser::Error
   expect(exception.message).to eq(
     "`config/rubocop.yml` must be a Hash",
   )
   expect(exception.filename).to eq "config/rubocop.yml"
end
```

- To keep the line under 80 characters, it sometimes can't be re-written
  using `{}` instead of `do/end`.
- `{}` shouldn't be used for multiline blocks.
- If you want to assert more things on the exception, you have to yield
  a block to `raise_error` to do so.


I propose to relax this rule by allowing to chain blocks that spans
over multiple lines.