### PR TITLE
Allow supported languages to be unconfigured

### DIFF
--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -47,9 +47,8 @@ class HoundConfig
   end
 
   def options_for(name)
-    key = normalize_key(name)
-
-    content[key] || default_options_for(key)
+    config = content[name] || {}
+    default_options_for(name).merge(config)
   end
 
   def default_options_for(name)

--- a/spec/models/config/ruby_spec.rb
+++ b/spec/models/config/ruby_spec.rb
@@ -71,7 +71,6 @@ describe Config::Ruby do
       commit: commit,
       content: {
         "ruby" => {
-          "enabled" => true,
           "config_file" => "config/rubocop.yml",
         },
       },

--- a/spec/models/hound_config_spec.rb
+++ b/spec/models/hound_config_spec.rb
@@ -50,6 +50,20 @@ describe HoundConfig do
       end
     end
 
+    context "when the given language is supported but unconfigured" do
+      it "returns true" do
+        commit = stubbed_commit(
+          ".hound.yml" => <<-EOS.strip_heredoc
+            scss:
+              config_file: config/.scss_lint.yml
+          EOS
+        )
+        hound_config = HoundConfig.new(commit)
+
+        expect(hound_config).to be_enabled_for("scss")
+      end
+    end
+
     context "given a language in beta" do
       context "when the given language is enabled" do
         it "returns true" do

--- a/spec/models/linter/base_spec.rb
+++ b/spec/models/linter/base_spec.rb
@@ -29,4 +29,45 @@ describe Linter::Base do
       expect(linter.file_included?(double)).to eq true
     end
   end
+
+  describe "#enabled?" do
+    context "when the hound config is enabled for the given language" do
+      it "returns true" do
+        hound_config = double("HoundConfig", enabled_for?: true)
+        linter = Linter::Test.new(
+          hound_config: hound_config,
+          build: double,
+          repository_owner_name: "foo",
+        )
+
+        expect(linter.enabled?).to eq true
+      end
+    end
+
+    context "when the hound config is disabled for the given language" do
+      it "returns false" do
+        hound_config = double("HoundConfig", enabled_for?: false)
+        linter = Linter::Test.new(
+          hound_config: hound_config,
+          build: double,
+          repository_owner_name: "foo",
+        )
+
+        expect(linter.enabled?).to eq false
+      end
+    end
+
+    context "when the hound config is disabled for the given language" do
+      it "returns false" do
+        hound_config = double("HoundConfig", enabled_for?: false)
+        linter = Linter::Test.new(
+          hound_config: hound_config,
+          build: double,
+          repository_owner_name: "foo",
+        )
+
+        expect(linter.enabled?).to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
Linters that are supported[1] out of the box for Hound, should not be
enabled in the users `.hound.yml`[1]
Beta languages still needs to be enabled in the configuration[2]

[1]
```yaml
ruby:
  enabled: true
```

[2]
```yaml
python:
  enabled: true
```