### PR TITLE
Don't merge empty Rubocop configurations

### DIFF
--- a/app/models/config/ruby.rb
+++ b/app/models/config/ruby.rb
@@ -5,6 +5,7 @@ module Config
         hound_config.content
       else
         result = super
+        ensure_correct_type(result)
         parse_inherit_from(result)
       end
     end
@@ -12,9 +13,7 @@ module Config
     private
 
     def parse(file_content)
-      result = Parser.yaml(file_content)
-
-      ensure_correct_type(result)
+      Parser.yaml(file_content)
     end
 
     def parse_inherit_from(config)
@@ -22,7 +21,7 @@ module Config
 
       inherited_config = inherit_from.reduce({}) do |result, ancestor_file_path|
         raw_ancestor_config = commit.file_content(ancestor_file_path)
-        ancestor_config = parse(raw_ancestor_config)
+        ancestor_config = parse(raw_ancestor_config) || {}
         result.merge(ancestor_config)
       end
 

--- a/spec/models/config/ruby_spec.rb
+++ b/spec/models/config/ruby_spec.rb
@@ -62,6 +62,28 @@ describe Config::Ruby do
         "Style/Encoding" => { "Enabled" => true },
       )
     end
+
+    context "with an empty `inherit_from`" do
+      it "returns the merged configuration using `inherit_from`" do
+        rubocop = <<-EOS.strip_heredoc
+          inherit_from: config/rubocop_todo.yml
+          Style/Encoding:
+            Enabled: true
+        EOS
+        rubocop_todo = <<-EOS.strip_heredoc
+          # this is an empty file
+        EOS
+        commit = stubbed_commit(
+          "config/rubocop.yml" => rubocop,
+          "config/rubocop_todo.yml" => rubocop_todo,
+        )
+        config = build_config(commit)
+
+        expect(config.content).to eq(
+          "Style/Encoding" => { "Enabled" => true },
+        )
+      end
+    end
   end
 
   context "when the given content is invalid" do


### PR DESCRIPTION
This is a behavior Rubocop has, Hound should not be any different.

Changes:

- Refactor: Move `ensure_correct_type` to `Config::MY_CONFIG#content`.
  The `#parse` method should not do more than just parsing.

Resolves #983