### PR TITLE
View each failure in specs with multiple expects

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,4 +13,8 @@ RSpec.configure do |config|
   config.include GithubApiHelper
   config.include StripeApiHelper
   WebMock.disable_net_connect!(allow_localhost: true)
+
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true
+  end
 end


### PR DESCRIPTION
When we write tests with multiple expects, only the first failure is
reported when the test fails. `aggregate_failures` allows us to see
any or all the failures that happened in a specific test.

https://www.relishapp.com/rspec/rspec-core/docs/expectation-framework-integration/aggregating-failures