### PR TITLE
Allow a linter to respond to many names

### DIFF
--- a/app/models/config/base.rb
+++ b/app/models/config/base.rb
@@ -67,7 +67,11 @@ module Config
     end
 
     def linter_config
-      hound_config.content[linter_name]
+      hound_config.content.slice(*linter_names).values.first
+    end
+
+    def linter_names
+      [linter_name]
     end
 
     def commit

--- a/app/models/config/coffee_script.rb
+++ b/app/models/config/coffee_script.rb
@@ -8,12 +8,11 @@ module Config
       ensure_correct_type(result)
     end
 
-    def linter_config
-      super || hound_config.content[alternate_linter_name]
-    end
-
-    def alternate_linter_name
-      linter_name.sub("_", "")
+    def linter_names
+      [
+        linter_name,
+        linter_name.sub("_", ""),
+      ]
     end
   end
 end

--- a/app/models/config/java_script.rb
+++ b/app/models/config/java_script.rb
@@ -25,12 +25,11 @@ module Config
       commit.file_content(ignore_file).to_s.split("\n")
     end
 
-    def linter_config
-      super || hound_config.content[alternate_linter_name]
-    end
-
-    def alternate_linter_name
-      linter_name.sub("_", "")
+    def linter_names
+      [
+        linter_name,
+        linter_name.sub("_", ""),
+      ]
     end
   end
 end


### PR DESCRIPTION
This allows us to configure that a given linter should respond to
multiple names in the `.hound.yml` configuration file.

https://trello.com/c/oHuaCx6b