### PR TITLE
Merge RuboCop overrides first

### DIFF
--- a/app/models/linter/ruby.rb
+++ b/app/models/linter/ruby.rb
@@ -1,7 +1,6 @@
 # Determine Ruby style guide violations per-line.
 module Linter
   class Ruby < Base
-    DEFAULT_CONFIG_FILENAME = "ruby.yml"
     FILE_REGEXP = /.+\.rb\z/
     RUBY_PARSER_VERSION = 2.3
 

--- a/app/services/ruby_config_builder.rb
+++ b/app/services/ruby_config_builder.rb
@@ -1,5 +1,6 @@
 class RubyConfigBuilder
   HOUND_DEFAULTS_FILENAME = "ruby.yml".freeze
+  VIRTUAL_FILENAME = "".freeze
 
   def initialize(overrides = {}, repository_owner_name = nil)
     @overrides = overrides
@@ -7,31 +8,42 @@ class RubyConfigBuilder
   end
 
   def config
-    RuboCop::Config.new(merged_config, "")
+    RuboCop::ConfigLoader.merge_with_default(
+      combined_overrides,
+      VIRTUAL_FILENAME,
+    )
   end
 
   private
 
   attr_reader :overrides, :repository_owner_name
 
-  def merged_config
-    RuboCop::ConfigLoader.merge(combined_defaults, normalized_overrides)
+  def combined_overrides
+    RuboCop::ConfigLoader.merge(normalized_hound_config, normalized_overrides)
   rescue TypeError
-    combined_defaults
+    hound_config
   end
 
-  def combined_defaults
-    RuboCop::ConfigLoader.configuration_from_file(hound_config_filepath)
+  def normalized_overrides
+    normalize_config(overrides)
+  end
+
+  def normalized_hound_config
+    normalize_config(hound_config)
+  end
+
+  def hound_config
+    Config::Parser.yaml(File.read(hound_config_filepath))
   end
 
   def hound_config_filepath
     DefaultConfigFile.new(HOUND_DEFAULTS_FILENAME, repository_owner_name).path
   end
 
-  def normalized_overrides
-    RuboCop::Config.new(overrides, "").tap do |custom_config|
-      custom_config.add_missing_namespaces
-      custom_config.make_excludes_absolute
+  def normalize_config(config)
+    RuboCop::Config.new(config, VIRTUAL_FILENAME).tap do |new_config|
+      new_config.add_missing_namespaces
+      new_config.make_excludes_absolute
     end
   rescue NoMethodError
     RuboCop::Config.new

--- a/spec/services/ruby_config_builder_spec.rb
+++ b/spec/services/ruby_config_builder_spec.rb
@@ -4,12 +4,24 @@ require "app/services/ruby_config_builder"
 
 RSpec.describe RubyConfigBuilder do
   context "when there is no custom configuration" do
-    subject(:builder) { described_class.new }
+    it "returns the Hound defaults" do
+      builder = RubyConfigBuilder.new
 
-    it "returns the Hound defaults", aggregate_failures: true do
       config = builder.config
 
+      expect(config["Rails/ActionFilter"]).to match enabled_rule
       expect(config["Style/StringLiterals"]).to match hound_override_rule
+      expect(config["Style/VariableName"]).to match rubocop_default_rule
+    end
+  end
+
+  context "when owner is thoughtbot" do
+    it "returns thoughbot specific configuration" do
+      builder = RubyConfigBuilder.new({}, "thoughtbot")
+
+      config = builder.config
+
+      expect(config["Rails/ActionFilter"]).to match disabled_rule
       expect(config["Style/VariableName"]).to match rubocop_default_rule
     end
   end
@@ -17,6 +29,9 @@ RSpec.describe RubyConfigBuilder do
   context "when custom configuration is provided" do
     it "returns merged config" do
       overrides = {
+        "AllCops" => {
+          "DisabledByDefault" => true,
+        },
         "Style/VariableName" => {
           "EnforcedStyle" => "camel_case",
         },
@@ -25,20 +40,30 @@ RSpec.describe RubyConfigBuilder do
 
       config = builder.config
 
+      expect(config["AllCops"]["DisabledByDefault"]).to be true
+      expect(config["Style/Tab"]).to match disabled_rule
       expect(config["Style/StringLiterals"]).to match hound_override_rule
       expect(config["Style/VariableName"]).to match customer_override_rule
     end
   end
 
   def customer_override_rule
-    hash_including("EnforcedStyle" => "camel_case")
+    hash_including("EnforcedStyle" => "camel_case", "Enabled" => true)
   end
 
   def hound_override_rule
-    hash_including("EnforcedStyle" => "double_quotes")
+    hash_including("EnforcedStyle" => "double_quotes", "Enabled" => true)
   end
 
   def rubocop_default_rule
-    hash_including("EnforcedStyle" => "snake_case")
+    hash_including("EnforcedStyle" => "snake_case", "Enabled" => true)
+  end
+
+  def disabled_rule
+    hash_including("Enabled" => false)
+  end
+
+  def enabled_rule
+    hash_including("Enabled" => true)
   end
 end


### PR DESCRIPTION
There is some important code that is run in
`RuboCop::ConfigLoader.merge_with_defaults` -- it checks for presence of
`DisabledByDefault` and disables all of the rules but the overrides.

Because we were calling `RuboCop::ConfigLoader.configuration_from_file`
first (and it calls `merge_with_defaults` in turn) and then merging the
custom config, we were not preserving the `DisabledByDefault` logic.

Fixes #1049