### PR TITLE
Add beta support for JSCS linting via hound-jscs

### DIFF
--- a/app/jobs/jscs_review_job.rb
+++ b/app/jobs/jscs_review_job.rb
@@ -1,0 +1,3 @@
+class JscsReviewJob
+  @queue = :jscs_review
+end

--- a/app/models/config/jscs.rb
+++ b/app/models/config/jscs.rb
@@ -1,0 +1,9 @@
+module Config
+  class Jscs < Base
+    private
+
+    def parse(file_content)
+      Parser.raw(file_content)
+    end
+  end
+end

--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -2,6 +2,7 @@ class HoundConfig
   CONFIG_FILE = ".hound.yml"
   BETA_LANGUAGES = %w(
     eslint
+    jscs
     python
     swift
   )

--- a/app/models/linter/collection.rb
+++ b/app/models/linter/collection.rb
@@ -6,6 +6,7 @@ module Linter
       Linter::Go,
       Linter::Haml,
       Linter::JavaScript,
+      Linter::Jscs,
       Linter::Python,
       Linter::Ruby,
       Linter::Scss,

--- a/app/models/linter/jscs.rb
+++ b/app/models/linter/jscs.rb
@@ -1,0 +1,5 @@
+module Linter
+  class Jscs < Base
+    FILE_REGEXP = /.+((?<!\.coffee)\.js|(?:\.es6|\.es6\.js))\z/
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -2,12 +2,13 @@
 
 # Add new inflection rules using the following format
 # (all these examples are active by default):
-# ActiveSupport::Inflector.inflections do |inflect|
+ActiveSupport::Inflector.inflections do |inflect|
 #   inflect.plural /^(ox)$/i, '\1en'
 #   inflect.singular /^(ox)en/i, '\1'
 #   inflect.irregular 'person', 'people'
 #   inflect.uncountable %w( fish sheep )
-# end
+  inflect.uncountable %w(jscs)
+end
 #
 # These inflection rules are supported but not enabled by default:
 # ActiveSupport::Inflector.inflections do |inflect|

--- a/spec/models/config/jscs_spec.rb
+++ b/spec/models/config/jscs_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+require "app/models/config/base"
+require "app/models/config/jscs"
+
+describe Config::Jscs do
+  it_behaves_like "a service based linter" do
+    let(:raw_config) do
+      <<-EOS.strip_heredoc
+        { "disallowKeywordsInComments": true }
+      EOS
+    end
+
+    let(:hound_config_content) do
+      {
+        "jscs" => {
+          "enabled" => true,
+          "config_file" => "config/.jscsrc",
+        },
+      }
+    end
+  end
+end

--- a/spec/models/linter/jscs_spec.rb
+++ b/spec/models/linter/jscs_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+describe Linter::Jscs do
+  describe ".can_lint?" do
+    context "given an .es6 file" do
+      it "returns true" do
+        result = Linter::Jscs.can_lint?("foo.es6")
+
+        expect(result).to eq true
+      end
+    end
+
+    context "given an .es6.js file" do
+      it "returns true" do
+        result = Linter::Jscs.can_lint?("foo.es6.js")
+
+        expect(result).to eq true
+      end
+    end
+
+    context "given a .js file" do
+      it "returns true" do
+        result = Linter::Jscs.can_lint?("foo.js")
+
+        expect(result).to eq true
+      end
+    end
+
+    context "given a non-jscs file" do
+      it "returns false" do
+        result = Linter::Jscs.can_lint?("foo.coffee.js")
+
+        expect(result).to eq false
+      end
+    end
+  end
+
+  describe "#file_review" do
+    it "returns a saved and incomplete file review" do
+      commit_file = build_commit_file(filename: "lib/a.js")
+      linter = build_linter
+
+      result = linter.file_review(commit_file)
+
+      expect(result).to be_persisted
+      expect(result).not_to be_completed
+    end
+
+    it "schedules a review job" do
+      build = build(:build, commit_sha: "foo", pull_request_number: 123)
+      stub_jscs_config(content: "config")
+      commit_file = build_commit_file(filename: "lib/a.js")
+      allow(Resque).to receive(:enqueue)
+      linter = build_linter(build)
+
+      linter.file_review(commit_file)
+
+      expect(Resque).to have_received(:enqueue).with(
+        JscsReviewJob,
+        filename: commit_file.filename,
+        commit_sha: build.commit_sha,
+        pull_request_number: build.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
+        config: "config",
+      )
+    end
+  end
+
+  def stub_jscs_config(content: "")
+    stubbed_jscs_config = double("JscsConfig", content: content)
+    allow(Config::Jscs).to receive(:new).and_return(stubbed_jscs_config)
+
+    stubbed_jscs_config
+  end
+
+  def raw_hound_config
+    <<-EOS.strip_heredoc
+      jscs:
+        enabled: true
+        config_file: config/.jscsrc
+    EOS
+  end
+end

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -142,6 +142,30 @@ describe StyleChecker do
         end
       end
 
+      context "when JSCS is enabled" do
+        it "does not immediately return violations" do
+          commit_file = stub_commit_file("test.js", "var test = 'test'")
+          head_commit = stub_head_commit(
+            HoundConfig::CONFIG_FILE => <<-EOS.strip_heredoc
+              jscs:
+                enabled: true
+                config_file: config/.jscsrc
+            EOS
+          )
+          pull_request = stub_pull_request(
+            commit_files: [commit_file],
+            head_commit: head_commit,
+          )
+
+          violation_messages = pull_request_violations(pull_request)
+
+          expect(violation_messages).to eq [
+            "Missing semicolon.",
+            "'test' is defined but never used.",
+          ]
+        end
+      end
+
       context "when eslint is disabled or unconfigured" do
         context "with style violations" do
           it "returns violations" do


### PR DESCRIPTION
Enable JSCS linting by setting the `jscs` config key to `true`.

[hound-jscs]: https://github.com/thoughtbot/hound-jscs/

To enable:

```
jscs:
  enabled: true
  config_file: .jscsrc
```

https://trello.com/c/M6hL2wKC