### PR TITLE
Extract RuboCop configuration merging logic

### DIFF
--- a/app/models/linter/ruby.rb
+++ b/app/models/linter/ruby.rb
@@ -44,26 +44,11 @@ module Linter
     end
 
     def linter_config
-      @linter_config ||= RuboCop::Config.new(merged_config, "")
+      @linter_config ||= config_builder.config
     end
 
-    def merged_config
-      RuboCop::ConfigLoader.merge(default_config, custom_config)
-    rescue TypeError
-      default_config
-    end
-
-    def default_config
-      RuboCop::ConfigLoader.configuration_from_file(default_config_file)
-    end
-
-    def custom_config
-      RuboCop::Config.new(config.content, "").tap do |custom_config|
-        custom_config.add_missing_namespaces
-        custom_config.make_excludes_absolute
-      end
-    rescue NoMethodError
-      RuboCop::Config.new
+    def config_builder
+      RubyConfigBuilder.new(config.content, repository_owner_name)
     end
 
     # This is deprecated in favor of RuboCop's DisplayCopNames option.
@@ -73,13 +58,6 @@ module Linter
         Analytics.new(repository_owner_name).track_show_cop_names
         { debug: true }
       end
-    end
-
-    def default_config_file
-      DefaultConfigFile.new(
-        DEFAULT_CONFIG_FILENAME,
-        repository_owner_name
-      ).path
     end
   end
 end

--- a/app/services/ruby_config_builder.rb
+++ b/app/services/ruby_config_builder.rb
@@ -1,0 +1,39 @@
+class RubyConfigBuilder
+  HOUND_DEFAULTS_FILENAME = "ruby.yml".freeze
+
+  def initialize(overrides = {}, repository_owner_name = nil)
+    @overrides = overrides
+    @repository_owner_name = repository_owner_name
+  end
+
+  def config
+    RuboCop::Config.new(merged_config, "")
+  end
+
+  private
+
+  attr_reader :overrides, :repository_owner_name
+
+  def merged_config
+    RuboCop::ConfigLoader.merge(combined_defaults, normalized_overrides)
+  rescue TypeError
+    combined_defaults
+  end
+
+  def combined_defaults
+    RuboCop::ConfigLoader.configuration_from_file(hound_config_filepath)
+  end
+
+  def hound_config_filepath
+    DefaultConfigFile.new(HOUND_DEFAULTS_FILENAME, repository_owner_name).path
+  end
+
+  def normalized_overrides
+    RuboCop::Config.new(overrides, "").tap do |custom_config|
+      custom_config.add_missing_namespaces
+      custom_config.make_excludes_absolute
+    end
+  rescue NoMethodError
+    RuboCop::Config.new
+  end
+end

--- a/spec/models/config/ruby_spec.rb
+++ b/spec/models/config/ruby_spec.rb
@@ -28,6 +28,24 @@ describe Config::Ruby do
         expect(config.content).to eq("LineLength" => { "Max" => 90 })
       end
     end
+
+    it "dumps the config content to yaml" do
+      rubocop = <<-EOS.strip_heredoc
+        Style/Encoding:
+          Enabled: true
+      EOS
+      commit = stubbed_commit(
+        "config/rubocop.yml" => rubocop,
+      )
+
+      config = build_config(commit)
+
+      expect(config.content.to_yaml).to eq <<-YML.strip_heredoc
+        ---
+        Style/Encoding:
+          Enabled: true
+      YML
+    end
   end
 
   context "when the configuration uses `inherit_from`" do

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -17,7 +17,14 @@ describe StyleChecker do
     it "only fetches content for supported files" do
       ruby_file = double("GithubFile", filename: "ruby.rb", patch: "foo")
       bogus_file = double("GithubFile", filename: "[:facebook]", patch: "bar")
-      head_commit = stub_head_commit(ruby_file.filename => "")
+      config = <<-HOUND.strip_heredoc
+        ruby:
+          enabled: true
+      HOUND
+      head_commit = stub_head_commit(
+        ruby_file.filename => "",
+        ".hound.yml" => config,
+      )
       pull_request = PullRequest.new(payload_stub, "anything")
       allow(pull_request).to receive(:head_commit).and_return(head_commit)
       allow(pull_request).to receive(:modified_github_files).

--- a/spec/services/ruby_config_builder_spec.rb
+++ b/spec/services/ruby_config_builder_spec.rb
@@ -1,0 +1,44 @@
+require "rubocop"
+require "app/models/default_config_file"
+require "app/services/ruby_config_builder"
+
+RSpec.describe RubyConfigBuilder do
+  context "when there is no custom configuration" do
+    subject(:builder) { described_class.new }
+
+    it "returns the Hound defaults", aggregate_failures: true do
+      config = builder.config
+
+      expect(config["Style/StringLiterals"]).to match hound_override_rule
+      expect(config["Style/VariableName"]).to match rubocop_default_rule
+    end
+  end
+
+  context "when custom configuration is provided" do
+    it "returns merged config" do
+      overrides = {
+        "Style/VariableName" => {
+          "EnforcedStyle" => "camel_case",
+        },
+      }
+      builder = RubyConfigBuilder.new(overrides)
+
+      config = builder.config
+
+      expect(config["Style/StringLiterals"]).to match hound_override_rule
+      expect(config["Style/VariableName"]).to match customer_override_rule
+    end
+  end
+
+  def customer_override_rule
+    hash_including("EnforcedStyle" => "camel_case")
+  end
+
+  def hound_override_rule
+    hash_including("EnforcedStyle" => "double_quotes")
+  end
+
+  def rubocop_default_rule
+    hash_including("EnforcedStyle" => "snake_case")
+  end
+end


### PR DESCRIPTION
* Introduces `RubyConfigBuilder` to encapsulate merging RuboCop's
  defaults, Hound's defaults, and the user's custom config.

This is a precursor for providing an endpoint for users to fetch their
completely merged config file.