### PR TITLE
Reduce spec dependencies for ConfigBuilder

### DIFF
--- a/spec/models/config_builder_spec.rb
+++ b/spec/models/config_builder_spec.rb
@@ -1,4 +1,8 @@
-require "rails_helper"
+require "spec_helper"
+require "app/models/config_builder"
+require "app/models/config/base"
+require "app/models/config/ruby"
+require "app/models/config/unsupported"
 
 describe ConfigBuilder do
   describe ".for" do


### PR DESCRIPTION
This test/code doesn't need the whole Rails framework.
Shave off precious time on focused spec runs :)