### PR TITLE
Fix default Python config.

### DIFF
--- a/app/models/config/base.rb
+++ b/app/models/config/base.rb
@@ -14,8 +14,6 @@ module Config
 
     private
 
-    DEFAULT_CONTENT = "{}"
-
     attr_implement :parse, [:file_content]
 
     def ensure_correct_type(result)
@@ -38,7 +36,7 @@ module Config
           commit.file_content(file_path)
         end
       else
-        DEFAULT_CONTENT
+        default_content
       end
     end
 
@@ -54,6 +52,10 @@ module Config
 
     def url?
       URI::regexp(%w(http https)).match(file_path)
+    end
+
+    def default_content
+      "{}"
     end
 
     def raise_parse_error(message)

--- a/app/models/config/python.rb
+++ b/app/models/config/python.rb
@@ -5,5 +5,9 @@ module Config
     def parse(file_content)
       Parser.raw(file_content)
     end
+
+    def default_content
+      ""
+    end
   end
 end

--- a/spec/models/config/python_spec.rb
+++ b/spec/models/config/python_spec.rb
@@ -20,4 +20,19 @@ describe Config::Python do
       }
     end
   end
+
+  describe "#content" do
+    context "when there is no config content for the given linter" do
+      it "returns the empty string" do
+        hound_config = double(
+          "HoundConfig",
+          commit: double("Commit"),
+          content: {},
+        )
+        config = Config::Python.new(hound_config, "unconfigured_linter")
+
+        expect(config.content).to eq ""
+      end
+    end
+  end
 end


### PR DESCRIPTION
The Python linter we're using (Flake8) expects a non-JSON configuration format, and passing `{}` to it causes an exception.

Since constants in Ruby aren't inherited in the same way as methods, we need to move the default to a method in order to override it.