### PR TITLE
Don't fail on violations

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,2 @@
-fail_on_violations: true
-
 ruby:
   config_file: .ruby-style.yml


### PR DESCRIPTION
This was enabled on Hound itself in order to vet the feature before
releasing it to the world. The Hound team treats violations as
suggestions and sometimes decides to ignore them. In these cases,
failing the PR does not make sense. The feature has been working well
for quite awhile now, so it can be disabled here.

Am I correct in thinking no one else wants this enabled? @thoughtbot/hound 