### PR TITLE
Extract service from `CompletedFileReviewJob`

### DIFF
--- a/app/jobs/completed_file_review_job.rb
+++ b/app/jobs/completed_file_review_job.rb
@@ -1,43 +1,15 @@
 class CompletedFileReviewJob
   @queue = :high
 
+  # The following parameters are required for this job to run.
+  # filename
+  # commit_sha
+  # pull_request_number
+  # patch
+  # violations
+  #   [{ line: 123, message: "WAT" }]
   def self.perform(attributes)
-    # filename
-    # commit_sha
-    # pull_request_number
-    # patch
-    # violations
-    #   [{ line: 123, message: "WAT" }]
-
-    build = Build.find_by!(
-      pull_request_number: attributes.fetch("pull_request_number"),
-      commit_sha: attributes.fetch("commit_sha")
-    )
-    file_review = build.file_reviews.find_by!(
-      filename: attributes.fetch("filename")
-    )
-    commit_file = CommitFile.new(
-      patch: attributes.fetch("patch"),
-      filename: nil,
-      commit: nil,
-    )
-
-    attributes.fetch("violations").each do |violation|
-      line = commit_file.line_at(violation.fetch("line"))
-      file_review.build_violation(line, violation.fetch("message"))
-    end
-
-    file_review.complete
-    file_review.save!
-
-    payload = Payload.new(build.payload)
-    pull_request = PullRequest.new(payload, Hound::GITHUB_TOKEN)
-
-    BuildReport.run(
-      pull_request: pull_request,
-      build: build,
-      token: build.user_token,
-    )
+    CompleteFileReview.run(attributes)
   rescue ActiveRecord::RecordNotFound
     Resque.enqueue_in(30, self, attributes)
   rescue Resque::TermException

--- a/app/services/complete_file_review.rb
+++ b/app/services/complete_file_review.rb
@@ -1,0 +1,61 @@
+class CompleteFileReview
+  def self.run(attributes)
+    new(attributes).run
+  end
+
+  def initialize(attributes)
+    @attributes = attributes
+  end
+
+  def run
+    create_violations!
+
+    BuildReport.run(
+      pull_request: pull_request,
+      build: build,
+      token: build.user_token,
+    )
+  end
+
+  private
+
+  attr_reader :attributes
+
+  def create_violations!
+    attributes.fetch("violations").each do |violation|
+      line = commit_file.line_at(violation.fetch("line"))
+      file_review.build_violation(line, violation.fetch("message"))
+    end
+
+    file_review.complete
+    file_review.save!
+  end
+
+  def pull_request
+    PullRequest.new(payload, Hound::GITHUB_TOKEN)
+  end
+
+  def payload
+    Payload.new(build.payload)
+  end
+
+  def build
+    @build ||= Build.find_by!(
+      pull_request_number: attributes.fetch("pull_request_number"),
+      commit_sha: attributes.fetch("commit_sha"),
+    )
+  end
+
+  def file_review
+    @file_review ||= build.file_reviews.
+      find_by!(filename: attributes.fetch("filename"))
+  end
+
+  def commit_file
+    @commit_sha ||= CommitFile.new(
+      patch: attributes.fetch("patch"),
+      filename: nil,
+      commit: nil,
+    )
+  end
+end

--- a/spec/jobs/completed_file_review_job_spec.rb
+++ b/spec/jobs/completed_file_review_job_spec.rb
@@ -2,129 +2,48 @@ require "rails_helper"
 
 describe CompletedFileReviewJob do
   describe ".perform" do
-    it "completes FileReview with violations" do
-      file_review = create_file_review
-      stub_build_report_run
-      stub_pull_request
-      stub_payload
+    it "calls `CompleteFileReview`" do
+      allow(CompleteFileReview).to receive(:run)
 
       CompletedFileReviewJob.perform(attributes)
 
-      file_review.reload
-      expect(file_review).to be_completed
-      expect(file_review.violations).to be_present
-    end
-
-    it "runs Build Report" do
-      file_review = create_file_review
-      build = file_review.build
-      stub_build_report_run
-      pull_request = stub_pull_request
-      payload = stub_payload
-
-      CompletedFileReviewJob.perform(attributes)
-
-      expect(BuildReport).to have_received(:run).with(
-        pull_request: pull_request,
-        build: build,
-        token: Hound::GITHUB_TOKEN,
-      )
-      expect(Payload).to have_received(:new).with(build.payload)
-      expect(PullRequest).
-        to(have_received(:new).with(payload, Hound::GITHUB_TOKEN))
+      expect(CompleteFileReview).to have_received(:run).with(attributes)
     end
 
     context "when build doesn't exist" do
       it "enqueues job with a 30 second delay" do
+        allow(CompleteFileReview).to receive(:run).
+          and_raise(ActiveRecord::RecordNotFound)
         allow(Resque).to receive(:enqueue_in)
 
         CompletedFileReviewJob.perform(attributes)
 
-        expect(Resque).to(
-          have_received(:enqueue_in).with(30, CompletedFileReviewJob, attributes)
-        )
+        expect(Resque).to have_received(:enqueue_in).
+          with(30, CompletedFileReviewJob, attributes)
       end
     end
 
     context "when Resque process is killed" do
       it "enqueues job" do
