### PR TITLE
Add endpoint fetch merged RuboCop config

### DIFF
--- a/app/controllers/linter_configs_controller.rb
+++ b/app/controllers/linter_configs_controller.rb
@@ -1,0 +1,39 @@
+class LinterConfigsController < ApplicationController
+  def show
+    case params[:linter]
+    when "ruby"
+      ruby_config = Config::Ruby.new(hound_config, "ruby")
+      config = RubyConfigBuilder.new(ruby_config.content, params[:owner]).config
+      render body: config.to_yaml, content_type: "text/yaml"
+    else
+      head 404
+    end
+  end
+
+  protected
+
+  def repo
+    Repo.find_by(full_github_name: full_github_name)
+  end
+
+  def full_github_name
+    "#{params[:owner]}/#{params[:repo]}"
+  end
+
+  def hound_config
+    HoundConfig.new(head_commit)
+  end
+
+  def head_commit
+    Commit.new(full_github_name, default_branch, github_api)
+  end
+
+  def default_branch
+    repo = github_api.repo(full_github_name)
+    repo["default_branch"]
+  end
+
+  def github_api
+    GithubApi.new(current_user.token)
+  end
+end

--- a/app/controllers/linter_configs_controller.rb
+++ b/app/controllers/linter_configs_controller.rb
@@ -1,39 +1,21 @@
 class LinterConfigsController < ApplicationController
   def show
-    case params[:linter]
-    when "ruby"
-      ruby_config = Config::Ruby.new(hound_config, "ruby")
-      config = RubyConfigBuilder.new(ruby_config.content, params[:owner]).config
-      render body: config.to_yaml, content_type: "text/yaml"
+    config_builder = RepoConfigBuilder.new(
+      repo: repo,
+      token: current_user.token,
+    )
+    config_file = config_builder.config_for(params[:linter])
+
+    if config_file.present?
+      render body: config_file.content, content_type: config_file.format
     else
       head 404
     end
   end
 
-  protected
+  private
 
   def repo
-    Repo.find_by(full_github_name: full_github_name)
-  end
-
-  def full_github_name
-    "#{params[:owner]}/#{params[:repo]}"
-  end
-
-  def hound_config
-    HoundConfig.new(head_commit)
-  end
-
-  def head_commit
-    Commit.new(full_github_name, default_branch, github_api)
-  end
-
-  def default_branch
-    repo = github_api.repo(full_github_name)
-    repo["default_branch"]
-  end
-
-  def github_api
-    GithubApi.new(current_user.token)
+    Repo.find_by(full_github_name: "#{params[:owner]}/#{params[:repo]}")
   end
 end

--- a/app/models/config_file.rb
+++ b/app/models/config_file.rb
@@ -1,0 +1,8 @@
+class ConfigFile
+  attr_reader :content, :format
+
+  def initialize(content:, format:)
+    @content = content
+    @format = format
+  end
+end

--- a/app/services/repo_config_builder.rb
+++ b/app/services/repo_config_builder.rb
@@ -1,0 +1,38 @@
+class RepoConfigBuilder
+  def initialize(repo:, token:)
+    @repo = repo
+    @token = token
+  end
+
+  def config_for(linter_name)
+    case linter_name
+    when "ruby"
+      build_ruby_config
+    end
+  end
+
+  private
+
+  def build_ruby_config
+    ruby_config = Config::Ruby.new(hound_config, "ruby")
+    config = RubyConfigBuilder.new(ruby_config.content, @repo.owner.name).config
+    ConfigFile.new(content: config.to_yaml, format: :yaml)
+  end
+
+  def hound_config
+    HoundConfig.new(head_commit)
+  end
+
+  def head_commit
+    Commit.new(@repo.full_github_name, default_branch, github_api)
+  end
+
+  def default_branch
+    repo = github_api.repo(@repo.full_github_name)
+    repo["default_branch"]
+  end
+
+  def github_api
+    @_github_api ||= GithubApi.new(@token)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Houndapp::Application.routes.draw do
   get "/configuration", to: "pages#configuration"
   get "/faq", to: "pages#show", id: "faq"
 
+  get "/config/:owner/:repo/:linter", to: "linter_configs#show"
+
   resource :account, only: [:show, :update]
   resources :builds, only: [:create]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Houndapp::Application.routes.draw do
   get "/configuration", to: "pages#configuration"
   get "/faq", to: "pages#show", id: "faq"
 
-  get "/config/:owner/:repo/:linter", to: "linter_configs#show"
+  get "/owners/:owner/:repo/configs/:linter", to: "linter_configs#show"
 
   resource :account, only: [:show, :update]
   resources :builds, only: [:create]

--- a/spec/controllers/linter_configs_controller_spec.rb
+++ b/spec/controllers/linter_configs_controller_spec.rb
@@ -4,6 +4,8 @@ describe LinterConfigsController do
   context "requesting ruby" do
     it "returns the merged RuboCop config" do
       user = create(:user)
