### PR TITLE
Send `excluded_files` to services

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,8 @@ Linter jobs are created with the following arguments:
 
 * `config` - The configuration for the linter. This will be linter specific.
 * `content` - The source code to check for violations.
+* `excluded_files` - A comma-separated list of with patterns that should be
+  ignored by the linter. i.e `vendor/assets/stylesheets/*`
 * `filename` - The name of the source file for the code snippet. This should be
   passed through to the outbound queue.
 * `commit_sha` - The git commit SHA of the code snippet. This should be passed

--- a/app/models/linter/base.rb
+++ b/app/models/linter/base.rb
@@ -43,6 +43,7 @@ module Linter
         commit_sha: build.commit_sha,
         config: config.content,
         content: commit_file.content,
+        excluded_files: config.excluded_files.join(", "),
         filename: commit_file.filename,
         patch: commit_file.patch,
         pull_request_number: build.pull_request_number,

--- a/spec/models/linter/go_spec.rb
+++ b/spec/models/linter/go_spec.rb
@@ -40,12 +40,13 @@ describe Linter::Go do
 
       expect(Resque).to have_received(:enqueue).with(
         GoReviewJob,
-        filename: commit_file.filename,
         commit_sha: build.commit_sha,
-        pull_request_number: build.pull_request_number,
-        patch: commit_file.patch,
-        content: commit_file.content,
         config: Config::Go::DEFAULT_CONFIG,
+        content: commit_file.content,
+        excluded_files: "",
+        filename: commit_file.filename,
+        patch: commit_file.patch,
+        pull_request_number: build.pull_request_number,
       )
     end
   end

--- a/spec/models/linter/python_spec.rb
+++ b/spec/models/linter/python_spec.rb
@@ -35,7 +35,7 @@ describe Linter::Python do
       allow(Resque).to receive(:push)
       build = build(:build, commit_sha: "foo", pull_request_number: 123)
       linter = build_linter(build)
-      stub_python_config("config")
+      stub_python_config(content: "config")
       commit_file = build_commit_file
 
       linter.file_review(commit_file)
@@ -45,12 +45,13 @@ describe Linter::Python do
         {
           class: "review.PythonReviewJob",
           args: [
-            filename: commit_file.filename,
             commit_sha: build.commit_sha,
-            pull_request_number: build.pull_request_number,
-            patch: commit_file.patch,
-            content: commit_file.content,
             config: "config",
+            content: commit_file.content,
+            excluded_files: "",
+            filename: commit_file.filename,
+            patch: commit_file.patch,
+            pull_request_number: build.pull_request_number,
           ],
         }
       )
@@ -74,8 +75,15 @@ describe Linter::Python do
     )
   end
 
-  def stub_python_config(config = "config")
-    stubbed_python_config = double("PythonConfig", content: config)
+  def stub_python_config(options = {})
+    default_options = {
+      content: "",
+      excluded_files: [],
+    }
+    stubbed_python_config = double(
+      "PythonConfig",
+      default_options.merge(options),
+    )
     allow(Config::Python).to receive(:new).and_return(stubbed_python_config)
 
     stubbed_python_config


### PR DESCRIPTION
This is a step closer to push the responsibilities down to each service instead of having it living in `Hound` itself.

Use case: If a user adds Bootstrap's stylesheets to a project in a PR, Hound will pickup on it and try to lint them with whichever linter is responsible for it. But, since they are "vendored" code - it's not something you want linted. 

Format, send it as comma-separated list.
```json
{
   "excluded_files": "pattern_1, pattern_2"
}
```