-        allow(Build).to(
-          receive(:find_by!).and_raise(Resque::TermException.new(1))
-        )
+        allow(CompleteFileReview).to receive(:run).
+          and_raise(Resque::TermException.new(1))
         allow(Resque).to receive(:enqueue)
 
         CompletedFileReviewJob.perform(attributes)
 
-        expect(Resque).to(
-          have_received(:enqueue).with(CompletedFileReviewJob, attributes)
-        )
-      end
-    end
-
-    context "when there are two builds with the same commit_sha" do
-      it "finds the correct build by pull request number" do
-        create(:build, commit_sha: "abc123", pull_request_number: 1)
-        correct_build = create(
-          :build,
-          commit_sha: "abc123",
-          pull_request_number: 123
-        )
-        create(
-          :file_review,
-          build: correct_build,
-          filename: attributes.fetch("filename")
-        )
-        stub_build_report_run
-        pull_request = stub_pull_request
-        stub_payload
-
-        CompletedFileReviewJob.perform(attributes)
-
-        expect(BuildReport).to have_received(:run).with(
-          pull_request: pull_request,
-          build: correct_build,
-          token: Hound::GITHUB_TOKEN,
-        )
+        expect(Resque).to have_received(:enqueue).
+          with(CompletedFileReviewJob, attributes)
       end
     end
   end
 
-  def attributes
-    @attributes ||= {
+  let(:attributes) do
+    {
       "filename" => "test.scss",
       "commit_sha" => "abc123",
       "pull_request_number" => 123,
       "patch" => File.read("spec/support/fixtures/patch.diff"),
-      "violations" => [
-        { "line" => 14, "message" => "woohoo" }
-      ]
+      "violations" => ["line" => 14, "message" => "woohoo"],
     }
-  end
-
-  def create_file_review
-    build = build(
-      :build,
-      commit_sha: attributes.fetch("commit_sha"),
-      pull_request_number: attributes.fetch("pull_request_number")
-    )
-    create(:file_review, build: build, filename: attributes.fetch("filename"))
-  end
-
-  def stub_build_report_run
-    allow(BuildReport).to receive(:run)
-  end
-
-  def stub_pull_request
-    pull_request = double("PullRequest")
-    allow(PullRequest).to receive(:new).and_return(pull_request)
-
-    pull_request
-  end
-
-  def stub_payload
-    payload = double("Payload")
-    allow(Payload).to receive(:new).and_return(payload)
-
-    payload
   end
 end

--- a/spec/services/complete_file_review_spec.rb
+++ b/spec/services/complete_file_review_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+describe CompleteFileReview do
+  describe ".run" do
+    it "completes FileReview with violations" do
+      file_review = create_file_review
+      stub_build_report_run
+      stub_pull_request
+      stub_payload
+
+      CompleteFileReview.run(attributes)
+
+      file_review.reload
+      expect(file_review).to be_completed
+      expect(file_review.violations).to be_present
+    end
+
+    it "runs Build Report" do
+      file_review = create_file_review
+      build = file_review.build
+      stub_build_report_run
+      pull_request = stub_pull_request
+      payload = stub_payload
+
+      CompleteFileReview.run(attributes)
+
+      expect(BuildReport).to have_received(:run).with(
+        pull_request: pull_request,
+        build: build,
+        token: Hound::GITHUB_TOKEN,
+      )
+      expect(Payload).to have_received(:new).with(build.payload)
+      expect(PullRequest).
+        to(have_received(:new).with(payload, Hound::GITHUB_TOKEN))
+    end
+
+    context "when there are two builds with the same commit_sha" do
+      it "finds the correct build by pull request number" do
+        create(:build, commit_sha: "abc123", pull_request_number: 1)
+        correct_build = create(
+          :build,
+          commit_sha: "abc123",
+          pull_request_number: 123,
+        )
+        create(
+          :file_review,
+          build: correct_build,
+          filename: attributes.fetch("filename"),
+        )
+        stub_build_report_run
+        pull_request = stub_pull_request
+        stub_payload
+
+        CompleteFileReview.run(attributes)
+
+        expect(BuildReport).to have_received(:run).with(
+          pull_request: pull_request,
+          build: correct_build,
+          token: Hound::GITHUB_TOKEN,
+        )
+      end
+    end
+  end
+
+  let(:attributes) do
+    {
+      "filename" => "test.scss",
+      "commit_sha" => "abc123",
+      "pull_request_number" => 123,
+      "patch" => File.read("spec/support/fixtures/patch.diff"),
+      "violations" => ["line" => 14, "message" => "woohoo"],
+    }
+  end
+
+  def create_file_review
+    build = build(
+      :build,
+      commit_sha: attributes.fetch("commit_sha"),
+      pull_request_number: attributes.fetch("pull_request_number"),
+    )
+    create(:file_review, build: build, filename: attributes.fetch("filename"))
+  end
+
+  def stub_build_report_run
+    allow(BuildReport).to receive(:run)
+  end
+
+  def stub_pull_request
+    pull_request = double("PullRequest")
+    allow(PullRequest).to receive(:new).and_return(pull_request)
+
+    pull_request
+  end
+
+  def stub_payload
+    payload = double("Payload")
+    allow(Payload).to receive(:new).and_return(payload)
+
+    payload
+  end
+end


### PR DESCRIPTION
To follow the pattern of a job class having a corresponding service
object.