### PR TITLE
Cache number of violations per build

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -54,10 +54,7 @@ class Repo < ActiveRecord::Base
   end
 
   def total_violations
-    Violation.
-      joins(:file_review).
-      where(file_reviews: { build_id: build_ids }).
-      count
+    builds.sum(:violations_count)
   end
 
   private

--- a/app/models/violation.rb
+++ b/app/models/violation.rb
@@ -7,11 +7,17 @@ class Violation < ActiveRecord::Base
   delegate :count, to: :messages, prefix: true
   delegate :filename, to: :file_review
 
+  after_create :increment_build_violations_count
+
   def add_message(message)
     self[:messages] << message
   end
 
   def messages
     self[:messages].uniq
+  end
+
+  def increment_build_violations_count
+    file_review.build.increment!(:violations_count, messages_count)
   end
 end

--- a/db/migrate/20151216235118_add_violations_count_to_builds.rb
+++ b/db/migrate/20151216235118_add_violations_count_to_builds.rb
@@ -1,0 +1,5 @@
+class AddViolationsCountToBuilds < ActiveRecord::Migration
+  def change
+    add_column :builds, :violations_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151019123908) do
+ActiveRecord::Schema.define(version: 20151216235118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 20151019123908) do
     t.string   "commit_sha",          limit: 255
     t.text     "payload"
     t.integer  "user_id"
+    t.integer  "violations_count"
   end
 
   add_index "builds", ["repo_id"], name: "index_builds_on_repo_id", using: :btree

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -77,9 +77,9 @@ feature "Account" do
   scenario "user sees paid repo usage" do
     user = create(:user)
     paid_repo = create(:repo, users: [user])
-    paid_repo.builds << create_failed_build
-    paid_repo.builds << create_failed_build
-    paid_repo.builds << create(:build)
+    create_failed_build(paid_repo)
+    create_failed_build(paid_repo)
+    create(:build, repo: paid_repo)
     create(:subscription, repo: paid_repo, user: user)
 
     sign_in_as(user)
@@ -92,9 +92,10 @@ feature "Account" do
 
   private
 
-  def create_failed_build
-    file_review = build(:file_review, violations: build_list(:violation, 1))
-    create(:build, file_reviews: [file_review])
+  def create_failed_build(repo)
+    build = create(:build, repo: repo)
+    file_review = create(:file_review, build: build)
+    create(:violation, file_review: file_review)
   end
 
   def stub_customer_find_request_with_subscriptions(customer_id, subscriptions)

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -154,4 +154,14 @@ describe Repo do
       end
     end
   end
+
+  describe "#total_violations" do
+    it "returns a sum of all the violations for the repo" do
+      repo = create(:repo)
+      create(:build, violations_count: 5, repo: repo)
+      create(:build, violations_count: 3, repo: repo)
+
+      expect(repo.total_violations).to eq 8
+    end
+  end
 end

--- a/spec/models/violation_spec.rb
+++ b/spec/models/violation_spec.rb
@@ -34,4 +34,15 @@ describe Violation do
       expect(violation.messages_count).to eq 2
     end
   end
+
+  describe "after create callbacks" do
+    it "increments the build's violations count by the number of messages" do
+      violation = build(:violation, messages: ["foo", "bar"])
+
+      violation.save
+
+      violation.reload
+      expect(violation.file_review.build.violations_count).to eq 2
+    end
+  end
 end


### PR DESCRIPTION
We display the number of violations per repo on the account page (for
paid repos). That was causing timeouts, since repos can have many builds
and sql `IN` uses a loop for large arrays.
To speed things up, we can cache the number of violations (messages) per
build.