### PR TITLE
Drop support for `*.coffee.js` files

### DIFF
--- a/app/models/linter/eslint.rb
+++ b/app/models/linter/eslint.rb
@@ -1,5 +1,5 @@
 module Linter
   class Eslint < Base
-    FILE_REGEXP = /.+((?<!\.coffee)\.js|(?:\.es6|\.es6\.js))\z/
+    FILE_REGEXP = /.+(\.js|\.es6|\.es6\.js)\z/
   end
 end

--- a/app/models/linter/java_script.rb
+++ b/app/models/linter/java_script.rb
@@ -1,7 +1,7 @@
 module Linter
   class JavaScript < Base
     DEFAULT_CONFIG_FILENAME = "javascript.json"
-    FILE_REGEXP = /.+(?<!\.coffee)\.js\z/
+    FILE_REGEXP = /.+\.js\z/
 
     def file_review(commit_file)
       FileReview.create!(filename: commit_file.filename) do |file_review|

--- a/app/models/linter/jscs.rb
+++ b/app/models/linter/jscs.rb
@@ -1,5 +1,5 @@
 module Linter
   class Jscs < Base
-    FILE_REGEXP = /.+((?<!\.coffee)\.js|(?:\.es6|\.es6\.js))\z/
+    FILE_REGEXP = /.+(\.js|\.es6|\.es6\.js)\z/
   end
 end

--- a/spec/models/linter/eslint_spec.rb
+++ b/spec/models/linter/eslint_spec.rb
@@ -28,7 +28,7 @@ describe Linter::Eslint do
 
     context "given a non-eslint file" do
       it "returns false" do
-        result = Linter::Eslint.can_lint?("foo.coffee.js")
+        result = Linter::Eslint.can_lint?("foo.js.coffee")
 
         expect(result).to eq false
       end

--- a/spec/models/linter/java_script_spec.rb
+++ b/spec/models/linter/java_script_spec.rb
@@ -12,17 +12,9 @@ describe Linter::JavaScript do
       end
     end
 
-    context "given a .coffee.js file" do
-      it "returns false" do
-        result = Linter::JavaScript.can_lint?("foo.coffee.js")
-
-        expect(result).to eq false
-      end
-    end
-
     context "given a non-js file" do
       it "returns false" do
-        result = Linter::JavaScript.can_lint?("foo.rb")
+        result = Linter::JavaScript.can_lint?("foo.js.coffee")
 
         expect(result).to eq false
       end

--- a/spec/models/linter/jscs_spec.rb
+++ b/spec/models/linter/jscs_spec.rb
@@ -28,7 +28,7 @@ describe Linter::Jscs do
 
     context "given a non-jscs file" do
       it "returns false" do
-        result = Linter::Jscs.can_lint?("foo.coffee.js")
+        result = Linter::Jscs.can_lint?("foo.js.coffee")
 
         expect(result).to eq false
       end

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -72,7 +72,7 @@ describe StyleChecker do
 
     context "for a CoffeeScript file" do
       it "is processed with a coffee.js extension" do
-        commit_file = stub_commit_file("test.coffee.js", "foo ->")
+        commit_file = stub_commit_file("test.js.coffee", "foo ->")
         pull_request = stub_pull_request(commit_files: [commit_file])
 
         violation_messages = pull_request_violations(pull_request)


### PR DESCRIPTION
They should be named `*.js.coffee`