### PR TITLE
Support multiple linters per file

### DIFF
--- a/app/models/linter/collection.rb
+++ b/app/models/linter/collection.rb
@@ -1,0 +1,40 @@
+module Linter
+  class Collection
+    LINTERS = [
+      Linter::CoffeeScript,
+      Linter::Go,
+      Linter::Haml,
+      Linter::JavaScript,
+      Linter::Python,
+      Linter::Ruby,
+      Linter::Scss,
+      Linter::Swift,
+    ].freeze
+
+    def self.for(filename:, **linter_args)
+      linter_classes = LINTERS.
+        select { |linter_class| linter_class.can_lint?(filename) }.
+        map { |linter_class| linter_class.new(**linter_args) }
+
+      new(linter_classes.presence || default_linter(**linter_args))
+    end
+
+    attr_reader :linters
+
+    def initialize(linters = [])
+      @linters = Array(linters)
+    end
+
+    def file_review(commit_file)
+      linters.
+        select(&:enabled?).
+        select { |linter| linter.file_included?(commit_file) }.
+        each { |linter| linter.file_review(commit_file) }
+    end
+
+    def self.default_linter(**linter_args)
+      Linter::Unsupported.new(**linter_args)
+    end
+    private_class_method :default_linter
+  end
+end

--- a/app/models/style_checker.rb
+++ b/app/models/style_checker.rb
@@ -2,46 +2,25 @@
 # Builds style guide based on file extension.
 # Delegates to style guide for line violations.
 class StyleChecker
-  pattr_initialize :pull_request, :build do
-    @linters = {}
-  end
-  attr_private :linters
+  pattr_initialize :pull_request, :build
 
   def review_files
     pull_request.commit_files.each do |commit_file|
-      linter = build_linter(commit_file.filename)
+      collection = build_linter_collection(commit_file.filename)
 
-      if linter.enabled? && linter.file_included?(commit_file)
-        linter.file_review(commit_file)
-      end
+      collection.file_review(commit_file)
     end
   end
 
   private
 
-  LINTERS = [
-    Linter::CoffeeScript,
-    Linter::Go,
-    Linter::Haml,
-    Linter::JavaScript,
-    Linter::Python,
-    Linter::Ruby,
-    Linter::Scss,
-    Linter::Swift,
-    Linter::Unsupported,
-  ].freeze
-
-  def build_linter(filename)
-    linter_class = find_linter_class(filename)
-    linters[linter_class] ||= linter_class.new(
+  def build_linter_collection(filename)
+    Linter::Collection.for(
+      filename: filename,
       hound_config: hound_config,
       build: build,
       repository_owner_name: pull_request.repository_owner_name,
     )
-  end
-
-  def find_linter_class(filename)
-    LINTERS.detect { |linter_class| linter_class.can_lint?(filename) }
   end
 
   def hound_config

--- a/spec/models/linter/collection_spec.rb
+++ b/spec/models/linter/collection_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+describe Linter::Collection do
+  describe ".for" do
+    context "when the given filename maps to a linter" do
+      it "instantiates the collection with the matching linters" do
+        hound_config = double("HoundConfig")
+        build = double("Build")
+        pull_request = double(
+          "PullRequest",
+          head_commit: "HeadCommit",
+          repository_owner_name: "thoughtbot",
+        )
+        collection = Linter::Collection.for(
+          filename: "bank.rb",
+          hound_config: hound_config,
+          build: build,
+          repository_owner_name: pull_request.repository_owner_name,
+        )
+
+        expect(collection.linters.sample).to be_a Linter::Ruby
+      end
+    end
+
+    context "when the given filename does not map to a linter" do
+      it "instantiates the collection with the unsupported linter" do
+        hound_config = double("HoundConfig")
+        build = double("Build")
+        pull_request = double(
+          "PullRequest",
+          head_commit: "HeadCommit",
+          repository_owner_name: "thoughtbot",
+        )
+        collection = Linter::Collection.for(
+          filename: "bank.f",
+          hound_config: hound_config,
+          build: build,
+          repository_owner_name: pull_request.repository_owner_name,
+        )
+
+        expect(collection.linters.sample).to be_a Linter::Unsupported
+      end
+    end
+  end
+
+  describe "#file_review" do
+    context "when the linters are enabled and has given file included" do
+      it "calls `file_review` on the linters" do
+        element_a = double(
+          "ElementA",
+          enabled?: true,
+          file_included?: true,
+          file_review: true,
+        )
+        element_b = double(
+          "ElementB",
+          enabled?: false,
+          file_included?: true,
+          file_review: true,
+        )
+        element_c = double(
+          "ElementC",
+          enabled?: true,
+          file_included?: true,
+          file_review: true,
+        )
+        elements = [element_a, element_b, element_c]
+        commit_file = double("CommitFile")
+        collection = Linter::Collection.new(elements)
+
+        collection.file_review(commit_file)
+
+        expect(element_a).to have_received(:file_review).with(commit_file)
+        expect(element_b).not_to have_received(:file_review)
+        expect(element_c).to have_received(:file_review).with(commit_file)
+      end
+    end
+
+    context "when the linters are disabled and has the file included" do
+      it "does nothing" do
+        element_a = double(
+          "ElementA",
+          enabled?: false,
+          file_included?: false,
+          file_review: true,
+        )
+        element_b = double(
+          "ElementB",
+          enabled?: true,
+          file_included?: false,
+          file_review: true,
+        )
+        element_c = double(
+          "ElementC",
+          enabled?: false,
+          file_included?: true,
+          file_review: true,
+        )
+        elements = [element_a, element_b, element_c]
+        commit_file = double("CommitFile")
+        collection = Linter::Collection.new(elements)
+
+        collection.file_review(commit_file)
+
+        expect(element_a).not_to have_received(:file_review)
+        expect(element_b).not_to have_received(:file_review)
+        expect(element_c).not_to have_received(:file_review)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Linter::Collection` wraps a list of linters. To work as a replacement
for a single `Linter`, even though multiple linters are used.