### PR TITLE
Display message for repos that can't be activated

### DIFF
--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -8,10 +8,7 @@ class ReposController < ApplicationController
           current_user.repos.clear
         end
 
-        repos = current_user.
-          repos.
-          order(active: :desc, full_github_name: :asc).
-          includes(:subscription)
+        repos = current_user.repos_by_activation_ability.includes(:subscription)
 
         render json: repos
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,6 +54,12 @@ class User < ActiveRecord::Base
     @payment_gateway_subscriptions ||= payment_gateway_customer.subscriptions
   end
 
+  def repos_by_activation_ability
+    repos.
+      order("memberships.admin DESC").
+      order(active: :desc, full_github_name: :asc)
+  end
+
   private
 
   def crypt

--- a/app/serializers/repo_serializer.rb
+++ b/app/serializers/repo_serializer.rb
@@ -1,5 +1,6 @@
 class RepoSerializer < ActiveModel::Serializer
   attributes(
+    :admin,
     :active,
     :full_github_name,
     :full_plan_name,
@@ -17,5 +18,9 @@ class RepoSerializer < ActiveModel::Serializer
 
   def full_plan_name
     "#{object.plan_type} repo".titleize
+  end
+
+  def admin
+    object.memberships.find_by(user_id: current_user.id).admin?
   end
 end

--- a/app/services/repo_synchronization.rb
+++ b/app/services/repo_synchronization.rb
@@ -9,7 +9,11 @@ class RepoSynchronization
     Repo.transaction do
       repos.each do |resource|
         attributes = repo_attributes(resource.to_hash)
-        user.repos << Repo.find_or_create_with(attributes)
+        repo = Repo.find_or_create_with(attributes)
+        user.memberships.create!(
+          repo: repo,
+          admin: resource.to_hash[:permissions][:admin],
+        )
       end
     end
   end

--- a/app/views/templates/repo.haml
+++ b/app/views/templates/repo.haml
@@ -1,5 +1,9 @@
 .repo-name
   %span {{ repo.full_github_name }}
-.activation-toggle{'ng-class' => '{private: repo.private}'}
+.activation-toggle{ "ng-class": "{private: repo.private}" }
   %span.private-label Private - $12
-  %button.toggle{'ng-click' => 'toggle()', 'ng-disabled' => 'processing'}
+  %button.toggle{ "ng-click": "toggle()",
+    "ng-disabled": "processing",
+    "ng-if": "repo.admin" }
+  .restricted{ "ng-if": "!repo.admin" }
+    = t("cannot_activate_repo")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
   active_repos: "Active repos"
   search_placeholder: "Search by repo"
   pending_status: "Hound is busy reviewing changes..."
+  cannot_activate_repo: "Only repo admins can activate"
   complete_status:
     zero: "No violations found. Woof!"
     one: "1 violation found."

--- a/db/migrate/20151204174817_add_admin_to_memberships.rb
+++ b/db/migrate/20151204174817_add_admin_to_memberships.rb
@@ -1,0 +1,5 @@
+class AddAdminToMemberships < ActiveRecord::Migration
+  def change
+    add_column :memberships, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,10 +57,11 @@ ActiveRecord::Schema.define(version: 20151216235118) do
   add_index "file_reviews", ["build_id"], name: "index_file_reviews_on_build_id", using: :btree
 
   create_table "memberships", force: :cascade do |t|
-    t.integer  "user_id",    null: false
-    t.integer  "repo_id",    null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "user_id",                    null: false
+    t.integer  "repo_id",                    null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.boolean  "admin",      default: false, null: false
   end
 
   add_index "memberships", ["repo_id"], name: "index_memberships_on_repo_id", using: :btree

--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -22,8 +22,7 @@ class GithubApi
   end
 
   def repos
-    all_repos = client.repos(nil, accept: PREVIEW_MEDIA_TYPE)
-    authorized_repos(all_repos)
+    client.repos(accept: PREVIEW_MEDIA_TYPE)
   end
 
   def repo(repo_name)

--- a/spec/controllers/activations_controller_spec.rb
+++ b/spec/controllers/activations_controller_spec.rb
@@ -8,11 +8,16 @@ describe ActivationsController, "#create" do
       activator = double("RepoActivator", activate: true, errors: [])
       allow(RepoActivator).to receive(:new).and_return(activator)
       stub_sign_in(membership.user)
+      expected_repo_json = RepoSerializer.new(
+        repo,
+        scope_name: :current_user,
+        scope: membership.user,
+      ).to_json
 
       post :create, repo_id: repo.id, format: :json
 
-      expect(response.code).to eq "201"
-      expect(response.body).to eq RepoSerializer.new(repo).to_json
+      expect(response).to have_http_status(:created)
+      expect(response.body).to eq expected_repo_json
       expect(activator).to have_received(:activate)
       expect(RepoActivator).to have_received(:new).
         with(repo: repo, github_token: membership.user.token)

--- a/spec/controllers/deactivations_controller_spec.rb
+++ b/spec/controllers/deactivations_controller_spec.rb
@@ -8,11 +8,16 @@ describe DeactivationsController, "#create" do
       activator = double(:repo_activator, deactivate: true)
       allow(RepoActivator).to receive(:new).and_return(activator)
       stub_sign_in(membership.user)
+      expected_repo_json = RepoSerializer.new(
+        repo,
+        scope_name: :current_user,
+        scope: membership.user,
+      ).to_json
 
       post :create, repo_id: repo.id, format: :json
 
-      expect(response.code).to eq "201"
-      expect(response.body).to eq RepoSerializer.new(repo).to_json
+      expect(response).to have_http_status(:created)
+      expect(response.body).to eq expected_repo_json
       expect(activator).to have_received(:deactivate)
       expect(RepoActivator).to have_received(:new).
         with(repo: repo, github_token: membership.user.token)

--- a/spec/lib/github_api_spec.rb
+++ b/spec/lib/github_api_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "config/initializers/constants"
 require "attr_extras"
 require "lib/github_api"
 require "json"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,7 +6,7 @@ describe User do
   it { should validate_presence_of :github_username }
   it { should have_many(:memberships).dependent(:destroy) }
 
-  describe ".subscribed_repos" do
+  describe "#subscribed_repos" do
     it "returns subscribed repos" do
       user = create(:user)
       _unsubscribed_repo = create(:repo, users: [user])
@@ -16,6 +16,22 @@ describe User do
       repos = user.subscribed_repos
 
       expect(repos).to eq [active_subscription.repo]
+    end
+  end
+
+  describe "#repos_by_activation_ability" do
+    it "orders active repos with admin permissions first then by name" do
+      repo1 = create(:repo, name: "foo", active: false)
+      repo2 = create(:repo, name: "bar", active: false)
+      repo3 = create(:repo, name: "baz", active: true)
+      user = create(:user)
+      create(:membership, user: user, repo: repo1, admin: false)
+      create(:membership, user: user, repo: repo2, admin: true)
+      create(:membership, user: user, repo: repo3, admin: true)
+
+      results = user.repos_by_activation_ability
+
+      expect(results).to eq [repo3, repo2, repo1]
     end
   end
 

--- a/spec/serializers/repo_serializer_spec.rb
+++ b/spec/serializers/repo_serializer_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe RepoSerializer do
+  describe "#admin" do
+    context "when current user is an admin of the repo" do
+      it "returns true" do
+        membership = create(:membership, admin: true)
+        serializer = RepoSerializer.new(
+          membership.repo,
+          scope: membership.user,
+          scope_name: :current_user,
+        )
+
+        expect(serializer.admin).to eq true
+      end
+    end
+
+    context "when current user is not an admin of the repo" do
+      it "returns false" do
+        membership = create(:membership, admin: false)
+        serializer = RepoSerializer.new(
+          membership.repo,
+          scope: membership.user,
+          scope_name: :current_user,
+        )
+
+        expect(serializer.admin).to eq false
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/github_repos_response_for_jimtom_page2.json
+++ b/spec/support/fixtures/github_repos_response_for_jimtom_page2.json
@@ -32,6 +32,6 @@
   "created_at": "2011-01-26T19:01:12Z",
   "updated_at": "2011-01-26T19:14:43Z",
   "permissions": {
-    "admin": true
+    "admin": false
   }
 }]


### PR DESCRIPTION
Why:

Users should be able to see the repos they have access to on GitHub,
but cannot activate due to not having enough access (they are not an
admin). We should communicate in the UI that the repo cannot be
activated.

How:

* Store a flag on membership whether a user is an admin of the repo
* Display all of user's repos on the repos list
* Implement `RepoSerializer#admin?` that uses `current_user`.
* Add a message to each repo that cannot be activated stating why.

https://trello.com/c/XVDAV6uf
<img width="1129" alt="screenshot 2015-12-04 17 59 18" src="https://cloud.githubusercontent.com/assets/116327/11605297/c68a2db8-9ab0-11e5-91e0-d5cecbfbe0bd.png">
