### PR TITLE
Make `coffeescript` accessible under all names

### DIFF
--- a/app/models/config/coffee_script.rb
+++ b/app/models/config/coffee_script.rb
@@ -1,5 +1,12 @@
 module Config
   class CoffeeScript < Base
+    def linter_names
+      [
+        linter_name,
+        linter_name.sub("_", ""),
+      ]
+    end
+
     private
 
     def parse(file_content)

--- a/spec/models/config/coffee_script_spec.rb
+++ b/spec/models/config/coffee_script_spec.rb
@@ -56,6 +56,15 @@ describe Config::CoffeeScript do
     end
   end
 
+  describe "#linter_names" do
+    it "returns the names that the linter can be reached as" do
+      commit = double("Commit")
+      config = build_config(commit)
+
+      expect(config.linter_names).to eq ["coffee_script", "coffeescript"]
+    end
+  end
+
   def build_config(commit)
     hound_config = double(
       "HoundConfig",
@@ -67,6 +76,6 @@ describe Config::CoffeeScript do
         },
       },
     )
-    Config::CoffeeScript.new(hound_config, "coffeescript")
+    Config::CoffeeScript.new(hound_config, "coffee_script")
   end
 end


### PR DESCRIPTION
This allows `.hound.yml` file to specify `coffeescript` or
`coffee_script`.