### PR TITLE
Add absolute filename to get file exclusion working

### DIFF
--- a/app/models/linter/ruby.rb
+++ b/app/models/linter/ruby.rb
@@ -40,7 +40,11 @@ module Linter
     end
 
     def parsed_source(commit_file)
-      RuboCop::ProcessedSource.new(commit_file.content, RUBY_PARSER_VERSION)
+      RuboCop::ProcessedSource.new(
+        commit_file.content,
+        RUBY_PARSER_VERSION,
+        File.join(Rails.root, commit_file.filename),
+      )
     end
 
     def linter_config


### PR DESCRIPTION
Rubocop expects the absolute path to a filename for it to be excluded