### PR TITLE
Add beta support for `JSHint` linting via `hound-jshint`

### DIFF
--- a/app/jobs/jshint_review_job.rb
+++ b/app/jobs/jshint_review_job.rb
@@ -1,0 +1,3 @@
+class JshintReviewJob
+  @queue = :jshint_review
+end

--- a/app/models/config/jshint.rb
+++ b/app/models/config/jshint.rb
@@ -1,0 +1,9 @@
+module Config
+  class Jshint < Base
+    private
+
+    def parse(file_content)
+      Parser.raw(file_content)
+    end
+  end
+end

--- a/app/models/linter/collection.rb
+++ b/app/models/linter/collection.rb
@@ -7,6 +7,7 @@ module Linter
       Linter::Haml,
       Linter::JavaScript,
       Linter::Jscs,
+      Linter::Jshint,
       Linter::Mdast,
       Linter::Python,
       Linter::Ruby,

--- a/app/models/linter/jshint.rb
+++ b/app/models/linter/jshint.rb
@@ -1,0 +1,5 @@
+module Linter
+  class Jshint < Base
+    FILE_REGEXP = /.+\.js\z/
+  end
+end

--- a/spec/models/config/jshint_spec.rb
+++ b/spec/models/config/jshint_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+require "app/models/config/base"
+require "app/models/config/jshint"
+
+describe Config::Jshint do
+  it_behaves_like "a service based linter" do
+    let(:raw_config) do
+      <<-EOS.strip_heredoc
+        {
+          "maxlen": 80,
+        }
+      EOS
+    end
+
+    let(:hound_config_content) do
+      {
+        "jshint" => {
+          "enabled" => true,
+          "config_file" => "config/.jshintrc",
+        },
+      }
+    end
+  end
+end

--- a/spec/models/linter/jshint_spec.rb
+++ b/spec/models/linter/jshint_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+describe Linter::Jshint do
+  describe ".can_lint?" do
+    context "given a .js file" do
+      it "returns true" do
+        result = Linter::Jshint.can_lint?("foo.js")
+
+        expect(result).to eq true
+      end
+    end
+
+    context "given a .js.coffee file" do
+      it "returns false" do
+        result = Linter::Jshint.can_lint?("foo.js.coffee")
+
+        expect(result).to eq false
+      end
+    end
+
+    context "given a non-js file" do
+      it "returns false" do
+        result = Linter::Jshint.can_lint?("foo.rb")
+
+        expect(result).to eq false
+      end
+    end
+  end
+
+  describe "#file_review" do
+    it "returns a saved and incomplete file review" do
+      commit_file = build_commit_file(filename: "lib/a.js")
+      linter = build_linter
+
+      result = linter.file_review(commit_file)
+
+      expect(result).to be_persisted
+      expect(result).not_to be_completed
+    end
+
+    it "schedules a review job" do
+      build = build(:build, commit_sha: "foo", pull_request_number: 123)
+      stub_eslint_config(content: "config")
+      commit_file = build_commit_file(filename: "lib/a.js")
+      allow(Resque).to receive(:enqueue)
+      linter = build_linter(build)
+
+      linter.file_review(commit_file)
+
+      expect(Resque).to have_received(:enqueue).with(
+        JshintReviewJob,
+        filename: commit_file.filename,
+        commit_sha: build.commit_sha,
+        pull_request_number: build.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
+        config: "config",
+      )
+    end
+  end
+
+  def stub_eslint_config(content: "")
+    stubbed_eslint_config = double("JshintConfig", content: content)
+    allow(Config::Jshint).to receive(:new).and_return(stubbed_eslint_config)
+
+    stubbed_eslint_config
+  end
+
+  def raw_hound_config
+    <<-EOS.strip_heredoc
+      eslint:
+        enabled: true
+        config_file: config/.jshintrc
+    EOS
+  end
+end

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -166,7 +166,30 @@ describe StyleChecker do
         end
       end
 
-      context "when eslint is disabled or unconfigured" do
+      context "when JSHint is enabled" do
+        it "does not immediately return violations" do
+          commit_file = stub_commit_file("test.js", "var test = 'test'")
+          head_commit = stub_head_commit(
+            HoundConfig::CONFIG_FILE => <<-EOS.strip_heredoc
+              jshint:
+                enabled: true
+                config_file: config/.jshintrc
+              javascript:
+                enabled: false
+            EOS
+          )
+          pull_request = stub_pull_request(
+            commit_files: [commit_file],
+            head_commit: head_commit,
+          )
+
+          violation_messages = pull_request_violations(pull_request)
+
+          expect(violation_messages).to eq []
+        end
+      end
+
+      context "when a specifc linter is disabled or unconfigured" do
         context "with style violations" do
           it "returns violations" do
             commit_file = stub_commit_file("test.js", "var test = 'test'")


### PR DESCRIPTION
Enable JSHint linting backed by [hound-jshint] by setting the `jshint`
config key to `true`.

[hound-jshint]: https://github.com/thoughtbot/hound-jshint/

To enable:

```
jshint:
  enabled: true
  config_file: .jshintrc

javascript:
  enabled: false
```

The current JavaScript linter is already backed by `JSHint`, so to use
the newer version we must disable the old one.

https://trello.com/c/Xk8StXIm