### PR TITLE
Order language logos alphabetically

### DIFF
--- a/app/views/home/index.haml
+++ b/app/views/home/index.haml
@@ -22,20 +22,8 @@
         %ul.languages
           %li.language
             .language-logo
-              = image_tag "languages/ruby.svg"
-            %h5 Ruby
-          %li.language
-            .language-logo
               = image_tag "languages/coffeescript.svg"
             %h5 CoffeeScript
-          %li.language
-            .language-logo
-              = image_tag "languages/javascript.svg"
-            %h5 JavaScript
-          %li.language
-            .language-logo
-              = image_tag "languages/sass.svg"
-            %h5 Scss
           %li.language
             .language-logo
               = image_tag "languages/go.svg"
@@ -46,8 +34,16 @@
             %h5 Haml
           %li.language
             .language-logo
-              = image_tag "languages/python.svg"
-            %h5 Python
+              = image_tag "languages/javascript.svg"
+            %h5 JavaScript
+          %li.language
+            .language-logo
+              = image_tag "languages/ruby.svg"
+            %h5 Ruby
+          %li.language
+            .language-logo
+              = image_tag "languages/sass.svg"
+            %h5 Scss
 
 %section.importance
   .section-content


### PR DESCRIPTION
I assume Ruby was first because it was supported first and is still has
the largest percentage of builds. However, with the move towards equal
opportunity linters, it's awkward to have Ruby up front. Sorting
alphabetically seems good to me.

In c0ea6270a5b7aaccc0c8499fa047b7b06836543e, I forgot to create a
feature branch and accidentally pushed to master :frowning: . Since it
doesn't include any breaking changes, I think I don't want to muddy
the history further by introducing a revert commit, then going through
our PR flow. I'm hoping for this one to serve in its place.

<img width="835" alt="hound" src="https://cloud.githubusercontent.com/assets/72176/10401282/db142ae6-6e72-11e5-8c61-97eafb3ce5c9.png">
