### PR TITLE
Support disabling cops with inline comments

### DIFF
--- a/app/models/linter/ruby.rb
+++ b/app/models/linter/ruby.rb
@@ -16,7 +16,7 @@ module Linter
 
     def perform_file_review(commit_file)
       FileReview.create!(filename: commit_file.filename) do |file_review|
-        team.inspect_file(parsed_source(commit_file)).each do |violation|
+        permitted_rubocop_offenses(commit_file).each do |violation|
           line = commit_file.line_at(violation.line)
           file_review.build_violation(line, violation.message)
         end
@@ -24,6 +24,10 @@ module Linter
         file_review.build = build
         file_review.complete
       end
+    end
+
+    def permitted_rubocop_offenses(commit_file)
+      team.inspect_file(parsed_source(commit_file)).reject(&:disabled?)
     end
 
     def team

--- a/spec/models/linter/ruby_spec.rb
+++ b/spec/models/linter/ruby_spec.rb
@@ -580,6 +580,26 @@ describe Linter::Ruby do
       end
     end
 
+    context "with inline configuration" do
+      context "disabling a cop" do
+        it "does not return a violation" do
+          config = stub_ruby_config(
+            "StringLiterals" => {
+              "EnforcedStyle" => "double_quotes",
+            },
+          )
+          code = <<-CODE.strip_heredoc
+            # rubocop:disable Style/StringLiterals
+            'hello world'
+          CODE
+
+          violations = violations_in(code, config: config)
+
+          expect(violations).to be_empty
+        end
+      end
+    end
+
     context "thoughtbot organization PR" do
       it "uses the thoughtbot configuration for rubocop" do
         spy_on_rubocop_team


### PR DESCRIPTION
Rubocop supports [disabling cops with inline comments][inline-disable],
but Hound does not. This is so because Rubocop still reports the
violations internally, then chooses to ignore those that have been
disabled via comment. Hound is not using the parts of Rubocop that do
this, resulting in comments on the violations. Fortunately there is a
`Offense#disabled?` method which returns true for violations disabled
by comments.

Fixes #995

[inline-disable]: https://github.com/bbatsov/rubocop/tree/2195f366bb47d8d8794943c247c00ba55213900b#disabling-cops-within-source-code