### PR TITLE
Set admin flag on existing memberships to true

### DIFF
--- a/db/migrate/20151204174817_add_admin_to_memberships.rb
+++ b/db/migrate/20151204174817_add_admin_to_memberships.rb
@@ -1,5 +1,14 @@
 class AddAdminToMemberships < ActiveRecord::Migration
-  def change
-    add_column :memberships, :admin, :boolean, default: false, null: false
+  def up
+    add_column :memberships, :admin, :boolean
+
+    execute "UPDATE memberships SET admin=true"
+
+    change_column_default :memberships, :admin, false
+    change_column_null :memberships, :admin, false
+  end
+
+  def down
+    remove_column :memberships, :admin
   end
 end


### PR DESCRIPTION
All the existing memberships should have admin status, since we only
added memberships if users were admins of the repos.
Thus, we should preserve that state, otherwise all of the current repos
would say that they require admin permissions, until users re-sync.