### PR TITLE
Add support for hound-mdast

### DIFF
--- a/app/jobs/mdast_review_job.rb
+++ b/app/jobs/mdast_review_job.rb
@@ -1,0 +1,3 @@
+class MdastReviewJob
+  @queue = :mdast_review
+end

--- a/app/models/config/mdast.rb
+++ b/app/models/config/mdast.rb
@@ -1,0 +1,9 @@
+module Config
+  class Mdast < Base
+    private
+
+    def parse(file_content)
+      Parser.raw(file_content)
+    end
+  end
+end

--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -3,6 +3,7 @@ class HoundConfig
   BETA_LANGUAGES = %w(
     eslint
     jscs
+    mdast
     python
     swift
   )

--- a/app/models/linter/collection.rb
+++ b/app/models/linter/collection.rb
@@ -7,6 +7,7 @@ module Linter
       Linter::Haml,
       Linter::JavaScript,
       Linter::Jscs,
+      Linter::Mdast,
       Linter::Python,
       Linter::Ruby,
       Linter::Scss,

--- a/app/models/linter/mdast.rb
+++ b/app/models/linter/mdast.rb
@@ -1,0 +1,5 @@
+module Linter
+  class Mdast < Base
+    FILE_REGEXP = /.+\.(?:md|markdown)\z/
+  end
+end

--- a/spec/models/config/mdast_spec.rb
+++ b/spec/models/config/mdast_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+require "app/models/config/base"
+require "app/models/config/mdast"
+
+describe Config::Mdast do
+  it_behaves_like "a service based linter" do
+    let(:raw_config) do
+      <<-EOS.strip_heredoc
+        {
+          "heading-style": "setext"
+        }
+      EOS
+    end
+
+    let(:hound_config_content) do
+      {
+        "mdast" => {
+          "enabled" => true,
+          "config_file" => "config/.mdastrc",
+        },
+      }
+    end
+  end
+end

--- a/spec/models/linter/mdast_spec.rb
+++ b/spec/models/linter/mdast_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+describe Linter::Mdast do
+  describe ".can_lint?" do
+    context "given an .md file" do
+      it "returns true" do
+        result = Linter::Mdast.can_lint?("foo.md")
+
+        expect(result).to eq true
+      end
+    end
+
+    context "given an .markdown file" do
+      it "returns true" do
+        result = Linter::Mdast.can_lint?("foo.markdown")
+
+        expect(result).to eq true
+      end
+    end
+
+    context "given a non-markdown file" do
+      it "returns false" do
+        result = Linter::Mdast.can_lint?("foo.txt")
+
+        expect(result).to eq false
+      end
+    end
+  end
+
+  describe "#file_review" do
+    it "returns a saved and incomplete file review" do
+      commit_file = build_commit_file(filename: "lib/a.md")
+      linter = build_linter
+
+      result = linter.file_review(commit_file)
+
+      expect(result).to be_persisted
+      expect(result).not_to be_completed
+    end
+
+    it "schedules a review job" do
+      build = build(:build, commit_sha: "foo", pull_request_number: 123)
+      stub_mdast_config(content: "config")
+      commit_file = build_commit_file(filename: "lib/a.md")
+      allow(Resque).to receive(:enqueue)
+      linter = build_linter(build)
+
+      linter.file_review(commit_file)
+
+      expect(Resque).to have_received(:enqueue).with(
+        MdastReviewJob,
+        filename: commit_file.filename,
+        commit_sha: build.commit_sha,
+        pull_request_number: build.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
+        config: "config",
+      )
+    end
+  end
+
+  def stub_mdast_config(content: "")
+    stubbed_mdast_config = double("MdastConfig", content: content)
+    allow(Config::Mdast).to receive(:new).and_return(stubbed_mdast_config)
+
+    stubbed_mdast_config
+  end
+
+  def raw_hound_config
+    <<-EOS.strip_heredoc
+      mdast:
+        enabled: true
+        config_file: config/.mdastrc
+    EOS
+  end
+end

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -265,6 +265,17 @@ describe StyleChecker do
       end
     end
 
+    context "for a Markdown file" do
+      it "does not immediately return violations" do
+        commit_file = stub_commit_file("test.md", "# Hello!")
+        pull_request = stub_pull_request(commit_files: [commit_file])
+
+        violation_messages = pull_request_violations(pull_request)
+
+        expect(violation_messages).to be_empty
+      end
+    end
+
     context "with unsupported file type" do
       it "uses the unsupported linter" do
         commit_file = stub_commit_file(


### PR DESCRIPTION
Adds beta support for Markdown linting via [hound-mdast]. under the `mdast` config key.

[hound-mdast]: https://github.com/thoughtbot/hound-mdast/

To enable:

```
mdast:
  enabled: true
  config_file: .mdastrc
```

https://trello.com/c/9jD9GdL9