### PR TITLE
Don't pass filename to HamlLint

### DIFF
--- a/app/models/linter/haml.rb
+++ b/app/models/linter/haml.rb
@@ -32,11 +32,7 @@ module Linter
     attr_reader :commit_file
 
     def content
-      HamlLint::Document.new(
-        commit_file.content,
-        file: commit_file.filename,
-        config: linter_config,
-      )
+      HamlLint::Document.new(commit_file.content, config: linter_config)
     end
 
     def run_linters

--- a/spec/models/linter/haml_spec.rb
+++ b/spec/models/linter/haml_spec.rb
@@ -115,6 +115,26 @@ describe Linter::Haml do
         end
       end
     end
+
+    context "when RuboCop linter is enabled" do
+      it "does not raise missing dir for Tempfile error" do
+        content = <<-EOS.strip_heredoc
+          %div
+        EOS
+        commit_file = build_commit_file(
+          filename: "/does/not/exist/foo.haml",
+          content: content,
+        )
+        config = {
+          "linters" => {
+            "RuboCop" => { "enabled" => true },
+          },
+        }
+        linter = build_linter(config)
+
+        expect { linter.file_review(commit_file) }.not_to raise_error
+      end
+    end
   end
 
   describe "#file_included?" do


### PR DESCRIPTION
When we pass a filename to HamlLint and RuboCop linter is enabled then
HamlLint will try to create a Tempfile in the directory that it gets
from the file's path. It won't exist on Heroku, so it throws an
exception.

HamlLint still works without a filename, so let's not pass it in.

Fixes the following issue we've been seeing:
```
No such file or directory @ rb_sysopen - app/views/articles/_form.html.haml.haml_lint.tmp20160205-6932-alnw3e
```