### PR TITLE
Report invalid configuration files per linter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,9 +182,8 @@ If the given `config` is invalid, the invalid file should be posted to the
 outbound `ReportInvalidConfigJob` queue:
 
 * `commit_sha` - The git commit SHA of the code snippet. This is provided by the
-  inbound queue..
-* `filename` - The name of the source file for the code snippet. This is
-  provided by the inbound queue.
+  inbound queue.
+* `linter_name` - The name of the linter that received an invalid config file.
 * `pull_request_number` - The GitHub pull request number. This is provided by
   the inbound queue.
 

--- a/app/jobs/report_invalid_config_job.rb
+++ b/app/jobs/report_invalid_config_job.rb
@@ -5,7 +5,7 @@ class ReportInvalidConfigJob
     ReportInvalidConfig.run(
       pull_request_number: attributes.fetch("pull_request_number"),
       commit_sha: attributes.fetch("commit_sha"),
-      filename: attributes.fetch("filename"),
+      linter_name: attributes.fetch("linter_name"),
     )
   end
 end

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -19,8 +19,8 @@ class CommitStatus
     github.create_error_status(repo_name, sha, message)
   end
 
-  def set_config_error(filename)
-    message = I18n.t(:config_error_status, filename: filename)
+  def set_config_error(linter_name)
+    message = I18n.t(:config_error_status, linter_name: linter_name)
     github.create_error_status(repo_name, sha, message, configuration_url)
   end
 

--- a/app/models/config/base.rb
+++ b/app/models/config/base.rb
@@ -59,7 +59,7 @@ module Config
     end
 
     def raise_parse_error(message)
-      raise Config::ParserError.new(message, filename: file_path)
+      raise Config::ParserError.new(message, linter_name: linter_name)
     end
 
     def file_path

--- a/app/models/config/parser_error.rb
+++ b/app/models/config/parser_error.rb
@@ -1,10 +1,10 @@
 module Config
   class ParserError < StandardError
-    attr_reader :filename
+    attr_reader :linter_name
 
-    def initialize(message, filename:)
+    def initialize(message, linter_name:)
       super(message)
-      @filename = filename
+      @linter_name = linter_name
     end
   end
 end

--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -8,7 +8,7 @@ class BuildRunner
       review_pull_request
     end
   rescue Config::ParserError => exception
-    report_config_file_as_invalid(exception.filename)
+    report_config_file_as_invalid(exception)
   rescue Octokit::Unauthorized
     if users_with_token.any?
       reset_token
@@ -114,11 +114,11 @@ class BuildRunner
     )
   end
 
-  def report_config_file_as_invalid(filename)
+  def report_config_file_as_invalid(exception)
     ReportInvalidConfig.run(
       pull_request_number: payload.pull_request_number,
       commit_sha: payload.head_sha,
-      filename: filename,
+      linter_name: exception.linter_name,
     )
   end
 end

--- a/app/services/report_invalid_config.rb
+++ b/app/services/report_invalid_config.rb
@@ -3,19 +3,19 @@ class ReportInvalidConfig
     new(**args).run
   end
 
-  def initialize(pull_request_number:, commit_sha:, filename:)
+  def initialize(pull_request_number:, commit_sha:, linter_name:)
     @pull_request_number = pull_request_number
     @commit_sha = commit_sha
-    @filename = filename
+    @linter_name = linter_name
   end
 
   def run
-    commit_status.set_config_error(filename)
+    commit_status.set_config_error(linter_name)
   end
 
   private
 
-  attr_reader :pull_request_number, :commit_sha, :filename
+  attr_reader :pull_request_number, :commit_sha, :linter_name
 
   def commit_status
     @commit_status ||= CommitStatus.new(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,7 +13,7 @@ en:
     one: "1 violation found."
     other: "%{count} violations found."
   config_error_status:
-    "Error parsing config file: %{filename}. Click \"details\" for
+    "Error parsing config for: %{linter_name}. Click \"details\" for
     assistance."
   hound_error_status: "We've encountered an error while reviewing your code."
 

--- a/spec/jobs/report_invalid_config_job_spec.rb
+++ b/spec/jobs/report_invalid_config_job_spec.rb
@@ -6,7 +6,7 @@ describe ReportInvalidConfigJob do
       attributes = {
         "pull_request_number" => "42",
         "commit_sha" => "abc123",
-        "filename" => "config/.rubocop.yml",
+        "linter_name" => "ruby",
       }
       allow(ReportInvalidConfig).to receive(:run)
 
@@ -15,7 +15,7 @@ describe ReportInvalidConfigJob do
       expect(ReportInvalidConfig).to have_received(:run).with(
         pull_request_number: attributes["pull_request_number"],
         commit_sha: attributes["commit_sha"],
-        filename: attributes["filename"],
+        linter_name: attributes["linter_name"],
       )
     end
   end

--- a/spec/models/commit_status_spec.rb
+++ b/spec/models/commit_status_spec.rb
@@ -75,19 +75,19 @@ describe CommitStatus do
       repo_name = "thoughtbot/hound"
       sha = "abc123"
       token = "token"
-      filename = "config/.rubocop.yml"
+      linter_name = "ruby"
       commit_status = CommitStatus.new(
         repo_name: repo_name,
         sha: sha,
         token: token,
       )
 
-      commit_status.set_config_error(filename)
+      commit_status.set_config_error(linter_name)
 
       expect(github_api).to have_received(:create_error_status).with(
         repo_name,
         sha,
-        I18n.t(:config_error_status, filename: filename),
+        I18n.t(:config_error_status, linter_name: linter_name),
         configuration_url,
       )
     end

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -199,7 +199,7 @@ describe BuildRunner do
         expect(ReportInvalidConfig).to have_received(:run).with(
           pull_request_number: payload.pull_request_number,
           commit_sha: payload.head_sha,
-          filename: "config/rubocop.yml",
+          linter_name: "ruby",
         )
       end
     end

--- a/spec/services/report_invalid_config_spec.rb
+++ b/spec/services/report_invalid_config_spec.rb
@@ -8,15 +8,16 @@ describe ReportInvalidConfig do
       stubbed_build(repo_name: "thoughtbot/hound")
       pull_request_number = "42"
       commit_sha = "abc123"
-      filename = "config/.rubocop.yml"
+      linter_name = "ruby"
 
       ReportInvalidConfig.run(
         pull_request_number: pull_request_number,
         commit_sha: commit_sha,
-        filename: filename,
+        linter_name: linter_name,
       )
 
-      expect(commit_status).to have_received(:set_config_error).with(filename)
+      expect(commit_status).to have_received(:set_config_error).
+        with(linter_name)
       expect(Build).to have_received(:find_by!).with(
         pull_request_number: pull_request_number,
         commit_sha: commit_sha,


### PR DESCRIPTION
Since the services does not have any concept of a configuration files,
but only the contents of them. It makes more sense to report invalid
configuration files per linter basis instead of per file basis.

Instead of Hound reporting the invalid configuration file by saying:

    Error parsing config file: config/rubocop.yml...

Hound will instead report:

    Error parsing config file for: ruby...

Which means that the linters does not need to know which file they are
parsing.

https://trello.com/c/42U5K0Bs