+      owner = create(:owner, name: "thoughtbot")
+      repo = create(:repo, full_github_name: "thoughtbot/hound", owner: owner)
       stub_sign_in(user)
       our_config = {
         "Style/OptionHash" => {
@@ -25,7 +27,7 @@ describe LinterConfigsController do
       )
       stub_encoded_contents_request(
         sha: "master",
-        repo_name: "thoughtbot/hound",
+        repo_name: repo.name,
         file: "ruby.yml",
         body: YAML.dump(our_config),
         token: user.token,

--- a/spec/controllers/linter_configs_controller_spec.rb
+++ b/spec/controllers/linter_configs_controller_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+describe LinterConfigsController do
+  context "requesting ruby" do
+    it "returns the merged RuboCop config" do
+      user = create(:user)
+      stub_sign_in(user)
+      our_config = {
+        "Style/OptionHash" => {
+          "Enabled" => true,
+        },
+      }
+      hound_yaml = <<-HOUND.strip_heredoc
+        ruby:
+          enabled: true
+          config_file: ruby.yml
+      HOUND
+      stub_repo_request("thoughtbot/hound", user.token)
+      stub_encoded_contents_request(
+        sha: "master",
+        repo_name: "thoughtbot/hound",
+        file: ".hound.yml",
+        body: hound_yaml,
+        token: user.token,
+      )
+      stub_encoded_contents_request(
+        sha: "master",
+        repo_name: "thoughtbot/hound",
+        file: "ruby.yml",
+        body: YAML.dump(our_config),
+        token: user.token,
+      )
+
+      get :show, owner: "thoughtbot", repo: "hound", linter: "ruby"
+
+      config = YAML.load(response.body)
+      expect(config["Style/StringLiterals"]).to match(
+        hash_including(
+          "EnforcedStyle" => "double_quotes",
+          "Enabled" => true,
+        ),
+      )
+      expect(config["Style/OptionHash"]).to match(
+        hash_including(
+          "Enabled" => true,
+        ),
+      )
+      expect(config["Metrics/LineLength"]).to match(
+        hash_including(
+          "Max" => 80,
+        ),
+      )
+    end
+  end
+
+  context "for an unsupported endpoint" do
+    it "returns a 404" do
+      user = create(:user)
+      stub_sign_in(user)
+      user.reload
+
+      get :show, owner: "thoughtbot", repo: "hound", linter: "fortran"
+
+      expect(response.status).to eq 404
+    end
+  end
+
+  context "when user is not signed in" do
+    it "redirects to root" do
+      get :show, owner: "thoughtbot", repo: "hound", linter: "ruby"
+
+      expect(response).to redirect_to(root_url)
+    end
+  end
+
+  def stub_encoded_contents_request(options = {})
+    repo_name = options.fetch(:repo_name)
+    file = options.fetch(:file)
+    sha = options.fetch(:sha)
+    token = options.fetch(:token)
+    content = Base64.encode64(options.fetch(:body))
+
+    stub_request(
+      :get,
+      "https://api.github.com/repos/#{repo_name}/contents/#{file}?ref=#{sha}",
+    ).with(
+      headers: { "Authorization" => "token #{token}" },
+    ).to_return(
+      status: 200,
+      body: { content: content }.to_json,
+      headers: { "Content-Type" => "application/json; charset=utf-8" },
+    )
+  end
+end

--- a/spec/routing/routes_spec.rb
+++ b/spec/routing/routes_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper.rb"
 
 RSpec.describe "application routing" do
   it "routes the linter configs controller" do
-    expect(get: "/config/foo/bar/baz").to route_to(
+    expect(get: "/owners/foo/bar/configs/baz").to route_to(
       controller: "linter_configs",
       action: "show",
       owner: "foo",

--- a/spec/routing/routes_spec.rb
+++ b/spec/routing/routes_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper.rb"
+
+RSpec.describe "application routing" do
+  it "routes the linter configs controller" do
+    expect(get: "/config/foo/bar/baz").to route_to(
+      controller: "linter_configs",
+      action: "show",
+      owner: "foo",
+      repo: "bar",
+      linter: "baz",
+    )
+  end
+end

--- a/spec/services/repo_config_builder_spec.rb
+++ b/spec/services/repo_config_builder_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+describe RepoConfigBuilder do
+  describe "#config_for" do
+    context "for ruby" do
+      it "returns the yaml formatted config" do
+        owner = build(:owner)
+        repo = build(:repo, owner: owner)
+        merged_config = { "hey" => "yo" }
+        token = "token"
+        stub_github(token)
+        stub_hound_config
+        stub_ruby_config(merged_config)
+        expected_yaml = YAML.dump(merged_config)
+
+        repo_config_builder = RepoConfigBuilder.new(repo: repo, token: token)
+        config = repo_config_builder.config_for("ruby")
+
+        expect(config.content).to eq expected_yaml
+        expect(config.format).to eq :yaml
+      end
+    end
+
+    context "for an unsupported linter" do
+      it "returns nil" do
+        repo = build(:repo)
+        repo_config_builder = RepoConfigBuilder.new(repo: repo, token: "hi")
+
+        config = repo_config_builder.config_for("nope")
+
+        expect(config).to be_nil
+      end
+    end
+  end
+
+  def stub_github(token)
+    response_repo = { "default_branch" => "master" }
+    github_api = double(GithubApi, repo: response_repo)
+    allow(GithubApi).to receive(:new).with(token).and_return(github_api)
+  end
+
+  def stub_hound_config
+    hound_config = double(HoundConfig)
+    allow(HoundConfig).to receive(:new).and_return(hound_config)
+  end
+
+  def stub_ruby_config(config)
+    ruby_config = double(Config::Ruby, content: {})
+    allow(Config::Ruby).to receive(:new).and_return(ruby_config)
+    ruby_config_builder = double(RubyConfigBuilder, config: config)
+    allow(RubyConfigBuilder).to receive(:new).and_return(ruby_config_builder)
+  end
+end


### PR DESCRIPTION
Adds `/config/:owner/:repo/:linter` route for providing users with their
fully merged config file. Currently only supports RuboCop via the `ruby`
linter value, e.g. `/config/thoughtbot/hound/ruby.yml`.

https://trello.com/c/3ZMngMl6