### PR TITLE
Allow services to report config files as invalid

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,6 +173,16 @@ Once linting is complete, resulting violations should be posted to the outbound
 * `patch` - The patch content from GitHub for the file being reviewed. This is
   provided by the inbound queue.
 
+If the given `config` is invalid, the invalid file should be posted to the
+outbound `ReportInvalidConfigJob` queue:
+
+* `commit_sha` - The git commit SHA of the code snippet. This is provided by the
+  inbound queue..
+* `filename` - The name of the source file for the code snippet. This is
+  provided by the inbound queue.
+* `pull_request_number` - The GitHub pull request number. This is provided by
+  the inbound queue.
+
 ## Contributor License Agreement
 
 If you submit a Contribution to this application's source code, you hereby grant

--- a/app/jobs/report_invalid_config_job.rb
+++ b/app/jobs/report_invalid_config_job.rb
@@ -1,0 +1,11 @@
+class ReportInvalidConfigJob
+  @queue = :high
+
+  def self.perform(attributes)
+    ReportInvalidConfig.run(
+      pull_request_number: attributes.fetch("pull_request_number"),
+      commit_sha: attributes.fetch("commit_sha"),
+      filename: attributes.fetch("filename"),
+    )
+  end
+end

--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -7,8 +7,8 @@ class BuildRunner
     if repo && relevant_pull_request?
       review_pull_request
     end
-  rescue Config::ParserError => e
-    commit_status.set_config_error(e.filename)
+  rescue Config::ParserError => exception
+    report_config_file_as_invalid(exception.filename)
   rescue Octokit::Unauthorized
     if users_with_token.any?
       reset_token
@@ -111,6 +111,14 @@ class BuildRunner
       repo_name: payload.full_repo_name,
       sha: payload.head_sha,
       token: token,
+    )
+  end
+
+  def report_config_file_as_invalid(filename)
+    ReportInvalidConfig.run(
+      pull_request_number: payload.pull_request_number,
+      commit_sha: payload.head_sha,
+      filename: filename,
     )
   end
 end

--- a/spec/jobs/report_invalid_config_job_spec.rb
+++ b/spec/jobs/report_invalid_config_job_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe ReportInvalidConfigJob do
+  describe ".perform" do
+    it "calls the `ReportInvalidConfig` service" do
+      attributes = {
+        "pull_request_number" => "42",
+        "commit_sha" => "abc123",
+        "filename" => "config/.rubocop.yml",
+      }
+      allow(ReportInvalidConfig).to receive(:run)
+
+      ReportInvalidConfigJob.perform(attributes)
+
+      expect(ReportInvalidConfig).to have_received(:run).with(
+        pull_request_number: attributes["pull_request_number"],
+        commit_sha: attributes["commit_sha"],
+        filename: attributes["filename"],
+      )
+    end
+  end
+end

--- a/spec/services/report_invalid_config_spec.rb
+++ b/spec/services/report_invalid_config_spec.rb
@@ -1,0 +1,34 @@
+class ReportInvalidConfig
+  def self.run(**args)
+    new(**args).run
+  end
+
+  def initialize(pull_request_number:, commit_sha:, filename:)
+    @pull_request_number = pull_request_number
+    @commit_sha = commit_sha
+    @filename = filename
+  end
+
+  def run
+    commit_status.set_config_error(filename)
+  end
+
+  private
+
+  attr_reader :pull_request_number, :commit_sha, :filename
+
+  def commit_status
+    @commit_status ||= CommitStatus.new(
+      repo_name: build.repo_name,
+      commit_sha: commit_sha,
+      token: Hound::GITHUB_TOKEN,
+    )
+  end
+
+  def build
+    @build ||= Build.find_by!(
+      pull_request_number: pull_request_number,
+      commit_sha: commit_sha,
+    )
+  end
+end


### PR DESCRIPTION
Either by executing the service, `ReportInvalidConfig`. Or by enqueueing
the corresponding job, `ReportInvalidConfigJob`.


https://trello.com/c/42U5K0Bs