### PR TITLE
Exclude files for JSHint

### DIFF
--- a/app/models/linter/jshint.rb
+++ b/app/models/linter/jshint.rb
@@ -1,5 +1,11 @@
 module Linter
   class Jshint < Base
     FILE_REGEXP = /.+\.js\z/
+
+    def file_included?(commit_file)
+      config.excluded_files.none? do |pattern|
+        File.fnmatch?(pattern, commit_file.filename)
+      end
+    end
   end
 end

--- a/spec/models/linter/jshint_spec.rb
+++ b/spec/models/linter/jshint_spec.rb
@@ -27,6 +27,46 @@ describe Linter::Jshint do
     end
   end
 
+  describe "#file_included?" do
+    context "file is in excluded file list" do
+      it "returns false" do
+        stub_jshint_config(excluded_files: ["foo.js"])
+        linter = build_linter
+        commit_file = double("CommitFile", filename: "foo.js")
+
+        expect(linter.file_included?(commit_file)).to eq false
+      end
+    end
+
+    context "file is not excluded" do
+      it "returns true" do
+        stub_jshint_config(excluded_files: ["foo.js"])
+        linter = build_linter(config: config)
+        commit_file = double("CommitFile", filename: "bar.js")
+
+        expect(linter.file_included?(commit_file)).to eq true
+      end
+
+      it "matches a glob pattern" do
+        stub_jshint_config(
+          excluded_files: ["app/assets/javascripts/*.js", "vendor/*"],
+        )
+        linter = build_linter(config: config)
+        commit_file1 = double(
+          "CommitFile",
+          filename: "app/assets/javascripts/bar.js",
+        )
+        commit_file2 = double(
+          "CommitFile",
+          filename: "vendor/assets/javascripts/foo.js",
+        )
+
+        expect(linter.file_included?(commit_file1)).to be false
+        expect(linter.file_included?(commit_file2)).to be false
+      end
+    end
+  end
+
   describe "#file_review" do
     it "returns a saved and incomplete file review" do
       commit_file = build_commit_file(filename: "lib/a.js")
@@ -40,7 +80,7 @@ describe Linter::Jshint do
 
     it "schedules a review job" do
       build = build(:build, commit_sha: "foo", pull_request_number: 123)
-      stub_eslint_config(content: "config")
+      stub_jshint_config(content: "config")
       commit_file = build_commit_file(filename: "lib/a.js")
       allow(Resque).to receive(:enqueue)
       linter = build_linter(build)
@@ -59,16 +99,23 @@ describe Linter::Jshint do
     end
   end
 
-  def stub_eslint_config(content: "")
-    stubbed_eslint_config = double("JshintConfig", content: content)
-    allow(Config::Jshint).to receive(:new).and_return(stubbed_eslint_config)
+  def stub_jshint_config(options = {})
+    default_options = {
+      content: "",
+      excluded_files: [],
+    }
+    stubbed_jshint_config = double(
+      "JshintConfig",
+      default_options.merge(options),
+    )
+    allow(Config::Jshint).to receive(:new).and_return(stubbed_jshint_config)
 
-    stubbed_eslint_config
+    stubbed_jshint_config
   end
 
   def raw_hound_config
     <<-EOS.strip_heredoc
-      eslint:
+      jshint:
         enabled: true
         config_file: config/.jshintrc
     EOS

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -186,30 +186,6 @@ describe StyleChecker do
           expect(violation_messages).to be_empty
         end
       end
-
-      context "an excluded file" do
-        it "returns no violations" do
-          config = <<-YAML.strip_heredoc
-              javascript:
-                ignore_file: '.jshintignore'
-          YAML
-
-          head_commit = stub_head_commit(
-            ".hound.yml" => config,
-            ".jshintignore" => "test.js",
-          )
-
-          commit_file = stub_commit_file("test.js", "var test = 'test'")
-          pull_request = stub_pull_request(
-            head_commit: head_commit,
-            commit_files: [commit_file],
-          )
-
-          violation_messages = pull_request_violations(pull_request)
-
-          expect(violation_messages).to be_empty
-        end
-      end
     end
 
     context "for a SCSS file" do


### PR DESCRIPTION
This was forgotten in the move done in:
https://github.com/thoughtbot/hound/commit/0eef7e727ba44d8765758efb64a3fc1534490ffc

Changes:

- Check for excluded files in `Linter::Jshint` by leveraging
  `Config::Jshint#excluded_files`.
- Rename `eslint` to `jshint` in `spec/models/linter/jshint_spec.rb`
- Remove dead-weight test.
  Since the JavaScript linter is extracted out into a service, the violations we get back will always be empty, since they haven't been linted yet.