### PR TITLE
Report invalid HAML format as violation

### DIFF
--- a/app/models/linter/haml.rb
+++ b/app/models/linter/haml.rb
@@ -2,6 +2,7 @@ module Linter
   class Haml < Base
     DEFAULT_CONFIG_FILENAME = "haml.yml"
     FILE_REGEXP = /.+\.haml\z/
+    HamlViolation = Struct.new(:line, :message)
 
     def file_review(commit_file)
       @commit_file = commit_file
@@ -43,6 +44,8 @@ module Linter
         linter.run(content)
         results + linter.lints
       end
+    rescue HamlLint::Exceptions::ParseError => haml_error
+      [HamlViolation.new(haml_error.line + 1, haml_error.message)]
     end
 
     def linters

--- a/spec/support/helpers/commit_file_helper.rb
+++ b/spec/support/helpers/commit_file_helper.rb
@@ -1,10 +1,10 @@
 module CommitFileHelper
-  def build_commit_file(filename:, content: "code")
+  def build_commit_file(filename:, content: "code", line_number: 1)
     line = double(
       "Line",
       changed?: true,
       content: "blah",
-      number: 1,
+      number: line_number,
       patch_position: 2,
     )
     double(


### PR DESCRIPTION
HamlLint includes the line number in the exception when it encounters an
invalid Haml format. However, the line number is of the line before the
error, thus we need to add one to comment under the erroneous line in
the pull request.