### PR TITLE
Add support for `Eslint` alongside `JShint`

### DIFF
--- a/app/jobs/eslint_review_job.rb
+++ b/app/jobs/eslint_review_job.rb
@@ -1,0 +1,3 @@
+class EslintReviewJob
+  @queue = :eslint_review
+end

--- a/app/models/config/eslint.rb
+++ b/app/models/config/eslint.rb
@@ -1,0 +1,9 @@
+module Config
+  class Eslint < Base
+    private
+
+    def parse(file_content)
+      Parser.raw(file_content)
+    end
+  end
+end

--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -1,6 +1,7 @@
 class HoundConfig
   CONFIG_FILE = ".hound.yml"
   BETA_LANGUAGES = %w(
+    eslint
     python
     swift
   )

--- a/app/models/linter/collection.rb
+++ b/app/models/linter/collection.rb
@@ -2,6 +2,7 @@ module Linter
   class Collection
     LINTERS = [
       Linter::CoffeeScript,
+      Linter::Eslint,
       Linter::Go,
       Linter::Haml,
       Linter::JavaScript,

--- a/app/models/linter/eslint.rb
+++ b/app/models/linter/eslint.rb
@@ -1,0 +1,5 @@
+module Linter
+  class Eslint < Base
+    FILE_REGEXP = /.+((?<!\.coffee)\.js|(?:\.es6|\.es6\.js))\z/
+  end
+end

--- a/app/models/linter/java_script.rb
+++ b/app/models/linter/java_script.rb
@@ -19,7 +19,7 @@ module Linter
     end
 
     def file_included?(commit_file)
-      !excluded_files.any? do |pattern|
+      excluded_files.none? do |pattern|
         File.fnmatch?(pattern, commit_file.filename)
       end
     end

--- a/spec/models/config/eslint_spec.rb
+++ b/spec/models/config/eslint_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+require "app/models/config/base"
+require "app/models/config/eslint"
+
+describe Config::Eslint do
+  it_behaves_like "a service based linter" do
+    let(:raw_config) do
+      <<-EOS.strip_heredoc
+        rules:
+            quotes: [2, "double"]
+      EOS
+    end
+
+    let(:hound_config_content) do
+      {
+        "eslint" => {
+          "enabled" => true,
+          "config_file" => "config/.eslintrc",
+        },
+      }
+    end
+  end
+end

--- a/spec/models/linter/eslint_spec.rb
+++ b/spec/models/linter/eslint_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+describe Linter::Eslint do
+  describe ".can_lint?" do
+    context "given an .es6 file" do
+      it "returns true" do
+        result = Linter::Eslint.can_lint?("foo.es6")
+
+        expect(result).to eq true
+      end
+    end
+
+    context "given an .es6.js file" do
+      it "returns true" do
+        result = Linter::Eslint.can_lint?("foo.es6.js")
+
+        expect(result).to eq true
+      end
+    end
+
+    context "given a .js file" do
+      it "returns true" do
+        result = Linter::Eslint.can_lint?("foo.js")
+
+        expect(result).to eq true
+      end
+    end
+
+    context "given a non-eslint file" do
+      it "returns false" do
+        result = Linter::Eslint.can_lint?("foo.coffee.js")
+
+        expect(result).to eq false
+      end
+    end
+  end
+
+  describe "#file_review" do
+    it "returns a saved and incomplete file review" do
+      commit_file = build_commit_file(filename: "lib/a.js")
+      linter = build_linter
+
+      result = linter.file_review(commit_file)
+
+      expect(result).to be_persisted
+      expect(result).not_to be_completed
+    end
+
+    it "schedules a review job" do
+      build = build(:build, commit_sha: "foo", pull_request_number: 123)
+      stub_eslint_config(content: "config")
+      commit_file = build_commit_file(filename: "lib/a.js")
+      allow(Resque).to receive(:enqueue)
+      linter = build_linter(build)
+
+      linter.file_review(commit_file)
+
+      expect(Resque).to have_received(:enqueue).with(
+        EslintReviewJob,
+        filename: commit_file.filename,
+        commit_sha: build.commit_sha,
+        pull_request_number: build.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
+        config: "config",
+      )
+    end
+  end
+
+  def stub_eslint_config(content: "")
+    stubbed_eslint_config = double("EslintConfig", content: content)
+    allow(Config::Eslint).to receive(:new).and_return(stubbed_eslint_config)
+
+    stubbed_eslint_config
+  end
+
+  def raw_hound_config
+    <<-EOS.strip_heredoc
+      eslint:
+        enabled: true
+        config_file: config/.eslintrc
+    EOS
+  end
+end


### PR DESCRIPTION
Add support for `eslint` backed by `hound-eslint`

Eslint is disabled by default, alongside any other Beta linters.

To enabled it, simplify configure your `.hound.yml`:

```yaml
eslint:
  enabled: true
  config_file: config/.eslintrc
  ignore_file: config/.eslintignore
```

This is backed by [hound-eslint]

[hound-eslint]: https://github.com/thoughtbot/hound-eslint

Changes:

- Implement `Config::Eslint` and `Linter::Eslint`.
- Support `*.js`, `*.es6`, and `*.es6.js`, for file extensions.
- Replace `!collection.any?` with `collection.none?`

https://trello.com/c/2a6yQORa
