### PR TITLE
Upgrade Rubygems according to bundler-audit, add rake bundler:audit rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "font-awesome-rails"
 gem "haml-rails"
 gem "haml_lint"
 gem "high_voltage"
-gem "jquery-rails"
+gem "jquery-rails", "~> 3.1.3"
 gem "jshintrb"
 gem "neat"
 gem "octokit"
@@ -33,12 +33,13 @@ gem "rubocop", "0.34.2"
 gem "sass-rails"
 gem "split", require: "split/dashboard"
 gem "stripe"
-gem "uglifier", ">= 1.0.3"
+gem "uglifier", ">= 2.7.2"
+gem "rest-client", ">= 1.8.0"
 
 group :staging, :production do
   gem "rack-timeout"
   gem "rails_12factor"
-  gem "sentry-raven"
+  gem "sentry-raven", ">= 0.12.2"
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :development, :test do
   gem "jasmine-rails"
   gem "poltergeist"
   gem "rspec-rails", ">= 3.2"
+  gem "bundler-audit", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,9 @@ GEM
       sass (~> 3.4)
       thor (~> 0.19)
     builder (3.2.2)
+    bundler-audit (0.4.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     byebug (3.2.0)
       columnize (~> 0.8)
       debugger-linecache (~> 1.2)
@@ -349,6 +352,7 @@ DEPENDENCIES
   angularjs-rails
   attr_extras
   bourbon
+  bundler-audit
   byebug
   capybara (~> 2.4.0)
   capybara-webkit (~> 1.5.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
     database_cleaner (1.3.0)
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
+    domain_name (0.5.25)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.0.1)
     dotenv-rails (2.0.1)
       dotenv (= 2.0.1)
@@ -123,8 +125,10 @@ GEM
       haml (~> 4.0)
       rubocop (>= 0.25.0)
       sysexits (~> 1.1)
-    hashie (3.2.0)
+    hashie (3.4.2)
     high_voltage (2.2.1)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     jasmine-core (2.1.3)
     jasmine-rails (0.10.6)
@@ -132,7 +136,7 @@ GEM
       phantomjs
       railties (>= 3.1.0)
       sprockets-rails
-    jquery-rails (3.1.1)
+    jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     jshintrb (0.3.0)
@@ -157,7 +161,7 @@ GEM
     neat (1.7.2)
       bourbon (>= 4.0)
       sass (>= 3.3)
-    netrc (0.7.7)
+    netrc (0.10.3)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     normalize-rails (3.0.3)
@@ -247,7 +251,8 @@ GEM
     resque-sentry (1.2.0)
       resque (>= 1.18.0)
       sentry-raven (>= 0.4.6)
-    rest-client (1.7.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     rspec-core (3.3.2)
@@ -288,10 +293,8 @@ GEM
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
     selectize-rails (0.12.1)
-    sentry-raven (0.9.4)
+    sentry-raven (0.15.2)
       faraday (>= 0.7.6)
-      hashie (>= 1.1.0)
-      uuidtools
     shoulda-matchers (2.6.2)
       activesupport (>= 3.0.0)
     simple-random (1.0.0)
@@ -320,10 +323,12 @@ GEM
     tilt (1.4.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.5.3)
+    uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
-    uuidtools (2.1.5)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     vegas (0.1.11)
       rack (>= 1.0.0)
     webmock (1.18.0)
@@ -360,7 +365,7 @@ DEPENDENCIES
   haml_lint
   high_voltage
   jasmine-rails
-  jquery-rails
+  jquery-rails (~> 3.1.3)
   jshintrb
   launchy
   neat
@@ -376,14 +381,15 @@ DEPENDENCIES
   resque (~> 1.25.0)
   resque-scheduler
   resque-sentry
+  rest-client (>= 1.8.0)
   rspec-rails (>= 3.2)
   rubocop (= 0.34.2)
   sass-rails
-  sentry-raven
+  sentry-raven (>= 0.12.2)
   shoulda-matchers
   split
   stripe
-  uglifier (>= 1.0.3)
+  uglifier (>= 2.7.2)
   webmock
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,6 @@ require File.expand_path('../config/application', __FILE__)
 
 Houndapp::Application.load_tasks
 
-task :default => "spec:javascript"
+task default: "spec:javascript"
+
+task default: "bundler:audit"

--- a/lib/tasks/bundler_audit.rake
+++ b/lib/tasks/bundler_audit.rake
@@ -1,0 +1,12 @@
+if Rails.env.development? || Rails.env.test?
+  require "bundler/audit/cli"
+
+  namespace :bundler do
+    desc "Updates the ruby-advisory-db and runs audit"
+    task :audit do
+      %w(update check).each do |command|
+        Bundler::Audit::CLI.start [command]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This Pull Request

- Adds `rake bundler:audit` from https://github.com/thoughtbot/suspenders/commit/e23157ede1477a6e3e1163516281cfda10b479c6
- Uses 1.9 hash syntax in Rakefile
- Upgrades some gems (jquery-rails, uglifier, sentry-raven, and explicitly adds rest-client)  to address the advices from [bundler-audit](https://github.com/rubysec/bundler-audit):

```
$ bundle-audit
Insecure Source URI found: git://github.com/octokit/octokit.rb.git
Name: jquery-rails
Version: 3.1.1
Advisory: CVE-2015-1840
Criticality: Medium
URL: https://groups.google.com/forum/#!topic/ruby-security-ann/XIZPbobuwaY
Title: CSRF Vulnerability in jquery-rails
Solution: upgrade to >= 4.0.4, ~> 3.1.3

Name: rest-client
Version: 1.7.2
Advisory: CVE-2015-1820
Criticality: Unknown
URL: https://github.com/rest-client/rest-client/issues/369
Title: rubygem-rest-client: session fixation vulnerability via Set-Cookie headers in 30x redirection responses
Solution: upgrade to >= 1.8.0

Name: rest-client
Version: 1.7.2
Advisory: CVE-2015-3448
Criticality: Unknown
URL: http://www.osvdb.org/show/osvdb/117461
Title: Rest-Client Gem for Ruby logs password information in plaintext
Solution: upgrade to >= 1.7.3

Name: sentry-raven
Version: 0.9.4
Advisory: CVE-2014-9490
Criticality: Medium
URL: http://osvdb.org/show/osvdb/115654
Title: sentry-raven Gem for Ruby contains a flaw that can result in a denial of service
Solution: upgrade to >= 0.12.2

Name: uglifier
Version: 2.5.3
Advisory: 126747
Criticality: Unknown
URL: https://github.com/mishoo/UglifyJS2/issues/751
Title: uglifier incorrectly handles non-boolean comparisons during minification
Solution: upgrade to >= 2.7.2

Vulnerabilities found!
```